### PR TITLE
Makefile target🎯[add]migrate_Django_db:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,9 @@ Re-setup:
 # Django開発サーバー　localhost:8002
 run_django_server:
 	docker exec -it uwsgi-django bash -c "python manage.py runserver 0.0.0.0:8002"
+# DBのフィールド変更時に毎回必要
+migrate_Django_db:
+	docker exec -it uwsgi-django bash -c "python manage.py migrate --noinput"
 
 # -----------------------------------------------
 # インクルードしたいファイルのリスト


### PR DESCRIPTION
makefileにmigrate用のターゲットを追加しました。
（DB修正時に毎回行う必要がある）

理由: account/のmigrateがentrypoint.shでは正常に動作しなかったため。
```
migrate_Django_db:

docker exec -it uwsgi-django bash -c "python manage.py migrate --noinput"
```