### PR TITLE
❗️❗️static/を再度gitignoreしました。理由: entrypoint.shで自動収集を設定(Djangoの機能として用意されていた)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ docker/srcs/hardhat/hardhat_pj/cache
 docker/srcs/hardhat/hardhat_pj/docs
 docker/srcs/hardhat/hardhat_pj/share/*.json
 
+# 再度修正。entrypoint.shで最新ファイルの自動収集を設定したため。
+static/
 
 #### init/ #####
 

--- a/docker/srcs/uwsgi-django/django-entrypoint.sh
+++ b/docker/srcs/uwsgi-django/django-entrypoint.sh
@@ -5,4 +5,8 @@ python manage.py migrate --noinput
 # superuserの作成 データベースに格納される。作成に失敗しても進む。
 # uwsgi-django/.envを参照
 python manage.py createsuperuser --no-input || true 
+
+# 全部の"static/"から、ルートのstatic/に集める
+python manage.py collectstatic --noinput
+
 exec "$@"


### PR DESCRIPTION
❗️❗️実行ください: git rm -r --cached docker/srcs/uwsgi-django/static