### PR TITLE
Cyber security: JWT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: Docker Compose CI
+on: [push]
+jobs:
+  docker-compose-ci-test:
+    runs-on: ubuntu-22.04
+    environment:
+      name: CREDENTIALS
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Display system architecture
+        run: |
+          echo "Operating System: $(uname -o)"
+          echo "Machine Hardware Name: $(uname -m)"
+          echo "Kernel Release: $(uname -r)"
+          echo "Processor Type: $(uname -p)"      
+
+      - name: Install Docker engine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          docker --version
+
+      - name: Set up Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
+      - name: create .env_credentials file
+        run: |
+          cat << EOF >> docker/srcs/.env_src_credentials
+          # ------------------------------------------------------------------------------
+          # CREDENTIALS
+          # ------------------------------------------------------------------------------
+          
+          # Auth0
+          GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${{ secrets.GF_AUTH_GENERIC_OAUTH_CLIENT_ID }}
+          GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${{ secrets.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET }}
+          
+          # grafana alert
+          GRAFANA_CONTACT_POINT_SLACK=${{ secrets.GRAFANA_CONTACT_POINT_SLACK }}
+          GRAFANA_CONTACT_POINT_DISCORD=${{ secrets.GRAFANA_CONTACT_POINT_DISCORD }}
+            
+          # API_KEY
+          INFURA_API_KEY=${{ secrets.INFURA_API_KEY }}
+          SEPOLIA_PRIVATE_KEY=${{ secrets.SEPOLIA_PRIVATE_KEY }}
+          GANACHE_PRIVATE_KEY=${{ secrets.GANACHE_PRIVATE_KEY }}
+          
+          # 42; Valid until 1st/Mar/2024
+          FT_UID=${{ secrets.FT_UID }}
+          FT_SECRET=${{ secrets.FT_SECRET }}
+          
+          # ------------------------------------------------------------------------------
+          EOF
+
+      - name: Build and start containers
+        run: make build_up_default || make logs
+
+      - name: wait for start up django container
+        run: |
+          timeout=300
+          elapsed=0
+          while [ "$(docker inspect --format='{{.State.Health.Status}}' uwsgi-django)" != "healthy" ]; do
+            if [ $elapsed -ge $timeout ]; then
+              echo -e "\e[31m[NG] Timeout waiting for uwsgi-django to finish starting up\e[0m"
+              exit 1
+            fi
+              echo -e "\e[q33mWaiting for uwsgi-django to finish starting up... remain:${$(( $timeout - $elapsed ))}sec\e[0m"
+            sleep 10
+            elapsed=$(($elapsed + 10))
+          done
+          echo -e "\e[32mAll uwsgi-django container is finish starting up\e[0m"
+
+      - name: Run Django Tests
+        run: |
+          docker exec uwsgi-django python manage.py test accounts.tests
+          if [ $? -eq 0 ]; then
+            echo -e "\e[32m[OK] ALL TEST SUCCESS\e[0m"
+          else
+            echo -e "\e[31m[NG] TEST FAILURE\e[0m"
+          fi

--- a/API_specification.md
+++ b/API_specification.md
@@ -1,0 +1,407 @@
+# API仕様書
+
+## 1. Basic認証
+
+### 1-1) ユーザー登録: Signup API
+- ユーザー登録を行うためのAPI
+
+### Endpoint
+- path: `/accounts/api/signup/`
+- name: `accounts:api_signup`
+
+### Permissions
+- 認証されていないユーザーもアクセス可能（`AllowAny`）
+
+### POST
+
+#### Request Parameters
+
+| パラメータ    | 型     | 説明                   | 必須 |
+|-----------|------|----------------------|--|
+| `email`   | 文字列 | 登録に使用するメールアドレス    | Yes |
+| `nickname`| 文字列 | ユーザーのニックネーム         | Yes |
+| `password1`| 文字列 | パスワード                | Yes |
+| `password2`| 文字列 | パスワード（確認用）          | Yes |
+
+#### Responses
+##### 200 OK
+- ユーザー登録が成功した場合や、ユーザーが既にログインしている場合に返されます
+```json
+// 登録に成功した場合
+{
+    "message": "Signup successful",
+    "redirect": "/pong/"
+}
+
+// 既にログインしている場合
+{
+    "message": "Already logged in",
+    "redirect": "/pong/"
+}
+```
+
+##### 400 Bad Request
+- パスワードが一致しない場合、またはメールアドレス、ニックネーム、パスワードが無効な場合に返されます
+```json
+{
+    "message": error_message
+}
+```
+
+##### 500 Internal Server Error
+- ユーザーの作成中に予期せぬエラーが発生した場合に返されます
+```json
+{
+    "message": error_message
+}
+```
+
+<br>
+
+### 1-2) ログイン: Basic Login API
+- ユーザーのログイン認証(Basic)を行うためのAPIです
+- 認証完了すると、認証情報が`IsAuthenticated`になります
+
+### Endpoint
+- path: `/accounts/api/login/`
+- name: `accounts:api_login`
+
+### Permissions
+- 認証されていないユーザーもアクセス可能（`AllowAny`）
+
+### GET
+#### Responses
+##### 200 OK
+- ログインが成功した場合や、ユーザーが既にログインしている場合に返されます
+- ユーザーが2FAを有効にしている場合、2FAの認証が求められます
+```json
+// ログインに成功した場合（2FA無効ユーザー）
+{
+  "message": "Basic authentication successful",
+  "redirect": "/accounts/user/"
+}
+
+// ログインに成功した場合（2FA有効ユーザー）
+{
+  "message": "2fa authentication needed",
+  "redirect": "/accounts/verify/verify_2fa/"
+}
+
+// すでにログインしている場合
+{
+  "message": "Already logged in",
+  "redirect": "/pong/"
+}
+```
+
+##### 401 Unauthorized
+- 不正なログイン情報を送信された場合に返されます
+```json
+{
+  "error": "Invalid credentials"
+}
+```
+
+<br>
+
+### 1-3) ログアウト: Logout API
+- ユーザーのログイン認証(Basic)をを解除するためのAPIです
+
+### Endpoint
+- path: `/accounts/api/logout/`
+- name: `accounts:api_logout`
+- 
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### POST
+#### Request Parameters
+
+| パラメータ   | 型     | 説明  | 必須 |
+|---------|------|-----|--|
+| -   | - | -  | -  |
+
+#### Responses
+##### 200 OK
+- ログアウトが成功した場合に返されます
+```json
+{
+  "message": "You have been successfully logout",
+  "redirect": "/pong/"
+}
+```
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+<br>
+
+## 2. 2段階認証
+### 2-1) 登録: Enable 2FA
+- 2FA登録用のAPI
+
+### Endpoint
+- path: `/accounts/api/enable_2fa/`
+- name: `accounts:api_enable_2fa`
+
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### GET
+#### Responses
+##### 200 OK
+- 2FA登録用のOTPデータの取得に成功した場合や、既に2FAが有効なユーザーに対して返されます
+```json
+// 2FA登録用のOTPデータの取得に成功
+{
+  "qr_code_data": qr_code_data,
+  "setup_key": secret_key_base32
+}
+
+// 既に2FAが有効なユーザー
+{
+  "message": "Already enabled 2FA",
+  "redirect": "/pong/"
+}
+```
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+### POST
+#### Request Parameters
+
+| パラメータ   | 型     | 説明            | 必須 |
+|---------|------|---------------|--|
+| `token` | 文字列 | 認証用のOTP（6桁数字） | Yes |
+
+#### Responses
+##### 200 OK
+- 2FA登録用のOTPデータの認証に成功した場合や、既に2FAが有効なユーザーに対して返されます
+```json
+// 2FA登録用のOTPデータの取得に成功
+{
+  "message": "2FA has been enabled successfully",
+  "redirect": "/accounts/user/"
+}
+
+// 既に2FAが有効なユーザー
+{
+  "message": "Already enabled 2FA",
+  "redirect": "/pong/"
+}
+```
+
+##### 400 Bad Request
+- 不正なOTPを送信した際に返されます
+```json
+{
+  "error": "Invalid token provided"
+}
+```
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+<br>
+
+### 2-2) 認証: Verify 2FA
+- 2FA認証用のAPI
+- 2FAを有効にしているユーザーは、Basicログイン後にこのAPIでOTPの認証が求められます
+
+### Endpoint
+- path: `/accounts/api/verify_2fa/`
+- name: `accounts:api_verify_2fa`
+
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### POST
+#### Request Parameters
+
+| パラメータ   | 型     | 説明            | 必須 |
+|---------|------|---------------|--|
+| `token` | 文字列 | 認証用のOTP（6桁数字） | Yes |
+
+#### Responses
+##### 200 OK
+- OTPが認証できた場合に返されます
+```json
+{
+  "message": "2FA verification successful",
+  "redirect": "/accounts/user/"
+}
+```
+
+##### 400 Bad Request
+- 不正なOTPを送信した際に返されます
+```json
+{
+  "error": "Invalid token"
+}
+```
+
+##### 401 Unauthorized
+- ログインしている2FA無効ユーザーや、ログインしていないユーザーによるリクエストに対し返されます
+```json
+// ログインしている2FA無効ユーザー
+{
+  "error": "No valid session found",
+  "redirect": "/accounts/login/"
+}
+
+// ログインしていないユーザー
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+<br>
+
+
+### 2-3) 登録解除: Disable 2FA
+- 2FA登録解除用のAPI
+
+### Endpoint
+- path: `/accounts/api/disable_2fa/`
+- name: `accounts:api_disable_2fa`
+
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### GET
+### Redirects
+- 2FAの無効化処理が完了した後、ユーザーはユーザーページ（`accounts:user`）にリダイレクトされます。
+
+### Response
+#### 302 Found
+- ログイン済みの2FAを無効にしているユーザーの場合、ユーザーページにリダイレクトします
+- 2FAが有効なユーザーは、2FAを無効化した後、ユーザーページにリダイレクトします
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+
+
+## 3. ユーザー情報
+### 3-1) 情報取得: user
+- ユーザー情報を取得するAPIです
+
+### Endpoint
+- path: `/accounts/api/user/profile/`
+- name: `accounts:api_user_profile`
+
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### GET
+#### Responses
+##### 200 OK
+- 正常にユーザー情報が取得でき場合に返されます
+```json
+{
+  "email": user_email,
+  "nickname": user_nickname,
+  "enable_2fa": user_enable_2fa
+}
+```
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+### 3-2) 編集: edit
+- ユーザー情報を編集するAPIです
+- ニックネーム or パスワードを変更できます
+
+### Endpoint
+- path: `/accounts/api/user/edit-profile/`
+- name: `accounts:api_edit_profile`
+
+### Permissions
+- 認証されているユーザーのみアクセス可能（`IsAuthenticated`）
+
+### POST
+#### Request Parameters
+- `nickname` or (`new_password` and `current_password`) が必須です
+
+| パラメータ               | 型     | 説明            | 必須 |
+|---------------------|------|---------------|--|
+| `nickname`          | 文字列 | 新しいニックネーム   | ニックネーム変更の場合に必須 |
+| `new_password`     | 文字列 | 新しいパスワード      | パスワード変更の場合に必須 |
+| `current_password` | 文字列 | 現在のパスワード      | パスワード変更の場合に必須 |
+
+#### Responses
+##### 200 OK
+- ニックネーム or パスワードが正常に変更された場合に返されます
+```json
+{
+  "message": message
+}
+```
+
+##### 400 Bad Request
+- 不正な入力値が送信された場合に返されます
+```json
+{
+  "error": error_message
+}
+```
+
+##### 401 Unauthorized
+- ログインしていないユーザーによるリクエストに対し返されます
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+<br>
+
+## 4. JWT
+### 4-1) JWT Refresh
+- Json Web Tokenの有効期限を更新するAPIです
+
+### Endpoint
+- path: `/accounts/api/token/refresh/`
+- name: `accounts:api_token_refresh`
+
+### Permissions
+- 認証されていないユーザーもアクセス可能（`AllowAny`）
+
+### POST
+#### Responses
+##### 200 OK
+- JWTの更新が正常に完了した場合に返されます
+- 更新したJWTはCookieにセットされます
+```json
+{
+  "message": "Token refreshed successfully"
+}
+```
+
+##### 401 Unauthorized
+- JWTを保持していないユーザーや、RefreshTokenの有効期限切れのユーザーに対し返されます
+```json
+{
+  "error": error_message
+}
+```

--- a/Makefile
+++ b/Makefile
@@ -141,20 +141,20 @@ reset_logstash:
 # -----------------------------------------------
 .PHONY: docker_rm
 docker_rm:
-	@if [ -n "$$(docker ps -qa)" ]; then docker stop $$(docker ps -qa); fi
-	@if [ -n "$$(docker ps -qa)" ]; then docker rm -f $$(docker ps -qa); fi
-	@if [ -n "$$(docker images -qa)" ]; then docker rmi -f $$(docker images -qa); fi
-	@if [ -n "$$(docker images -f "dangling=true" -q)" ]; then docker rmi -f $$(docker images -f "dangling=true" -q); fi
-	@docker network rm $$(docker network ls -q) 2>/dev/null || true
-	@docker volume prune -f
+	-@docker stop $$(docker ps -qa) 2>/dev/null
+	-@docker rm -f $$(docker ps -qa) 2>/dev/null
+	-@docker rmi -f $$(docker images -qa) 2>/dev/null
+	-@docker network rm $$(docker network ls -q) 2>/dev/null
+	-@docker volume rm $$(docker volume ls -q) 2>/dev/null
+	-@docker system prune -af --volumes
 
-.PHONY: remove_mount_volume_mac
-remove_mount_volume_mac:
-	rm -rf mount_volume
+.PHONY: remove_mount_volume
+remove_mount_volume:
+	sudo rm -rf mount_volume
 
 .PHONY: rm
 rm:
-	make remove_mount_volume_mac
+	make remove_mount_volume
 
 .PYHONY: ps
 ps:
@@ -169,6 +169,8 @@ ps_a:
 logs:
 	docker-compose $(COMPOSE_FILES_ARGS) logs
 
+.PHONY: fclean
+fclean: down docker_rm remove_mount_volume
 
 # -----------------------------------------------
 #  init
@@ -177,6 +179,7 @@ logs:
 .PHONY: init
 init: env cert_key
 	@chmod +x init/add_host.sh && ./init/add_host.sh init/.os_env
+	@chmod +x init/make_dir.sh && ./init/make_dir.sh init/.os_env
 
 .PHONY: env
 env:

--- a/docker/srcs/compose-yaml/compose-exporter.yaml
+++ b/docker/srcs/compose-yaml/compose-exporter.yaml
@@ -26,10 +26,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.ignored-mount-points'
-      - '^/(sys|proc|dev|host|etc)($|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.ignored-mount-points"
+      - "^/(sys|proc|dev|host|etc)($$|/)"
     ports:
       - 9100:9100
     networks:

--- a/docker/srcs/compose-yaml/compose-web.yaml
+++ b/docker/srcs/compose-yaml/compose-web.yaml
@@ -25,7 +25,8 @@ services:
     restart: unless-stopped
     depends_on:
       # - pgadmin
-      - uwsgi-django
+      uwsgi-django:
+        condition: service_healthy
     init: true
 
   frontend:
@@ -68,6 +69,11 @@ services:
         condition: service_healthy
     #      - postgres
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8001 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     init: true
     volumes:
       - '${VOLUME_PATH:?}/log_django_vol:/src/logs'

--- a/docker/srcs/uwsgi-django/accounts/authentication_backend.py
+++ b/docker/srcs/uwsgi-django/accounts/authentication_backend.py
@@ -8,7 +8,7 @@ class JWTAuthenticationBackend(BaseBackend):
     def authenticate(self, request, token=None):
         User = get_user_model()
         try:
-            payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+            payload = jwt.decode(token, settings.SIMPLE_JWT["SIGNING_KEY"], algorithms=["HS256"])
             user_id = payload.get('user_id')
             user = User.objects.get(id=user_id)
             return user

--- a/docker/srcs/uwsgi-django/accounts/authentication_backend.py
+++ b/docker/srcs/uwsgi-django/accounts/authentication_backend.py
@@ -1,0 +1,25 @@
+import jwt
+from django.conf import settings
+from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth import get_user_model
+
+
+class JWTAuthenticationBackend(BaseBackend):
+    def authenticate(self, request, token=None):
+        User = get_user_model()
+        try:
+            payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+            user_id = payload.get('user_id')
+            user = User.objects.get(id=user_id)
+            return user
+        except jwt.ExpiredSignatureError:
+            return None
+        except User.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        User = get_user_model()
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/docker/srcs/uwsgi-django/accounts/forms.py
+++ b/docker/srcs/uwsgi-django/accounts/forms.py
@@ -62,6 +62,7 @@ class Enable2FAForm(forms.Form):
         return token
 
 
+# todo: JWT認証への切り替えで不要に。testなどの呼び出しを変更後、削除予定
 class Verify2FAForm(forms.Form):
     token = forms.CharField(label='2FA Token', max_length=6, required=True)
 

--- a/docker/srcs/uwsgi-django/accounts/middleware.py
+++ b/docker/srcs/uwsgi-django/accounts/middleware.py
@@ -1,0 +1,9 @@
+from django.utils.deprecation import MiddlewareMixin
+
+
+class JWTAuthenticationMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        token = request.COOKIES.get('Access-Token')
+        if token:
+            # JWTをAuthorizationヘッダーに設定
+            request.META['HTTP_AUTHORIZATION'] = f'Bearer {token}'

--- a/docker/srcs/uwsgi-django/accounts/middleware.py
+++ b/docker/srcs/uwsgi-django/accounts/middleware.py
@@ -1,4 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
+from accounts.authentication_backend import JWTAuthenticationBackend
 
 
 class JWTAuthenticationMiddleware(MiddlewareMixin):
@@ -7,3 +8,8 @@ class JWTAuthenticationMiddleware(MiddlewareMixin):
         if token:
             # JWTをAuthorizationヘッダーに設定
             request.META['HTTP_AUTHORIZATION'] = f'Bearer {token}'
+
+            backend = JWTAuthenticationBackend()
+            user = backend.authenticate(request, token=token)
+            if user:
+                request.user = user

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -67,6 +67,10 @@ class UserManager(BaseUserManager):
             return False, err
         if not nickname.isalnum():
             return False, "Invalid nickname format"
+
+        if CustomUser.objects.filter(nickname=nickname).exists():
+            return False, "This nickname is already in use"
+
         return True, None
 
 

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -51,6 +51,10 @@ class UserManager(BaseUserManager):
     def _is_valid_email(self, email):
         if not email:
             return False, "The given email must be set"
+
+        if CustomUser.objects.filter(email=email).exists():
+            return False, "This email is already in use"
+
         try:
             validate_email(email)
             return True, None

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
@@ -1,0 +1,25 @@
+function handleLogout() {
+    fetch('/accounts/api/logout/', {
+    method: 'GET',
+    headers: {
+        'Content-Type': 'application/json'
+    }
+    }).then(response => {
+    if (!response.ok) {
+        throw new Error('Network response was not ok');
+    }
+    return response.json();
+    })
+    .then(data => {
+        if (data.message) {
+            alert(data.message);
+            window.location.href = data.redirect;
+        } else {
+            throw new Error('No message in response');
+        }
+    })
+    .catch(error => {
+        console.error('Logout failed:', error);
+        alert('Logout failed. Please try again.');
+    });
+}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
@@ -17,7 +17,16 @@
 
 <br>
 
+
 <!-- パスワード更新用のフォーム -->
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const is42AuthUser = "{{ is_42auth_user|yesno:'true,false' }}";  // Djangoのyesnoフィルターを使用
+        if (is42AuthUser) {
+            document.getElementById('password-form').style.display = 'none';  // パスワードフォームを非表示にする
+        }
+    });
+</script>
 <form id="password-form" onsubmit="updatePassword(event)">
     <h2>password</h2>
     <p>current password: <input type="password" id="current_password" placeholder="current-password" required></p>
@@ -87,77 +96,3 @@
 <a href="/pong">🏓 return to pong</a>
 </body>
 </html>
-
-
-
-<!--{% load static %}-->
-<!--<!doctype html>-->
-<!--<html lang="ja">-->
-<!--<head>-->
-<!--    <meta charset="utf-8">-->
-<!--    <title>edit profile</title>-->
-
-<!--    <style>-->
-<!--        .success-message {-->
-<!--            color: blue;-->
-<!--        }-->
-<!--        .errorlist {-->
-<!--            color: red;-->
-<!--        }-->
-<!--    </style>-->
-
-<!--</head>-->
-<!--<body>-->
-
-<!--{% block content %}-->
-<!--<div class="container">-->
-<!--    <h2>Edit Profile</h2>-->
-
-<!--    <hr>-->
-
-<!--    &lt;!&ndash; フィードバックメッセージの表示 &ndash;&gt;-->
-<!--    {% if messages %}-->
-<!--    <ul class="messages">-->
-<!--        {% for message in messages %}-->
-<!--        <li {% if message.tags %} class="{{ message.tags }} success-message"{% endif %}>{{ message }}</li>-->
-<!--        {% endfor %}-->
-<!--    </ul>-->
-<!--    {% endif %}-->
-
-<!--    &lt;!&ndash; ニックネーム編集フォーム &ndash;&gt;-->
-<!--    <form method="post">-->
-<!--        {% csrf_token %}-->
-<!--        <h4>Edit Nickname</h4>-->
-<!--        {{ user_form.as_p }}-->
-<!--        <button type="submit">change nickname</button>-->
-<!--    </form>-->
-
-<!--    <br>-->
-
-<!--    {% if password_form %}-->
-<!--    <hr>-->
-<!--    &lt;!&ndash; パスワード変更フォーム &ndash;&gt;-->
-<!--    <form method="post">-->
-<!--        {% csrf_token %}-->
-<!--        <h4>Change Password</h4>-->
-<!--        {% for field in password_form %}-->
-<!--        <p>-->
-<!--            {{ field.help_text }}-->
-<!--            {{ field.errors }}-->
-<!--            {{ field.label_tag }} {{ field }}-->
-<!--        </p>-->
-<!--        {% endfor %}-->
-<!--        <button type="submit">change password</button>-->
-<!--    </form>-->
-<!--    {% endif %}-->
-
-<!--</div>-->
-<!--{% endblock %}-->
-
-<!--<hr>-->
-<!--<br>-->
-<!--<a href="/pong/">🏓 pong index page</a>-->
-
-<!--</body>-->
-
-<!--</html>-->

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
@@ -1,71 +1,163 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>edit profile</title>
-
-    <style>
-        .success-message {
-            color: blue;
-        }
-        .errorlist {
-            color: red;
-        }
-    </style>
-
+    <title>edit user profile</title>
 </head>
 <body>
+<h1>edit user profile</h1>
+<p id="message-area"></p>
 
-{% block content %}
-<div class="container">
-    <h2>Edit Profile</h2>
+<!-- ニックネーム更新用のフォーム -->
+<form id="nickname-form" onsubmit="updateNickname(event)">
+    <h2>nickname</h2>
+    <p><input type="text" id="nickname" placeholder="{{ current_nickname }}" required></p>
+    <button type="submit">update nickname</button>
+</form>
 
-    <hr>
+<br>
 
-    <!-- フィードバックメッセージの表示 -->
-    {% if messages %}
-    <ul class="messages">
-        {% for message in messages %}
-        <li {% if message.tags %} class="{{ message.tags }} success-message"{% endif %}>{{ message }}</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
+<!-- パスワード更新用のフォーム -->
+<form id="password-form" onsubmit="updatePassword(event)">
+    <h2>password</h2>
+    <p>current password: <input type="password" id="current_password" placeholder="current-password" required></p>
+    <p>new password: <input type="password" id="new_password" placeholder="new-password"></p>
+    <button type="submit">update password</button>
+</form>
 
-    <!-- ニックネーム編集フォーム -->
-    <form method="post">
-        {% csrf_token %}
-        <h4>Edit Nickname</h4>
-        {{ user_form.as_p }}
-        <button type="submit">change nickname</button>
-    </form>
+<script>
+    function updateNickname(event) {
+        event.preventDefault();
+        const nickname = document.getElementById('nickname').value;
 
-    <br>
+        fetch('/accounts/api/user/edit-profile/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+            body: JSON.stringify({
+                nickname: nickname,
+            })
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    document.getElementById('message-area').textContent = data.error;
+                } else {
+                    document.getElementById('message-area').textContent = data.message;
+                    console.log('Success:', data.message);
+                }
+            })
+            .catch(error => console.error('Error:', error));
+    }
 
-    {% if password_form %}
-    <hr>
-    <!-- パスワード変更フォーム -->
-    <form method="post">
-        {% csrf_token %}
-        <h4>Change Password</h4>
-        {% for field in password_form %}
-        <p>
-            {{ field.help_text }}
-            {{ field.errors }}
-            {{ field.label_tag }} {{ field }}
-        </p>
-        {% endfor %}
-        <button type="submit">change password</button>
-    </form>
-    {% endif %}
+    function updatePassword(event) {
+        event.preventDefault();
+        const currentPassword = document.getElementById('current_password').value;
+        const newPassword = document.getElementById('new_password').value;
 
-</div>
-{% endblock %}
+        fetch('/accounts/api/user/edit-profile/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+            body: JSON.stringify({
+                current_password: currentPassword,
+                new_password: newPassword
+            })
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    document.getElementById('message-area').textContent = data.error;
+                } else {
+                    document.getElementById('message-area').textContent = data.message;
+                    console.log('Success:', data.message);
+                }
+            })
+            .catch(error => console.error('Error:', error));
+    }
+</script>
 
 <hr>
-<br>
-<a href="/pong/">🏓 pong index page</a>
-
+<a href="{% url 'accounts:user'%}">return to user page</a>
+<hr>
+<a href="/pong">🏓 return to pong</a>
 </body>
-
 </html>
+
+
+
+<!--{% load static %}-->
+<!--<!doctype html>-->
+<!--<html lang="ja">-->
+<!--<head>-->
+<!--    <meta charset="utf-8">-->
+<!--    <title>edit profile</title>-->
+
+<!--    <style>-->
+<!--        .success-message {-->
+<!--            color: blue;-->
+<!--        }-->
+<!--        .errorlist {-->
+<!--            color: red;-->
+<!--        }-->
+<!--    </style>-->
+
+<!--</head>-->
+<!--<body>-->
+
+<!--{% block content %}-->
+<!--<div class="container">-->
+<!--    <h2>Edit Profile</h2>-->
+
+<!--    <hr>-->
+
+<!--    &lt;!&ndash; フィードバックメッセージの表示 &ndash;&gt;-->
+<!--    {% if messages %}-->
+<!--    <ul class="messages">-->
+<!--        {% for message in messages %}-->
+<!--        <li {% if message.tags %} class="{{ message.tags }} success-message"{% endif %}>{{ message }}</li>-->
+<!--        {% endfor %}-->
+<!--    </ul>-->
+<!--    {% endif %}-->
+
+<!--    &lt;!&ndash; ニックネーム編集フォーム &ndash;&gt;-->
+<!--    <form method="post">-->
+<!--        {% csrf_token %}-->
+<!--        <h4>Edit Nickname</h4>-->
+<!--        {{ user_form.as_p }}-->
+<!--        <button type="submit">change nickname</button>-->
+<!--    </form>-->
+
+<!--    <br>-->
+
+<!--    {% if password_form %}-->
+<!--    <hr>-->
+<!--    &lt;!&ndash; パスワード変更フォーム &ndash;&gt;-->
+<!--    <form method="post">-->
+<!--        {% csrf_token %}-->
+<!--        <h4>Change Password</h4>-->
+<!--        {% for field in password_form %}-->
+<!--        <p>-->
+<!--            {{ field.help_text }}-->
+<!--            {{ field.errors }}-->
+<!--            {{ field.label_tag }} {{ field }}-->
+<!--        </p>-->
+<!--        {% endfor %}-->
+<!--        <button type="submit">change password</button>-->
+<!--    </form>-->
+<!--    {% endif %}-->
+
+<!--</div>-->
+<!--{% endblock %}-->
+
+<!--<hr>-->
+<!--<br>-->
+<!--<a href="/pong/">🏓 pong index page</a>-->
+
+<!--</body>-->
+
+<!--</html>-->

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -7,19 +6,59 @@
 </head>
 <body>
 <h1>ログイン</h1>
-<p>{{message}}</p>
-<form action="{% url 'accounts:login'%}" method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <p><input type="hidden" name="next" value="{{next}}"></p>
-    <p><button type="submit">ログイン</button></p>
+<p id="message-area"></p>
+<form id="login-form" onsubmit="loginUser(event)">
+    <input type="text" id="email" placeholder="E-mail" required><br>
+    <input type="password" id="password" placeholder="password" required autocomplete="current-password">
+    <input type="hidden" id="next" value="/accounts/user/">
+    <button type="submit">ログイン</button>
 </form>
+
+<script>
+    function loginUser(event) {
+        event.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const nextUrl = document.getElementById('next').value;
+
+        fetch('/accounts/api/login/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({email: email, password: password})
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    // Error
+                    document.getElementById('message-area').textContent = data.error;
+                    if (data.redirect) {
+                        window.location.href = data.redirect;
+                    } else {
+                        console.error('Error:', data.error);
+                    }
+                } else if (data.message) {
+                    // Verified
+                    console.log(data.message);
+                    window.location.href = data.redirect;  // Redirect on successful verification
+                }
+            })
+            .catch(error => console.error('Error:', error));
+        clearForm()
+    }
+
+    function clearForm() {
+        document.getElementById('email').value = '';
+        document.getElementById('password').value = '';
+    }
+</script>
 
 <hr>
 <a href="{% url 'accounts:oauth_ft' %}">login with 42</a>
 <hr>
 <a href="{% url 'accounts:signup'%}">ユーザー登録</a>
 <hr>
-<a href="/pong/">🏓 return to pong</a></li>
+<a href="/pong/">🏓 return to pong</a>
 </body>
 </html>

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/logout.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/logout.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -6,10 +5,41 @@
     <title>ログアウト</title>
 </head>
 <body>
-<p>good bye...</p>
 
-<a href="/pong/">🏓 return to pong</a></li>
+<script>
+    function handleLogout() {
+        fetch('/accounts/api/logout/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }).then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        })
+            .then(data => {
+                if (data.message) {
+                    alert(data.message);
+                    window.location.href = data.redirect;
+                } else {
+                    throw new Error('No message in response');
+                }
+            })
+            .catch(error => {
+                console.error('Logout failed:', error);
+                alert('Logout failed. Please try again.');
+            });
+    }
+</script>
+
+<button onclick="handleLogout()">Logout</button>
+
+<hr>
+<a href="{% url 'accounts:user'%}">return to user page</a>
+<hr>
+<a href="/pong/">🏓 return to pong</a>
 
 </body>
-
 </html>

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/signup.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/signup.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -7,16 +6,61 @@
 </head>
 <body>
 <h1>ユーザー登録</h1>
-<form action="{% url 'accounts:signup' %}" method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <p><button type="submit">登録</button></p>
+<p id="message-area"></p>
+<form id="login-form" onsubmit="signupUser(event)">
+    <p>email: <input type="text" id="email" placeholder="E-mail" required></p>
+    <p>nickname: <input type="text" id="nickname" placeholder="nickname" required></p>
+    <p>password: <input type="password" id="password1" placeholder="password"></p>
+    <p>password confirm: <input type="password" id="password2" placeholder="password confirmation"></p>
+    <div id="password-requirements">
+        パスワード要件:
+        <ul>
+            <li>8文字以上</li>
+            <li>一般的によく使われるパスワードは使用不可</li>
+            <li>数字のみのパスワードは使用不可</li>
+        </ul>
+    </div>
+    <button type="submit">Signup</button>
 </form>
 
-<hr>
-<a href="{% url 'accounts:oauth_ft' %}">sign-up with 42</a>
-<hr>
-<a href="/pong/">🏓 return to pong</a></li>
+<script>
+    function signupUser(event) {
+        event.preventDefault();
+        const email = document.getElementById('email').value;
+        const nickname = document.getElementById('nickname').value;
+        const password1 = document.getElementById('password1').value;
+        const password2 = document.getElementById('password2').value;
 
+        fetch('/accounts/api/signup/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({email: email, nickname: nickname, password1: password1, password2: password2})
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    // Error
+                    document.getElementById('message-area').textContent = data.error;
+                    if (data.redirect) {
+                        window.location.href = data.redirect;
+                    } else {
+                        console.error('Error:', data.error);
+                    }
+                } else if (data.message) {
+                    // Verified
+                    console.log(data.message);
+                    window.location.href = data.redirect;  // Redirect on successful verification
+                }
+            })
+            .catch(error => console.error('Error:', error));
+    }
+</script>
+
+<hr>
+<a href="{% url 'accounts:oauth_ft' %}">Signup with 42</a>
+<hr>
+<a href="/pong/">🏓 return to pong</a>
 </body>
 </html>

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user.html
@@ -1,42 +1,40 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>user info</title>
+    <title>User Info</title>
 </head>
 <body>
-<h1>user page</h1>
-<ul>
-    <li>email: {{email}}</li>
-    <li>nickname: {{nickname}}</li>
-
-    {% if user.has_usable_password %}
-        <li>password: ******</li>
-    {% endif %}
-
-    <li><a href="{% url 'accounts:edit' %}">edit profile</a></li>
-
-    <br>
-
-    <!-- 2FAの状態に応じた表示 -->
-    {% if user.enable_2fa %}
-        <li>2FA: ✅Enabled</li>
-        <li><a href="{% url 'accounts:disable_2fa' %}">Disable 2FA</a></li>
-    {% else %}
-        <li>2FA: Disabled</li>
-        <li><a href="{% url 'accounts:enable_2fa' %}">Enable 2FA</a></li>
-    {% endif %}
-
-    <br>
-
-    <li><a href="{% url 'accounts:logout' %}">logout</a></li>
+<h1>User Page</h1>
+<ul id="user-info">
+    <!-- JavaScriptで動的に内容が生成される -->
 </ul>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        fetch("/accounts/api/user/profile/")
+            .then(response => response.json())
+            .then(data => {
+                const userInfo = document.getElementById("user-info");
+                userInfo.innerHTML = `
+            <li>Email: ${data.email}</li>
+            <li>Nickname: ${data.nickname}</li>
+            ${data.has_usable_password ? '<li>Password: ******</li>' : ''}
+            <li><a href="/accounts/edit/">Edit Profile</a></li>
+            <br>
+            ${data.enable_2fa ?
+                    `<li>2FA: ✅Enabled</li><li><a href="/accounts/verify/disable_2fa/">Disable 2FA</a></li>` :
+                    `<li>2FA: Disabled</li><li><a href="/accounts/verify/enable_2fa/">Enable 2FA</a></li>`}
+            <br>
+            <li><a href="/accounts/logout/">Logout</a></li>
+        `;
+            })
+            .catch(error => console.error("Error:", error));
+    });
+</script>
 
 <hr>
 <br>
-<a href="/pong/">🏓 pong index page</a>
-
+<a href="/pong/">🏓 Pong Index Page</a>
 </body>
-
 </html>

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -26,12 +27,14 @@
                     `<li>2FA: ✅Enabled</li><li><a href="/accounts/verify/disable_2fa/">Disable 2FA</a></li>` :
                     `<li>2FA: Disabled</li><li><a href="/accounts/verify/enable_2fa/">Enable 2FA</a></li>`}
             <br>
-            <li><a href="/accounts/logout/">Logout</a></li>
+            <button onclick="handleLogout()">Logout</button>
         `;
             })
             .catch(error => console.error("Error:", error));
     });
 </script>
+
+<script src="{% static 'js/logout.js' %}"></script>
 
 <hr>
 <br>

--- a/docker/srcs/uwsgi-django/accounts/templates/verify/enable_2fa.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/verify/enable_2fa.html
@@ -1,44 +1,129 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>2FA</title>
+  <title>Enable 2FA</title>
 </head>
 <body>
 <h2>Enable Two-Factor Authentication (2FA)</h2>
 
-{% if qr_code_data %}
-  <p>以下のQRコード or Setup KeyをAuthenticatorに登録してください</p>
-  <img src="data:image/png;base64,{{ qr_code_data }}" alt="2FA QR Code">
-  <br>
+<div id="qrCodeContainer" style="margin-bottom: 20px;"></div>
+<div id="error-message" style="color: red;"></div>
 
-  <p>setup key: {{ setup_key }}</p>
-  <p>Setup KeyはQRコードのバックアップにもなります。セキュリティに注意して大切に保管してください。</p>
-  <br>
-  <p>アプリが生成したトークンを以下のフォームで認証してください</p>
-{% endif %}
-
-<form method="post">
-  {% csrf_token %}
+<form id="enableForm">
   <label for="token">Verification Code:</label>
   <input type="text" id="token" name="token" required>
-
-  <!-- エラーメッセージの表示 -->
-  {% if form.non_field_errors %}
-  <div class="error" style="color: red;">
-    {% for error in form.non_field_errors %}
-    {{ error }}
-    {% endfor %}
-  </div>
-  {% endif %}
-
-  <button type="submit" class="btn btn-primary">Verify and Enable 2FA</button>
+  <button type="button" onclick="verifyToken()">Enable 2FA</button>
 </form>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    fetch('/accounts/api/enable_2fa/', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
+            .then(response => response.json())
+            .then(data => {
+              if (data.error) {
+                document.getElementById('error-message').textContent = "Error retrieving 2FA setup: " + data.error;
+              } else if (data.redirect) {
+                console.log(data.message);
+                window.location.href = data.redirect;
+              }
+              else {
+                const qrCodeHtml = `
+                <p>Scan this QR Code with your authenticator app:</p>
+                <img src="data:image/png;base64,${data.qr_code_data}" alt="2FA QR Code"><br>
+                <p>Or enter this setup key: ${data.setup_key}</p>
+            `;
+                document.getElementById('qrCodeContainer').innerHTML = qrCodeHtml;
+              }
+            })
+            .catch(error => {
+              document.getElementById('error-message').textContent = "Network error or server is down.";
+              console.error("Fetch error:", error);
+            });
+  });
+
+  function verifyToken() {
+    const token = document.getElementById('token').value;
+    fetch('/accounts/api/enable_2fa/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ token: token })
+    })
+            .then(response => response.json())
+            .then(data => {
+              if (data.error) {
+                document.getElementById('error-message').textContent = "Verification failed: " + data.error;
+              } else if (data.redirect) {
+                console.log(data.message);
+                window.location.href = data.redirect;
+              } else if (data.success) {
+                console.log(data.message);
+                alert(data.message);
+                window.location.href = data.redirect;
+              }
+            })
+            .catch(error => {
+              document.getElementById('error-message').textContent = "Network error or server is down.";
+              console.error("Fetch error:", error);
+            });
+  }
+</script>
+
 <hr>
-<a href="{% url 'accounts:user'%}">return to user page</a>
-<hr>
-<a href="/pong">🏓 return to pong</a>
+<a href="/accounts/user/">Return to user page</a>
+<br>
+<a href="/pong/">🏓 Return to pong</a>
 </body>
 </html>
+
+<!--{% load static %}-->
+<!--<!doctype html>-->
+<!--<html lang="ja">-->
+<!--<head>-->
+<!--  <meta charset="utf-8">-->
+<!--  <title>2FA</title>-->
+<!--</head>-->
+<!--<body>-->
+<!--<h2>Enable Two-Factor Authentication (2FA)</h2>-->
+
+<!--{% if qr_code_data %}-->
+<!--  <p>以下のQRコード or Setup KeyをAuthenticatorに登録してください</p>-->
+<!--  <img src="data:image/png;base64,{{ qr_code_data }}" alt="2FA QR Code">-->
+<!--  <br>-->
+
+<!--  <p>setup key: {{ setup_key }}</p>-->
+<!--  <p>Setup KeyはQRコードのバックアップにもなります。セキュリティに注意して大切に保管してください。</p>-->
+<!--  <br>-->
+<!--  <p>アプリが生成したトークンを以下のフォームで認証してください</p>-->
+<!--{% endif %}-->
+
+<!--<form method="post">-->
+<!--  {% csrf_token %}-->
+<!--  <label for="token">Verification Code:</label>-->
+<!--  <input type="text" id="token" name="token" required>-->
+
+<!--  &lt;!&ndash; エラーメッセージの表示 &ndash;&gt;-->
+<!--  {% if form.non_field_errors %}-->
+<!--  <div class="error" style="color: red;">-->
+<!--    {% for error in form.non_field_errors %}-->
+<!--    {{ error }}-->
+<!--    {% endfor %}-->
+<!--  </div>-->
+<!--  {% endif %}-->
+
+<!--  <button type="submit" class="btn btn-primary">Verify and Enable 2FA</button>-->
+<!--</form>-->
+
+<!--<hr>-->
+<!--<a href="{% url 'accounts:user'%}">return to user page</a>-->
+<!--<hr>-->
+<!--<a href="/pong">🏓 return to pong</a>-->
+<!--</body>-->
+<!--</html>-->

--- a/docker/srcs/uwsgi-django/accounts/templates/verify/enable_2fa.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/verify/enable_2fa.html
@@ -9,8 +9,13 @@
 <h2>Enable Two-Factor Authentication (2FA)</h2>
 
 {% if qr_code_data %}
-  <p>以下のQRコードを2FAアプリでスキャンしてください</p>
+  <p>以下のQRコード or Setup KeyをAuthenticatorに登録してください</p>
   <img src="data:image/png;base64,{{ qr_code_data }}" alt="2FA QR Code">
+  <br>
+
+  <p>setup key: {{ setup_key }}</p>
+  <p>Setup KeyはQRコードのバックアップにもなります。セキュリティに注意して大切に保管してください。</p>
+  <br>
   <p>アプリが生成したトークンを以下のフォームで認証してください</p>
 {% endif %}
 
@@ -33,7 +38,7 @@
 
 <hr>
 <a href="{% url 'accounts:user'%}">return to user page</a>
-<br>
+<hr>
 <a href="/pong">🏓 return to pong</a>
 </body>
 </html>

--- a/docker/srcs/uwsgi-django/accounts/templates/verify/verify_2fa.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/verify/verify_2fa.html
@@ -1,39 +1,58 @@
-{% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
-    <title>2fa</title>
+    <title>2FA Verification</title>
 </head>
 <body>
-
-{% block content %}
 <h2>Verify Two-Factor Authentication (2FA)</h2>
 <p>Enter the verification code from your authentication app:</p>
 
-<form method="post">
-    {% csrf_token %}
-    <label for="token">Verification Code:</label>
-    <input type="text" id="token" name="token" required>
+<div id="error-message" style="color: red;"></div>
 
-    <!-- エラーメッセージの表示 -->
-    {% if form.non_field_errors %}
-    <div class="error" style="color: red;">
-        {% for error in form.non_field_errors %}
-        {{ error }}
-        {% endfor %}
-    </div>
-    {% endif %}
+<label for="token">Verification Code:</label>
+<input type="text" id="token" required>
+<button onclick="verifyToken()">Verify</button>
 
-    <button type="submit" class="btn btn-primary">Verify</button>
-</form>
+<script>
+    function verifyToken() {
+        const token = document.getElementById('token').value;
+        fetch('/accounts/api/verify_2fa/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ token: token })
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    // Error
+                    document.getElementById('error-message').textContent = data.error;
+                    if (data.redirect) {
+                        window.location.href = data.redirect;
+                    } else {
+                        console.error('Error:', data.error);
+                    }
+                } else if (data.message) {
+                    // Verified
+                    console.log(data.message);
+                    window.location.href = data.redirect;  // Redirect on successful verification
+                }
+            })
+            .catch(error => console.error("Error:", error));
 
-<!--<a href="{% url 'accounts:enable_2fa' %}">Enable 2FA on another device</a>-->
-{% endblock %}
+        clearForm()
+    }
+
+    function clearForm() {
+        document.getElementById('token').value = '';
+    }
+</script>
 
 <hr>
-<a href="{% url 'accounts:user'%}">return to user page</a>
+<a href="/accounts/user/">Return to user page</a>
 <br>
-<a href="/pong">🏓 return to pong</a>
+<a href="/pong/">🏓 Return to pong</a>
 </body>
 </html>

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -243,58 +243,49 @@ class DisableUserAccessTests(TestCase):
         self.assertFalse(self.user.enable_2fa)
 
 
-class AccessEnable2FaNotLoginUserTests(TestCase):
-    kEnable2FaName = "accounts:enable_2fa"
-    kUserPageName = "accounts:user"
+class UnLoginedUserAccessTests(TestCase):
+    """
+    un logged in user access to
+     accounts:enable_2fa  -> redirect to "accounts:login"
+     accounts:verify_2fa  -> redirect to "accounts:login"
+     accounts:disable_2fa -> redirect to "accounts:login"
+    """
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
     kLoginName = "accounts:login"
+
+    kEnable2FaName = "accounts:enable_2fa"
+    kEnable2FaURL = "/accounts/verify/enable_2fa/"
+
+    kVerify2FaName = "accounts:verify_2fa"
+    kVerify2FaURL = "/accounts/verify/verify_2fa/"
+
+    kDisable2FaName = "accounts:disable_2fa"
+    kDisable2FaURL = "/accounts/verify/disable_2fa/"
+
+    kUserPageName = "accounts:user"
+    kHomeURL = "/pong/"
 
     def setUp(self):
         self.enable_2fa_url = reverse(self.kEnable2FaName)
-        self.login_url = reverse(self.kLoginName)
-        self.not_login_user_redirect_to = f"{self.login_url}?next={self.enable_2fa_url}"
-
-        self.response = self.client.get(self.enable_2fa_url)
-
-    def test_status_code(self):
-        self.assertEqual(self.response.status_code, 302)
-
-    def test_redirect(self):
-        self.assertRedirects(self.response, self.not_login_user_redirect_to)
-
-
-class AccessVerify2FaNotLoginUserTests(TestCase):
-    kVerify2FaName = "accounts:verify_2fa"
-    kUserPageName = "accounts:user"
-    kLoginName = "accounts:login"
-
-    def setUp(self):
         self.verify_2fa_url = reverse(self.kVerify2FaName)
-        self.login_url = reverse(self.kLoginName)
-        self.not_login_user_redirect_to = f"{self.login_url}"  # LoginRequiredMixinでないためnextなし
-
-        self.response = self.client.get(self.verify_2fa_url)
-
-    def test_status_code(self):
-        self.assertEqual(self.response.status_code, 302)
-
-    def test_redirect(self):
-        self.assertRedirects(self.response, self.not_login_user_redirect_to)
-
-
-class NotLoginUserAccessDisable2FaTests(TestCase):
-    kDisable2FaName = "accounts:disable_2fa"
-    kUserPageName = "accounts:user"
-    kLoginName = "accounts:login"
-
-    def setUp(self):
         self.disable_2fa_url = reverse(self.kDisable2FaName)
+        self.user_page_url = reverse(self.kUserPageName)
         self.login_url = reverse(self.kLoginName)
-        self.not_login_user_redirect_to = f"{self.login_url}?next={self.disable_2fa_url}"
+        self.not_login_user_redirect_to = f"{self.login_url}?next="
 
-        self.response = self.client.get(self.disable_2fa_url)
+    def test_access_to_enable_2fa(self):
+        self.response = self.client.get(self.enable_2fa_url, follow=True)
+        redirect_to = self.not_login_user_redirect_to + self.enable_2fa_url
+        self.assertRedirects(self.response, redirect_to)
 
-    def test_status_code(self):
-        self.assertEqual(self.response.status_code, 302)
+    def test_access_to_verify_2fa(self):
+        self.response = self.client.get(self.verify_2fa_url, follow=True)
+        self.assertRedirects(self.response, self.login_url)  # LoginRequiredMixinでないためnextなし
 
-    def test_redirect(self):
-        self.assertRedirects(self.response, self.not_login_user_redirect_to)
+    def test_access_to_disable_2fa(self):
+        self.response = self.client.get(self.disable_2fa_url, follow=True)
+        redirect_to = self.not_login_user_redirect_to + self.disable_2fa_url
+        self.assertRedirects(self.response, redirect_to)

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -1,8 +1,15 @@
+from base64 import b32encode
+import pyotp
+import time
+
 from django.contrib.auth import get_user_model, login
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.messages import get_messages
-from django.urls import reverse, resolve
+from django_otp.util import random_hex
+from django_otp.plugins.otp_totp.models import TOTPDevice
 from django.test import TestCase
+from django.urls import reverse, resolve
+
 from accounts.forms import Enable2FAForm, Verify2FAForm
 from accounts.views.two_factor_auth import Enable2FaView, Verify2FaView
 
@@ -126,6 +133,101 @@ class Verify2FaFormTests(TestCase):
         self.assertContains(self.response, '<input', 2)
         self.assertContains(self.response, 'type="hidden"', 1)  # csrf
         self.assertContains(self.response, 'type="text"', 1)    # token
+
+
+class EnableAndVerify2FaTests(TestCase):
+    """
+    enable2fa and logged in user access to
+     accounts:enable_2fa  -> redirect to "accounts:user"
+     accounts:verify_2fa  -> redirect to "/pong/"
+     accounts:disable_2fa -> 2fa disabled -> redirect to "accounts:user"
+    """
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
+    kLoginName = "accounts:login"
+
+    kEnable2FaName = "accounts:enable_2fa"
+    kEnable2FaURL = "/accounts/verify/enable_2fa/"
+
+    kVerify2FaName = "accounts:verify_2fa"
+    kVerify2FaURL = "/accounts/verify/verify_2fa/"
+
+    kDisable2FaName = "accounts:disable_2fa"
+    kDisable2FaURL = "/accounts/verify/disable_2fa/"
+
+    kUserPageName = "accounts:user"
+    kHomeURL = "/pong/"
+
+    def setUp(self):
+        self.enable_2fa_url = reverse(self.kEnable2FaName)
+        self.verify_2fa_url = reverse(self.kVerify2FaName)
+        self.disable_2fa_url = reverse(self.kDisable2FaName)
+        self.user_page_url = reverse(self.kUserPageName)
+        self.login_url = reverse(self.kLoginName)
+
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                             nickname=self.kUserNickname,
+                                             password=self.kUserPassword,
+                                             enable_2fa=False)  # disable
+        self.user.save()
+        self.client.force_login(self.user)
+
+    def test_enable_2fa(self):
+        """
+        testing enable 2fa use post method for Enable2FaView
+        """
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.enable_2fa)  # disable
+
+        response = self.client.get(self.enable_2fa_url)
+        setup_key = response.context['setup_key']
+        secret_key_base32 = b32encode(bytes.fromhex(setup_key)).decode('utf-8')
+        totp = pyotp.TOTP(secret_key_base32)
+        otp_token = totp.now()
+
+        response = self.client.post(self.enable_2fa_url, {'token': otp_token}, follow=True)
+        # print(f"form.errors:[{response.context['form'].errors}]")
+
+        self.assertRedirects(response, self.user_page_url)   # succeed enable2fa -> redirect to user
+
+        self.assertTrue('_auth_user_id' in self.client.session)  # login
+
+        self.user.enable_2fa = True
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.enable_2fa)  # enable
+
+    def test_verify_2fa(self):
+        # enable 2fa and logout
+        self.test_enable_2fa()
+        self.client.logout()
+
+        # login
+        user_field = {
+            'username'  : self.kUserEmail,
+            'password'  : self.kUserPassword,
+        }
+        response = self.client.post(self.login_url, user_field, follow=True)
+        self.assertFalse('_auth_user_id' in self.client.session)  # login yet
+
+        # verify 2fa form
+        enable_2fa_view = resolve(self.kVerify2FaURL)
+        self.assertEqual(enable_2fa_view.func.view_class, Verify2FaView)
+
+        devices = TOTPDevice.objects.filter(user=self.user, confirmed=True)
+        device = devices.first()
+        totp = pyotp.TOTP(b32encode(bytes.fromhex(device.key)).decode('utf-8'))
+        otp_token = totp.now()
+
+        # verify
+        response = self.client.post(self.verify_2fa_url, {'token': otp_token}, follow=True)
+        self.assertRedirects(response, self.kHomeURL)
+
+        self.assertIn('_auth_user_id', self.client.session)  # login
+
 
 
 class Disable2FaTests(TestCase):

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -3,8 +3,124 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.messages import get_messages
 from django.urls import reverse, resolve
 from django.test import TestCase
-from accounts.forms import UserEditForm
-from accounts.views.user import EditUserProfileView
+from accounts.forms import Enable2FAForm, Verify2FAForm
+from accounts.views.two_factor_auth import Enable2FaView, Verify2FaView
+
+
+class Enable2FaFormTests(TestCase):
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
+    kLoginName = "accounts:login"
+    kEnable2FaName = "accounts:enable_2fa"
+    kEnable2FaURL = "/accounts/verify/enable_2fa/"
+
+    def setUp(self):
+
+        User = get_user_model()
+        user = User.objects.create_user(email=self.kUserEmail,
+                                        nickname=self.kUserNickname,
+                                        password=self.kUserPassword)
+        user.save()
+
+        login_url = reverse(self.kLoginName)
+        user_field = {
+            'username'  : self.kUserEmail,
+            'password'  : self.kUserPassword,
+        }
+        self.response = self.client.post(login_url, user_field)
+
+        # access to enable_2fa
+        enable_2fa_url = reverse(self.kEnable2FaName)
+        self.response = self.client.get(enable_2fa_url)
+
+    def test_status_code(self):
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_url_resolve_view(self):
+        enable_2fa_view = resolve(self.kEnable2FaURL)
+        self.assertEqual(enable_2fa_view.func.view_class, Enable2FaView)
+
+    def test_csrf(self):
+        self.assertContains(self.response, 'csrfmiddlewaretoken')
+
+    def test_contains_form(self):
+        form = self.response.context.get('form')
+        self.assertIsInstance(form, Enable2FAForm)
+
+    def test_form_inputs(self):
+        '''
+        The edit form should contain 5 <input> tags:
+         (csrf), token
+        '''
+        self.assertContains(self.response, '<input', 2)
+        self.assertContains(self.response, 'type="hidden"', 1)  # csrf
+        self.assertContains(self.response, 'type="text"', 1)    # token
+
+    def test_input_invalid_token(self):
+        invalid_tokens = [
+            '', 'a', '@', '.',
+            'abcdef', '123abc'
+            '000000', '999999',
+            '+000000', '-00000', '0000.0',
+            '000000a', 'aaaaaa',
+            '00000000', '000000-0000',
+            ' 000000 ',
+            '０００００００',
+        ]
+
+        for token in invalid_tokens:
+            form = Enable2FAForm(data={'token': token})
+            self.assertFalse(form.is_valid())
+
+
+class Verify2FaFormTests(TestCase):
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
+    kLoginName = "accounts:login"
+    kVerify2FaURL = "/accounts/verify/verify_2fa/"
+
+    def setUp(self):
+        User = get_user_model()
+        user = User.objects.create_user(email=self.kUserEmail,
+                                        nickname=self.kUserNickname,
+                                        password=self.kUserPassword,
+                                        enable_2fa=True)
+        user.save()
+
+        login_url = reverse(self.kLoginName)
+        user_field = {
+            'username'  : self.kUserEmail,
+            'password'  : self.kUserPassword,
+        }
+        self.response = self.client.post(login_url, user_field, follow=True)
+        # login -> redirect to verify_2fa
+
+    def test_status_code(self):
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_url_resolve_view(self):
+        enable_2fa_view = resolve(self.kVerify2FaURL)
+        self.assertEqual(enable_2fa_view.func.view_class, Verify2FaView)
+
+    def test_csrf(self):
+        self.assertContains(self.response, 'csrfmiddlewaretoken')
+
+    def test_contains_form(self):
+        form = self.response.context.get('form')
+        self.assertIsInstance(form, Verify2FAForm)
+
+    def test_form_inputs(self):
+        '''
+        The edit form should contain 5 <input> tags:
+         (csrf), token
+        '''
+        self.assertContains(self.response, '<input', 2)
+        self.assertContains(self.response, 'type="hidden"', 1)  # csrf
+        self.assertContains(self.response, 'type="text"', 1)    # token
 
 
 class NotLoginUserAccessEnable2FaTests(TestCase):

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -1,0 +1,64 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from accounts.forms import UserEditForm
+from accounts.views.user import EditUserProfileView
+
+
+class NotLoginUserAccessEnable2FaTests(TestCase):
+    kEnable2FaName = "accounts:enable_2fa"
+    kUserPageName = "accounts:user"
+    kLoginName = "accounts:login"
+
+    def setUp(self):
+        self.enable_2fa_url = reverse(self.kEnable2FaName)
+        self.login_url = reverse(self.kLoginName)
+        self.not_login_user_redirect_to = f"{self.login_url}?next={self.enable_2fa_url}"
+
+        self.response = self.client.get(self.enable_2fa_url)
+
+    def test_status_code(self):
+        self.assertEqual(self.response.status_code, 302)
+
+    def test_redirect(self):
+        self.assertRedirects(self.response, self.not_login_user_redirect_to)
+
+
+class NotLoginUserAccessVerify2FaTests(TestCase):
+    kVerify2FaName = "accounts:verify_2fa"
+    kUserPageName = "accounts:user"
+    kLoginName = "accounts:login"
+
+    def setUp(self):
+        self.verify_2fa_url = reverse(self.kVerify2FaName)
+        self.login_url = reverse(self.kLoginName)
+        self.not_login_user_redirect_to = f"{self.login_url}"  # LoginRequiredMixinでないためnextなし
+
+        self.response = self.client.get(self.verify_2fa_url)
+
+    def test_status_code(self):
+        self.assertEqual(self.response.status_code, 302)
+
+    def test_redirect(self):
+        self.assertRedirects(self.response, self.not_login_user_redirect_to)
+
+
+class NotLoginUserAccessDisable2FaTests(TestCase):
+    kDisable2FaName = "accounts:disable_2fa"
+    kUserPageName = "accounts:user"
+    kLoginName = "accounts:login"
+
+    def setUp(self):
+        self.disable_2fa_url = reverse(self.kDisable2FaName)
+        self.login_url = reverse(self.kLoginName)
+        self.not_login_user_redirect_to = f"{self.login_url}?next={self.disable_2fa_url}"
+
+        self.response = self.client.get(self.disable_2fa_url)
+
+    def test_status_code(self):
+        self.assertEqual(self.response.status_code, 302)
+
+    def test_redirect(self):
+        self.assertRedirects(self.response, self.not_login_user_redirect_to)

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -183,8 +183,7 @@ class EnableAndVerify2FaTests(TestCase):
         self.assertFalse(self.user.enable_2fa)  # disable
 
         response = self.client.get(self.enable_2fa_url)
-        setup_key = response.context['setup_key']
-        secret_key_base32 = b32encode(bytes.fromhex(setup_key)).decode('utf-8')
+        secret_key_base32 = response.context['setup_key']
         totp = pyotp.TOTP(secret_key_base32)
         otp_token = totp.now()
 
@@ -194,8 +193,6 @@ class EnableAndVerify2FaTests(TestCase):
         self.assertRedirects(response, self.user_page_url)   # succeed enable2fa -> redirect to user
 
         self.assertTrue('_auth_user_id' in self.client.session)  # login
-
-        self.user.enable_2fa = True
 
         self.user.refresh_from_db()
         self.assertTrue(self.user.enable_2fa)  # enable

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -128,6 +128,54 @@ class Verify2FaFormTests(TestCase):
         self.assertContains(self.response, 'type="text"', 1)    # token
 
 
+class Disable2FaTests(TestCase):
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
+    kDisable2FaName = "accounts:disable_2fa"
+
+    kUserPageName = "accounts:user"
+
+    def setUp(self):
+        self.disable_2fa_url = reverse(self.kDisable2FaName)
+        self.user_page_url = reverse(self.kUserPageName)
+
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                             nickname=self.kUserNickname,
+                                             password=self.kUserPassword,
+                                             enable_2fa=True)  # enable
+        self.user.save()
+        self.client.force_login(self.user)
+
+    def test_access_to_disable_2fa(self):
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.enable_2fa)  # enable
+
+        self.response = self.client.get(self.disable_2fa_url, follow=True)
+        self.assertRedirects(self.response, self.user_page_url)
+
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.enable_2fa)  # disabled
+
+    def test_re_access_to_disable_2fa(self):
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.enable_2fa)  # enable
+
+        self.response = self.client.get(self.disable_2fa_url, follow=True)
+        self.assertRedirects(self.response, self.user_page_url)
+
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.enable_2fa)  # disabled
+
+        self.response = self.client.get(self.disable_2fa_url, follow=True)
+        self.assertRedirects(self.response, self.user_page_url)
+
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.enable_2fa)  # disable
+
+
 class EnableUserAccessTests(TestCase):
     """
     enable2fa and logged in user access to

--- a/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
@@ -1,0 +1,106 @@
+from base64 import b32encode
+import pyotp
+
+from django.contrib.auth import get_user_model, login
+from django.contrib.auth.models import User
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from django.test import TestCase
+from django.urls import reverse, resolve
+from rest_framework.test import APITestCase
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from accounts.views.two_factor_auth import Verify2FaView
+
+
+class TokenIssuanceTest(TestCase):
+    kLoginName = 'accounts:login'
+    kEnable2FaName = "accounts:enable_2fa"
+    kUserPageName = "accounts:user"
+
+    kHomeURL = "/pong/"
+
+    kVerify2FaName = "accounts:verify_2fa"
+    kVerify2FaURL = "/accounts/verify/verify_2fa/"
+
+    kUserEmail = 'test@example.com'
+    kUserNickname = 'test'
+    kUserPassword = 'pass012345'
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                        nickname=self.kUserNickname,
+                                        password=self.kUserPassword,
+                                        enable_2fa=False)
+        self.user.save()
+
+        self.login_url = reverse(self.kLoginName)
+        user_field = {
+            'username'  : self.kUserEmail,
+            'password'  : self.kUserPassword,
+        }
+        self.response = self.client.post(self.login_url, user_field)
+        self.assertRedirects(self.response, self.kHomeURL)
+        self.assertEqual(self.response.status_code, 302)
+        self.assertTrue('_auth_user_id' in self.client.session)
+
+    def test_token_issuance_basic_login(self):
+        self.assertTrue('Access-Token' in self.response.cookies)
+        self.assertTrue('Refresh-Token' in self.response.cookies)
+
+        access_token_cookie = self.response.cookies['Access-Token']
+        self.assertTrue(access_token_cookie['httponly'])
+        self.assertEqual(access_token_cookie['samesite'], 'Strict')
+
+    def test_token_issuance_2fa(self):
+        self._enable_2fa()
+        self.client.logout()
+        self._login_with_2fa()
+
+        # assert JWT
+        self.assertTrue('Access-Token' in self.response.cookies)
+        self.assertTrue('Refresh-Token' in self.response.cookies)
+
+        access_token_cookie = self.response.cookies['Access-Token']
+        self.assertTrue(access_token_cookie['httponly'])
+        self.assertEqual(access_token_cookie['samesite'], 'Strict')
+
+    def _enable_2fa(self):
+        enable_2fa_url = reverse(self.kEnable2FaName)
+        response = self.client.get(enable_2fa_url)
+        secret_key_base32 = response.context['setup_key']
+        totp = pyotp.TOTP(secret_key_base32)
+        otp_token = totp.now()
+
+        response = self.client.post(enable_2fa_url, {'token': otp_token}, follow=True)
+
+        user_page_url = reverse(self.kUserPageName)
+        self.assertRedirects(response, user_page_url)   # succeed enable2fa -> redirect to user
+        self.assertTrue('_auth_user_id' in self.client.session)  # login
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.enable_2fa)  # enable
+
+    def _login_with_2fa(self):
+        # login
+        user_field = {
+            'username'  : self.kUserEmail,
+            'password'  : self.kUserPassword,
+        }
+        response = self.client.post(self.login_url, user_field, follow=True)
+        self.assertFalse('_auth_user_id' in self.client.session)  # login yet
+
+        # verify 2fa form
+        enable_2fa_view = resolve(self.kVerify2FaURL)
+        self.assertEqual(enable_2fa_view.func.view_class, Verify2FaView)
+
+        devices = TOTPDevice.objects.filter(user=self.user, confirmed=True)
+        device = devices.first()
+        totp = pyotp.TOTP(b32encode(bytes.fromhex(device.key)).decode('utf-8'))
+        otp_token = totp.now()
+
+        # verify
+        verify_2fa_url = reverse(self.kVerify2FaName)
+        response = self.client.post(verify_2fa_url, {'token': otp_token}, follow=True)
+        self.assertRedirects(response, self.kHomeURL)
+        self.assertIn('_auth_user_id', self.client.session)  # login

--- a/docker/srcs/uwsgi-django/accounts/tests/test_logout.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_logout.py
@@ -1,11 +1,15 @@
 from django.contrib.auth import get_user_model
+from django.http import JsonResponse
 from django.urls import reverse
 from django.test import TestCase
+from rest_framework import status
+
+from accounts.models import CustomUser, UserManager
 
 
-class LogoutTests(TestCase):
-    kLoginName = "accounts:login"
-    kLogoutName = "accounts:logout"
+class LogoutAPITests(TestCase):
+    kLoginAPIName = "accounts:api_login"
+    kLogoutAPIName = "accounts:api_logout"
     kLoginURL = "accounts/login.html"
     kLogoutURL = "accounts/logout.html"
     kHomeURL = "/pong/"
@@ -15,30 +19,38 @@ class LogoutTests(TestCase):
     kUserPassword = "pass012345"
 
     def setUp(self):
-        self.user = get_user_model().objects.create_user(email=self.kUserEmail,
-                                                         nickname=self.kUserNickname,
-                                                         password=self.kUserPassword)
-        self.login_url = reverse(self.kLoginName)
-        self.logout_url = reverse(self.kLogoutName)
-        self.client.login(username=self.kUserEmail, password=self.kUserPassword)
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.logout_api_url = reverse(self.kLogoutAPIName)
 
-    def test_logout_redirect(self):
-        # login user accesses login, redirect to home
-        response = self.client.get(self.login_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, self.kHomeURL)
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                             nickname=self.kUserNickname,
+                                             password=self.kUserPassword,
+                                             enable_2fa=False)
 
-        response = self.client.get(self.logout_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, self.kLogoutURL)
+    def test_logout_success(self):
+        # login
+        login_data = {
+            'email': self.kUserEmail,
+            'password': self.kUserPassword
+        }
+        response = self.client.post(self.login_api_path, data=login_data)
 
-        response = self.client.get(self.login_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, self.kLoginURL)
+        # logout
+        response = self.client.get(self.logout_api_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_json = response.json()
+        self.assertIn('You have been successfully logout', response_json['message'])
+        self.assertIn('/pong/', response_json['redirect'])
+
+        self.assertTrue(response.cookies.get('Access-Token', '').value == '')
+        self.assertTrue(response.cookies.get('Refresh-Token', '').value == '')
+
+        self.assertIsNone(self.client.session.get('_auth_user_id'))
 
 
-def test_user_session_ended(self):
-        self.client.get(self.logout_url)
-        response = self.client.get(self.logout_url)
-        user = response.context.get('user')
-        self.assertFalse(user.is_authenticated)
+    def test_logout_unauthenticated(self):
+        response = self.client.get(self.logout_api_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
@@ -3,203 +3,154 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.messages import get_messages
 from django.urls import reverse, resolve
 from django.test import TestCase
-from accounts.forms import UserEditForm
-from accounts.views.user import EditUserProfileView
+from rest_framework import status
+from rest_framework.test import APIClient
 
 
-class UserProfileEditFormTests(TestCase):
-    kLoginName = "accounts:login"
-    kLoginURL = "/accounts/login/"
+class UserProfileAPITests(TestCase):
+    kUserProfileAPIName = "accounts:api_user_profile"
 
-    kEditName = "accounts:edit"
-    kEditURL = "/accounts/edit/"
-    kHomeURL = "/pong/"
-
-    kUserEmail = 'test@example.com'
-    kUserNickname = 'test'
-    kUserPassword = 'pass012345'
+    kUserEmail = "test@example.com"
+    kUserNickname = "test"
+    kUserPassword = "pass012345"
 
     def setUp(self):
-        self.user = get_user_model().objects.create_user(email=self.kUserEmail,
-                                                         nickname=self.kUserNickname,
-                                                         password=self.kUserPassword)
-        self.user.save()
-        url = reverse(self.kLoginName)
-        user_field = {
-            'username'  : self.kUserEmail,
-            'password'  : self.kUserPassword,
-        }
-        self.response = self.client.post(url, user_field)
+        self.user_api_url = reverse(self.kUserProfileAPIName)
+        self.client = APIClient()
 
-        url = reverse(self.kEditName)
-        self.response = self.client.get(url)
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                             nickname=self.kUserNickname,
+                                             password=self.kUserPassword,
+                                             enable_2fa=False)
 
+    def test_valid_user(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.user_api_url)
 
-    def test_edit_status_code(self):
-        self.assertEqual(self.response.status_code, 200)
+        response_json = response.json()
+        self.assertIn(self.kUserEmail, response_json['email'])
+        self.assertIn(self.kUserNickname, response_json['nickname'])
+        self.assertFalse(response_json['enable_2fa'])
 
-
-    def test_edit_url_resolves_edit_view(self):
-        view = resolve(self.kEditURL)
-        self.assertEqual(view.func.view_class, EditUserProfileView)
-
-
-    def test_csrf(self):
-        self.assertContains(self.response, 'csrfmiddlewaretoken')
+    def test_invalid_user(self):
+        response = self.client.get(self.user_api_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
-    def test_contains_form(self):
-        form = self.response.context.get('form')
-        self.assertIsInstance(form, UserEditForm)
+class EditUserProfileAPITests(TestCase):
+    kEditUserProfileAPIName = "accounts:api_edit_profile"
+    kLoginAPIName = "accounts:api_login"
+    kLogoutAPIName = "accounts:api_logout"
 
+    kUserEmail = "test@example.com"
+    kUserNickname = "test"
+    kUserPassword = "pass012345"
 
-    def test_form_inputs(self):
-        '''
-        The edit form should contain 5 <input> tags:
-         (csrf), nickname, password
-        '''
-        self.assertContains(self.response, '<input', 6)
-        self.assertContains(self.response, 'type="hidden"', 2)      # csrf
-        self.assertContains(self.response, 'type="text"', 1)        # nickname
-        self.assertContains(self.response, 'type="password"', 3)    # password
-
-
-class UserProfileEditSuccessTests(TestCase):
-    kLoginName = "accounts:login"
-    kLoginURL = "/accounts/login/"
-
-    kEditName = "accounts:edit"
-    kEditURL = "/accounts/edit/"
-    kHomeURL = "/pong/"
-
-    kUserEmail = 'test@example.com'
-    kUserNickname = 'test'
-    kUserPassword = 'pass012345'
-
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
 
     def setUp(self):
-        self.user = get_user_model().objects.create_user(email=self.kUserEmail,
-                                                         nickname=self.kUserNickname,
-                                                         password=self.kUserPassword)
-        self.user.save()
-        url = reverse(self.kLoginName)
-        user_field = {
-            'username'  : self.kUserEmail,
-            'password'  : self.kUserPassword,
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.edit_user_profile_url = reverse(self.kEditUserProfileAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user = User.objects.create_user(email=self.kUserEmail,
+                                             nickname=self.kUserNickname,
+                                             password=self.kUserPassword,
+                                             enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                             nickname=self.kUser2Nickname,
+                                             password=self.kUser2Password,
+                                             enable_2fa=False)
+        login_data = {
+            'email': self.kUserEmail,
+            'password': self.kUserPassword
         }
-        self.response = self.client.post(url, user_field)
+        self.client.post(self.login_api_path, data=login_data)
 
-        url = reverse(self.kEditName)
-        self.response = self.client.get(url)
-        self.edit_url = reverse(self.kEditName)
+    # nickname
+    def test_update_nickname_successfully(self):
+        new_nickname = 'newNickname'
+        response = self.client.post(self.edit_user_profile_url, {'nickname': new_nickname})
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(f'nickname updat successfully {self.kUserNickname} -> {new_nickname}',
+                      response.data['message'])
 
-    def test_edit_nickname(self):
-        new_nickname = 'newnickname'
-        param = {
-            'nickname': new_nickname
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
         self.user.refresh_from_db()
-
         self.assertEqual(self.user.nickname, new_nickname)
-        messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(len(messages), 1)
 
-        msg = f"Your nickname was successfully updated from \"{self.kUserNickname}\" to \"{new_nickname}\""
-        self.assertIn(msg, str(messages[0]))
+    def test_update_nickname_fail_same_old_nickname(self):
+        response = self.client.post(self.edit_user_profile_url, {'nickname': self.kUserNickname})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('new nickname same as current', response.data['error'])
+
+    def test_update_nickname_fail_already_use_nickname(self):
+        response = self.client.post(self.edit_user_profile_url, {'nickname': self.kUser2Nickname})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('This nickname is already in use', response.data['error'])
+
+    def test_update_nickname_fail_invalid_nickname(self):
+        response = self.client.post(self.edit_user_profile_url, {'nickname': '*'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Invalid nickname format', response.data['error'])
 
 
-    def test_change_password(self):
-        new_password = "new9876abcd"
-        param = {
-            'old_password'  : self.kUserPassword,
-            'new_password1' : new_password,
-            'new_password2' : new_password,
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
+    # password
+    def test_update_password_successfully(self):
+        new_password = 'newPassword123'
+        response = self.client.post(self.edit_user_profile_url, {
+            'current_password': self.kUserPassword,
+            'new_password': new_password
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('password updat successfully', response.data['message'])
+
         self.user.refresh_from_db()
-
         self.assertTrue(self.user.check_password(new_password))
-        messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(len(messages), 1)
-        self.assertIn('Your password was successfully updated!', str(messages[0]))
+
+    def test_update_password_fail_incorrect_current(self):
+        response = self.client.post(self.edit_user_profile_url, {
+            'current_password': 'incorrectPassword',
+            'new_password': 'newPassword123'
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Current password is incorrect', response.data['error'])
+
+    def test_update_password_fail_same_as_current(self):
+        response = self.client.post(self.edit_user_profile_url, {
+            'current_password': self.kUserPassword,
+            'new_password': self.kUserPassword
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('new password same as current', response.data['error'])
+
+    def test_update_password_fail_invalid_password(self):
+        response = self.client.post(self.edit_user_profile_url, {
+            'current_password': self.kUserPassword,
+            'new_password': '012345'
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.json())
 
 
-class UserProfileEditFailureTests(TestCase):
-    kLoginName = "accounts:login"
-    kLoginURL = "/accounts/login/"
+    # other
+    def test_no_data_provided(self):
+        response = self.client.post(self.edit_user_profile_url, {})
 
-    kEditName = "accounts:edit"
-    kEditURL = "/accounts/edit/"
-    kHomeURL = "/pong/"
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Update profile error', response.data['error'])
 
-    kUserEmail = 'test@example.com'
-    kUserNickname = 'test'
-    kUserPassword = 'pass012345'
+    def test_un_login_user(self):
+        logout_api_url = reverse(self.kLogoutAPIName)
+        self.client.get(logout_api_url)
 
-
-    def setUp(self):
-        self.user = get_user_model().objects.create_user(email=self.kUserEmail,
-                                                         nickname=self.kUserNickname,
-                                                         password=self.kUserPassword)
-        self.user.save()
-        url = reverse(self.kLoginName)
-        user_field = {
-            'username'  : self.kUserEmail,
-            'password'  : self.kUserPassword,
-        }
-        self.response = self.client.post(url, user_field)
-
-        url = reverse(self.kEditName)
-        self.response = self.client.get(url)
-        self.edit_url = reverse(self.kEditName)
-
-
-    def test_nickname_not_changed(self):
-        param = {
-            'nickname': self.kUserNickname
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
-        self.user.refresh_from_db()
-
-        self.assertEqual(self.user.nickname, self.kUserNickname)
-        messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(len(messages), 1)
-        msg = f"Your nickname has not changed"
-        self.assertIn(msg, str(messages[0]))
-
-
-    def test_invalid_new_nickname(self):
-        new_nickname = "*"
-        param = {
-            'nickname': new_nickname
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
-        self.user.refresh_from_db()
-        self.assertEqual(self.user.nickname, self.kUserNickname)
-
-
-    def test_wrong_old_password(self):
-        wrong_password = "a"
-        new_password = "new9876abcd"
-        param = {
-            'old_password'  : wrong_password,
-            'new_password1' : new_password,
-            'new_password2' : new_password,
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
-        self.user.refresh_from_db()
-        self.assertTrue(self.user.check_password(self.kUserPassword))
-
-
-    def test_invalid_new_password(self):
-        new_password = "new"
-        param = {
-            'old_password'  : self.kUserPassword,
-            'new_password1' : new_password,
-            'new_password2' : new_password,
-        }
-        response = self.client.post(self.edit_url, param, follow=True)
-        self.user.refresh_from_db()
-        self.assertTrue(self.user.check_password(self.kUserPassword))
+        response = self.client.post(self.edit_user_profile_url, {'nickname': 'newNickname'})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -8,7 +8,8 @@ from accounts.views.basic_auth import LoginTemplateView, LoginAPIView
 from accounts.views.user import UserProfileView, UserProfileAPIView
 from accounts.views.user import EditUserProfileTemplateView, EditUserProfileAPIView
 from accounts.views.oauth import OAuthWith42
-from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView
+from accounts.views.two_factor_auth import Disable2FaView
+from accounts.views.two_factor_auth import Enable2FaTemplateView, Enable2FaAPIView
 from accounts.views.two_factor_auth import Verify2FaTepmlateView, Verify2FaAPIView
 
 app_name = 'accounts'
@@ -26,7 +27,7 @@ urlpatterns = [
     path('edit/', EditUserProfileTemplateView.as_view(), name='edit'),
 
     path('verify/disable_2fa/', Disable2FaView.as_view(), name='disable_2fa'),
-    path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
+    path('verify/enable_2fa/', Enable2FaTemplateView.as_view(), name='enable_2fa'),
     path('verify/verify_2fa/', Verify2FaTepmlateView.as_view(), name='verify_2fa'),
 
     path('api/signup/', SignupAPIView.as_view(), name='api_signup'),
@@ -34,5 +35,6 @@ urlpatterns = [
     path('api/logout/', LogoutAPIView.as_view(), name='api_logout'),
     path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),
     path('api/user/edit-profile/', EditUserProfileAPIView.as_view(), name='api_edit_profile'),
+    path('api/enable_2fa/', Enable2FaAPIView.as_view(), name='api_enable_2fa'),
     path('api/verify_2fa/', Verify2FaAPIView.as_view(), name='api_verify_2fa'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -2,7 +2,9 @@
 
 from django.urls import include, path
 
-from accounts.views.basic_auth import SignupView, LoginView, LogoutView
+from accounts.views.basic_auth import SignupView, LogoutView
+from accounts.views.basic_auth import LogoutTemplateView, LogoutAPIView
+from accounts.views.basic_auth import LoginTemplateView, LoginAPIView
 from accounts.views.user import UserProfileView, EditUserProfileView, UserProfileAPIView
 from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView
@@ -12,12 +14,12 @@ app_name = 'accounts'
 
 urlpatterns = [
     path('signup/', SignupView.as_view(), name='signup'),
-    path('login/', LoginView.as_view(), name='login'),
+    path('login/', LoginTemplateView.as_view(), name='login'),
 
     path('oauth-ft/', OAuthWith42.as_view(), name='oauth_ft'),
     path('oauth-ft/callback/', OAuthWith42.as_view(), name='oauth_ft_callback'),
 
-    path('logout/', LogoutView.as_view(), name='logout'),
+    path('logout/', LogoutTemplateView.as_view(), name='logout'),
 
     path('user/', UserProfileView.as_view(), name='user'),
     path('edit/', EditUserProfileView.as_view(), name='edit'),
@@ -26,6 +28,8 @@ urlpatterns = [
     path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
     path('verify/verify_2fa/', Verify2FaTepmlateView.as_view(), name='verify_2fa'),
 
+    path('api/login/', LoginAPIView.as_view(), name='api_login'),
+    path('api/logout/', LogoutAPIView.as_view(), name='api_logout'),
     path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),
     path('api/verify_2fa/', Verify2FaAPIView.as_view(), name='api_verify_2fa'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -5,8 +5,8 @@ from django.urls import include, path
 from accounts.views.basic_auth import SignupView, LoginView, LogoutView
 from accounts.views.user import UserProfileView, EditUserProfileView, UserProfileAPIView
 from accounts.views.oauth import OAuthWith42
-from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView, Verify2FaView
-
+from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView
+from accounts.views.two_factor_auth import Verify2FaTepmlateView, Verify2FaAPIView
 
 app_name = 'accounts'
 
@@ -24,8 +24,8 @@ urlpatterns = [
 
     path('verify/disable_2fa/', Disable2FaView.as_view(), name='disable_2fa'),
     path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
-    path('verify/verify_2fa/', Verify2FaView.as_view(), name='verify_2fa'),
+    path('verify/verify_2fa/', Verify2FaTepmlateView.as_view(), name='verify_2fa'),
 
-    path('api/user/profile/', UserProfileAPIView.as_view(), name='user_profile_api'),
     path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),
+    path('api/verify_2fa/', Verify2FaAPIView.as_view(), name='api_verify_2fa'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -3,7 +3,7 @@
 from django.urls import include, path
 
 from accounts.views.basic_auth import SignupView, LoginView, LogoutView
-from accounts.views.user import UserPageView, EditUserProfileView
+from accounts.views.user import UserProfileView, EditUserProfileView, UserProfileAPIView
 from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView, Verify2FaView
 
@@ -19,10 +19,13 @@ urlpatterns = [
 
     path('logout/', LogoutView.as_view(), name='logout'),
 
-    path('user/', UserPageView.as_view(), name='user'),
+    path('user/', UserProfileView.as_view(), name='user'),
     path('edit/', EditUserProfileView.as_view(), name='edit'),
 
     path('verify/disable_2fa/', Disable2FaView.as_view(), name='disable_2fa'),
     path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
     path('verify/verify_2fa/', Verify2FaView.as_view(), name='verify_2fa'),
+
+    path('api/user/profile/', UserProfileAPIView.as_view(), name='user_profile_api'),
+    path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -11,6 +11,7 @@ from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Disable2FaView
 from accounts.views.two_factor_auth import Enable2FaTemplateView, Enable2FaAPIView
 from accounts.views.two_factor_auth import Verify2FaTepmlateView, Verify2FaAPIView
+from accounts.views.jwt import JWTRefreshView
 
 app_name = 'accounts'
 
@@ -37,4 +38,6 @@ urlpatterns = [
     path('api/user/edit-profile/', EditUserProfileAPIView.as_view(), name='api_edit_profile'),
     path('api/enable_2fa/', Enable2FaAPIView.as_view(), name='api_enable_2fa'),
     path('api/verify_2fa/', Verify2FaAPIView.as_view(), name='api_verify_2fa'),
+
+    path('api/token/refresh/', JWTRefreshView.as_view(), name='api_token_refresh'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -5,7 +5,8 @@ from django.urls import include, path
 from accounts.views.basic_auth import SignupView, LogoutView
 from accounts.views.basic_auth import LogoutTemplateView, LogoutAPIView
 from accounts.views.basic_auth import LoginTemplateView, LoginAPIView
-from accounts.views.user import UserProfileView, EditUserProfileView, UserProfileAPIView
+from accounts.views.user import UserProfileView, UserProfileAPIView
+from accounts.views.user import EditUserProfileTemplateView, EditUserProfileAPIView
 from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Disable2FaView, Enable2FaView
 from accounts.views.two_factor_auth import Verify2FaTepmlateView, Verify2FaAPIView
@@ -22,7 +23,7 @@ urlpatterns = [
     path('logout/', LogoutTemplateView.as_view(), name='logout'),
 
     path('user/', UserProfileView.as_view(), name='user'),
-    path('edit/', EditUserProfileView.as_view(), name='edit'),
+    path('edit/', EditUserProfileTemplateView.as_view(), name='edit'),
 
     path('verify/disable_2fa/', Disable2FaView.as_view(), name='disable_2fa'),
     path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
@@ -31,5 +32,6 @@ urlpatterns = [
     path('api/login/', LoginAPIView.as_view(), name='api_login'),
     path('api/logout/', LogoutAPIView.as_view(), name='api_logout'),
     path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),
+    path('api/user/edit-profile/', EditUserProfileAPIView.as_view(), name='api_edit_profile'),
     path('api/verify_2fa/', Verify2FaAPIView.as_view(), name='api_verify_2fa'),
 ]

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import include, path
 
-from accounts.views.basic_auth import SignupView, LogoutView
+from accounts.views.basic_auth import SignupTemplateView, SignupAPIView
 from accounts.views.basic_auth import LogoutTemplateView, LogoutAPIView
 from accounts.views.basic_auth import LoginTemplateView, LoginAPIView
 from accounts.views.user import UserProfileView, UserProfileAPIView
@@ -14,7 +14,7 @@ from accounts.views.two_factor_auth import Verify2FaTepmlateView, Verify2FaAPIVi
 app_name = 'accounts'
 
 urlpatterns = [
-    path('signup/', SignupView.as_view(), name='signup'),
+    path('signup/', SignupTemplateView.as_view(), name='signup'),
     path('login/', LoginTemplateView.as_view(), name='login'),
 
     path('oauth-ft/', OAuthWith42.as_view(), name='oauth_ft'),
@@ -29,6 +29,7 @@ urlpatterns = [
     path('verify/enable_2fa/', Enable2FaView.as_view(), name='enable_2fa'),
     path('verify/verify_2fa/', Verify2FaTepmlateView.as_view(), name='verify_2fa'),
 
+    path('api/signup/', SignupAPIView.as_view(), name='api_signup'),
     path('api/login/', LoginAPIView.as_view(), name='api_login'),
     path('api/logout/', LogoutAPIView.as_view(), name='api_logout'),
     path('api/user/profile/', UserProfileAPIView.as_view(), name='api_user_profile'),

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -6,6 +6,7 @@ from django.shortcuts import render, redirect
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from accounts.forms import SignupForm, LoginForm
+from accounts.views.jwt import response_with_jwt
 
 
 class SignupView(View):
@@ -63,7 +64,7 @@ class LoginView(View):
                     return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
                 else:
                     login(request, user)  # 2FAが無効ならば、通常通りログイン
-                    return redirect(to=self.authenticated_redirect_to)
+                    return response_with_jwt(user, self.authenticated_redirect_to)
 
         param = {
             'form': form

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -106,7 +106,7 @@ class LoginAPIView(APIView):
     permission_classes = [AllowAny]
 
     # @csrf_exempt
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs) -> JsonResponse:
         if request.user.is_authenticated:
             data = {
                 'message': 'already logged in',
@@ -117,7 +117,6 @@ class LoginAPIView(APIView):
         email = request.data.get('email')
         password = request.data.get('password')
 
-        # Djangoの認証システムを使用してユーザーを認証します。
         user = authenticate(request, email=email, password=password)
         if user is None:
             data = {'error': 'Invalid credentials'}
@@ -137,43 +136,6 @@ class LoginAPIView(APIView):
                 'redirect': '/accounts/user/'
             }
             return get_jwt_response(user, data)
-
-
-# todo: rm, unused
-class LoginView(View):
-    login_url = "accounts/login.html"
-    authenticated_redirect_to = "/pong/"
-
-    def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            return redirect(to=self.authenticated_redirect_to)
-
-        form = LoginForm()
-        param = {
-            'form': form
-        }
-        return render(request, self.login_url, param)
-
-
-    def post(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            return redirect(to=self.authenticated_redirect_to)
-
-        form = LoginForm(request, data=request.POST)
-        if form.is_valid():
-            user = form.get_user()
-            if user:
-                if user.enable_2fa:
-                    request.session['tmp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
-                    return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
-                else:
-                    login(request, user)  # 2FAが無効ならば、通常通りログイン
-                    return response_with_jwt(user, self.authenticated_redirect_to)
-
-        param = {
-            'form': form
-        }
-        return render(request, self.login_url, param)
 
 
 class LogoutTemplateView(TemplateView):

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -8,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, redirect
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.views import APIView
 
 from accounts.forms import SignupForm, LoginForm
@@ -53,6 +54,7 @@ class LoginAPIView(APIView):
     """
     returns JsonResponse(redirect or error)
     """
+    authentication_classes = [JWTAuthentication]
     permission_classes = [AllowAny]
 
     # @csrf_exempt

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -13,7 +13,7 @@ from rest_framework.views import APIView
 
 from accounts.forms import SignupForm, LoginForm
 from accounts.models import CustomUser, UserManager
-from accounts.views.jwt import response_with_jwt, get_jwt_response
+from accounts.views.jwt import get_jwt_response
 
 
 class SignupTemplateView(View):

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -1,13 +1,17 @@
 # accounts/views/basic_auth.py
 
-from django.contrib.auth import login, logout
+from django.contrib.auth import authenticate, login, logout
+from django.http import HttpResponse, JsonResponse
 from django.views import View
+from django.views.generic import TemplateView
+from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, redirect
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.views import APIView
 
 from accounts.forms import SignupForm, LoginForm
-from accounts.views.jwt import response_with_jwt
-
+from accounts.views.jwt import response_with_jwt, get_jwt_response
 
 class SignupView(View):
     signup_url = "accounts/signup.html"
@@ -36,6 +40,56 @@ class SignupView(View):
         return render(request, self.signup_url, param)
 
 
+class LoginTemplateView(TemplateView):
+    template_name = "accounts/login.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            return redirect('/pong/')
+        return super().dispatch(request, *args, **kwargs)
+
+
+class LoginAPIView(APIView):
+    """
+    returns JsonResponse(redirect or error)
+    """
+    permission_classes = [AllowAny]
+
+    # @csrf_exempt
+    def post(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            data = {
+                'message': 'already logged in',
+                'redirect': '/pong/'
+            }
+            return JsonResponse(data, status=200)
+
+        email = request.data.get('email')
+        password = request.data.get('password')
+
+        # Djangoの認証システムを使用してユーザーを認証します。
+        user = authenticate(request, email=email, password=password)
+        if user is None:
+            data = {'error': 'Invalid credentials'}
+            return JsonResponse(data, status=401)
+
+        if user.enable_2fa:
+            request.session['tmp_auth_user_id'] = user.id
+            data = {
+                'message': '2fa authentication needed',
+                'redirect': '/accounts/verify/verify_2fa/'
+            }
+            return JsonResponse(data, status=200)
+        else:
+            # login(request, user)
+            data = {
+                'message': 'Basic authentication successful',
+                'redirect': '/accounts/user/'
+            }
+            return get_jwt_response(user, data)
+
+
+# todo: rm, unused
 class LoginView(View):
     login_url = "accounts/login.html"
     authenticated_redirect_to = "/pong/"
@@ -60,7 +114,7 @@ class LoginView(View):
             user = form.get_user()
             if user:
                 if user.enable_2fa:
-                    request.session['temp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
+                    request.session['tmp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
                     return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
                 else:
                     login(request, user)  # 2FAが無効ならば、通常通りログイン
@@ -72,9 +126,38 @@ class LoginView(View):
         return render(request, self.login_url, param)
 
 
+class LogoutTemplateView(TemplateView):
+    template_name = "accounts/logout.html"
+
+
+class LogoutAPIView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        data = {
+            'message': 'You have been successfully logout',
+            'redirect': '/pong/'
+        }
+        response = JsonResponse(data, status=200)
+
+        self._del_jwt(response)
+        return response
+
+    def _del_jwt(self, response):
+        response.delete_cookie('Access-Token')
+        response.delete_cookie('Refresh-Token')
+
+
+
+# todo: rm
 class LogoutView(View):
     logout_url = "accounts/logout.html"
 
     def get(self, request, *args, **kwargs):
-        logout(request)
-        return render(request, self.logout_url)
+        # logout(request)
+        response = render(request, self.logout_url)
+
+        response.delete_cookie('Access-Token')
+        response.delete_cookie('Refresh-Token')
+        return response

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -158,17 +158,3 @@ class LogoutAPIView(APIView):
     def _del_jwt(self, response):
         response.delete_cookie('Access-Token')
         response.delete_cookie('Refresh-Token')
-
-
-
-# todo: rm
-class LogoutView(View):
-    logout_url = "accounts/logout.html"
-
-    def get(self, request, *args, **kwargs):
-        # logout(request)
-        response = render(request, self.logout_url)
-
-        response.delete_cookie('Access-Token')
-        response.delete_cookie('Refresh-Token')
-        return response

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -133,8 +133,8 @@ class LogoutTemplateView(TemplateView):
 
 
 class LogoutAPIView(APIView):
-    authentication_classes = [JWTAuthentication]
-    permission_classes = [IsAuthenticated]
+    # authentication_classes = [JWTAuthentication]
+    # permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
         data = {

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -27,7 +27,6 @@ class SignupTemplateView(View):
 
 
 class SignupAPIView(APIView):
-    authentication_classes = [JWTAuthentication]
     permission_classes = [AllowAny]
     authenticated_redirect_to = "/pong/"
 
@@ -104,7 +103,6 @@ class LoginAPIView(APIView):
     """
     returns JsonResponse(redirect or error)
     """
-    authentication_classes = [JWTAuthentication]
     permission_classes = [AllowAny]
 
     # @csrf_exempt
@@ -183,8 +181,7 @@ class LogoutTemplateView(TemplateView):
 
 
 class LogoutAPIView(APIView):
-    # authentication_classes = [JWTAuthentication]
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
         data = {

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -32,14 +32,17 @@ class SignupAPIView(APIView):
 
     def post(self, request, *args, **kwargs):
         if request.user.is_authenticated:
-            return redirect(to=self.authenticated_redirect_to)
+            data = {
+                'message': "Already logged in",
+                'redirect': self.authenticated_redirect_to
+            }
+            return JsonResponse(data, status=200)
 
         email = request.data.get('email')
         nickname = request.data.get('nickname')
         password1 = request.data.get('password1')
         password2 = request.data.get('password2')
 
-        print(f"signup email: {email}, nickname: {nickname}, password1: {password1}, password2: {password2}")
         if password1 != password2:
             data = {'error': "passwords don't match"}
             return JsonResponse(data, status=400)
@@ -50,7 +53,9 @@ class SignupAPIView(APIView):
             return JsonResponse(data, status=400)
 
         try:
-            user = CustomUser.objects.create_user(email=email, password=password1, nickname=nickname)
+            user = CustomUser.objects.create_user(email=email,
+                                                  password=password1,
+                                                  nickname=nickname)
             # login(request, user)  # JWT: unuse login()
             data = {
                 'message': "Signup successful",
@@ -60,34 +65,6 @@ class SignupAPIView(APIView):
         except Exception as e:
             data = {'error': str(e)}
             return JsonResponse(data, status=500)
-
-
-# todo: rm
-class SignupView(View):
-    signup_url = "accounts/signup.html"
-    authenticated_redirect_to = "/pong/"
-
-    def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            return redirect(to=self.authenticated_redirect_to)
-
-        form = SignupForm()
-        param = {'form': form}
-        return render(request, self.signup_url, param)
-
-
-    def post(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            return redirect(to=self.authenticated_redirect_to)
-
-        form = SignupForm(request.POST)
-        if form.is_valid():
-            user = form.save()
-            login(request, user)
-            return redirect(to=self.authenticated_redirect_to)
-
-        param = {'form': form}
-        return render(request, self.signup_url, param)
 
 
 class LoginTemplateView(TemplateView):

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -130,8 +130,12 @@ class LogoutAPIView(APIView):
         response = JsonResponse(data, status=200)
 
         self._del_jwt(response)
+        self._del_sesisons(request)
         return response
 
     def _del_jwt(self, response):
         response.delete_cookie('Access-Token')
         response.delete_cookie('Refresh-Token')
+
+    def _del_sesisons(self, request):
+        request.session.flush()

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -25,7 +25,7 @@ def response_with_jwt(user, redirect_to: str) -> HttpResponse:
         max_age=3600,   # トークンの有効期限（秒）
         httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
         secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     response.set_cookie(
         'Refresh-Token',
@@ -33,7 +33,7 @@ def response_with_jwt(user, redirect_to: str) -> HttpResponse:
         max_age=3600,   # トークンの有効期限（秒）
         httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
         secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     return response
 
@@ -48,7 +48,7 @@ def get_jwt_response(user, data) -> JsonResponse:
         max_age=3600,   # トークンの有効期限（秒）
         httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
         secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     response.set_cookie(
         'Refresh-Token',
@@ -56,7 +56,7 @@ def get_jwt_response(user, data) -> JsonResponse:
         max_age=3600,   # トークンの有効期限（秒）
         httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
         secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     return response
 

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -2,6 +2,8 @@ from django.shortcuts import redirect
 from django.http import HttpResponse, JsonResponse
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.views import APIView
 
@@ -59,6 +61,16 @@ def get_jwt_response(user, data) -> JsonResponse:
         samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     return response
+
+
+def is_valid_jwt(request) -> bool:
+    try:
+        # JWTトークンを検証
+        user_auth = JWTAuthentication().authenticate(request)
+        return user_auth is not None
+    except InvalidToken:
+        # トークンが無効または期限切れ
+        return false
 
 
 class JWTAuthenticationView(APIView):

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -1,0 +1,34 @@
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.shortcuts import redirect
+from django.http import HttpResponse, JsonResponse
+
+
+def get_jwt_for_user(user):
+    refresh = RefreshToken.for_user(user)
+    return {
+        'refresh': str(refresh),
+        'access': str(refresh.access_token),
+    }
+
+
+def response_with_jwt(user, redirect_to: str) -> HttpResponse:
+    jwt = get_jwt_for_user(user)
+    response = redirect(to=redirect_to)
+
+    # CookieにJWTトークンをセット
+    response.set_cookie(
+        'Access-Token',
+        jwt['access'],
+        max_age=3600,   # トークンの有効期限（秒）
+        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
+        secure=True,    # HTTPSを通じてのみCookieを送信
+        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+    )
+    response.set_cookie(
+        'Refresh-Token',
+        jwt['refresh'],
+        httponly=True,
+        secure=True,
+        samesite='Lax',
+    )
+    return response

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -27,10 +27,18 @@ def response_with_jwt(user, redirect_to: str) -> HttpResponse:
         secure=True,    # HTTPSを通じてのみCookieを送信
         samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
+    response.set_cookie(
+        'Refresh-Token',
+        jwt['refresh'],
+        max_age=3600,   # トークンの有効期限（秒）
+        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
+        secure=True,    # HTTPSを通じてのみCookieを送信
+        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+    )
     return response
 
 
-def get_jwt_response(user, data):
+def get_jwt_response(user, data) -> JsonResponse:
     jwt = get_jwt_for_user(user)
     response = JsonResponse(data, status=200)
 

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -1,65 +1,58 @@
 from django.shortcuts import redirect
 from django.http import HttpResponse, JsonResponse
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from rest_framework_simplejwt.exceptions import InvalidToken
+from rest_framework_simplejwt.exceptions import TokenError, InvalidToken
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework.views import APIView
-
 
 def get_jwt_for_user(user):
     refresh = RefreshToken.for_user(user)
-    return {
+    data = {
         'refresh': str(refresh),
         'access': str(refresh.access_token),
     }
+    return data
 
 
-def response_with_jwt(user, redirect_to: str) -> HttpResponse:
-    jwt = get_jwt_for_user(user)
-    response = redirect(to=redirect_to)
-
-    # CookieにJWTトークンをセット
+def set_to_cookie(jwt,
+                  response,
+                  max_age_sec: int = 3600,
+                  http_only: bool = True,
+                  secure: bool = True,
+                  samesite: str = "Strict"):
     response.set_cookie(
         'Access-Token',
         jwt['access'],
-        max_age=3600,   # トークンの有効期限（秒）
-        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
-        secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        max_age=max_age_sec,# トークンの有効期限（秒）
+        httponly=http_only, # JavaScriptからのアクセスを防ぐ -> XSS対策
+        secure=secure,      # HTTPSを通じてのみCookieを送信
+        samesite=samesite,  # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
-    response.set_cookie(
-        'Refresh-Token',
-        jwt['refresh'],
-        max_age=3600,   # トークンの有効期限（秒）
-        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
-        secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
-    )
-    return response
+
+    if jwt.get('refresh'):
+        response.set_cookie(
+            'Refresh-Token',
+            jwt['refresh'],
+            max_age=max_age_sec,# トークンの有効期限（秒）
+            httponly=http_only, # JavaScriptからのアクセスを防ぐ -> XSS対策
+            secure=secure,      # HTTPSを通じてのみCookieを送信
+            samesite=samesite,  # Cookieは現在のウェブサイトからのリクエストでのみ送信
+        )
+
+
+def set_jwt_to_cookie(user, response):
+    jwt = get_jwt_for_user(user)
+    set_to_cookie(jwt, response)
 
 
 def get_jwt_response(user, data) -> JsonResponse:
-    jwt = get_jwt_for_user(user)
     response = JsonResponse(data, status=200)
-
-    response.set_cookie(
-        'Access-Token',
-        jwt['access'],
-        max_age=3600,   # トークンの有効期限（秒）
-        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
-        secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
-    )
-    response.set_cookie(
-        'Refresh-Token',
-        jwt['refresh'],
-        max_age=3600,   # トークンの有効期限（秒）
-        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
-        secure=True,    # HTTPSを通じてのみCookieを送信
-        samesite='None', # Cookieは現在のウェブサイトからのリクエストでのみ送信
-    )
+    set_jwt_to_cookie(user, response)
     return response
 
 
@@ -79,17 +72,41 @@ class JWTAuthenticationView(APIView):
     """
     permission_classes = [AllowAny]
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs) -> JsonResponse:
         user = authenticate(username=request.data['username'],
                             password=request.data['password'])
         if user is None:
-            data = {
-                'error': 'Invalid credentials'
-            }
-            return Response(data, status=400)
+            data = {'error': 'Invalid credentials'}
+            return JsonResponse(data, status=401)
 
-        refresh = RefreshToken.for_user(user)
-        return Response({
-            'refresh': str(refresh),
-            'access': str(refresh.access_token),
-        })
+        data = {'message': 'Authentication successful'}
+        return get_jwt_response(user, data, status=200)
+
+
+class JWTRefreshView(TokenRefreshView):
+    """
+    Receive a refresh token in the POST request
+    return the new access token and the refresh token
+    """
+    permission_classes = [AllowAny]
+
+    def post(self, request, *args, **kwargs) -> JsonResponse:
+        serializer = TokenRefreshSerializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+        except Exception as e:
+            data = {'error': str(e)}
+            return JsonResponse(data, status=401)
+
+        new_access_token = data['access']
+        new_refresh_token = data.get('refresh', None)
+
+        refresh_jwt = {
+            'access': str(new_access_token),
+            'refresh': str(new_refresh_token) if new_refresh_token else None,
+        }
+        data = {'message': 'Token refreshed successfully'}
+        response = JsonResponse(data, status=200)
+        set_to_cookie(refresh_jwt, response)
+        return response

--- a/docker/srcs/uwsgi-django/accounts/views/jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/views/jwt.py
@@ -1,6 +1,9 @@
-from rest_framework_simplejwt.tokens import RefreshToken
 from django.shortcuts import redirect
 from django.http import HttpResponse, JsonResponse
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.views import APIView
 
 
 def get_jwt_for_user(user):
@@ -24,11 +27,49 @@ def response_with_jwt(user, redirect_to: str) -> HttpResponse:
         secure=True,    # HTTPSを通じてのみCookieを送信
         samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
+    return response
+
+
+def get_jwt_response(user, data):
+    jwt = get_jwt_for_user(user)
+    response = JsonResponse(data, status=200)
+
+    response.set_cookie(
+        'Access-Token',
+        jwt['access'],
+        max_age=3600,   # トークンの有効期限（秒）
+        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
+        secure=True,    # HTTPSを通じてのみCookieを送信
+        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
+    )
     response.set_cookie(
         'Refresh-Token',
         jwt['refresh'],
-        httponly=True,
-        secure=True,
-        samesite='Lax',
+        max_age=3600,   # トークンの有効期限（秒）
+        httponly=True,  # JavaScriptからのアクセスを防ぐ -> XSS対策
+        secure=True,    # HTTPSを通じてのみCookieを送信
+        samesite='Lax', # Cookieは現在のウェブサイトからのリクエストでのみ送信
     )
     return response
+
+
+class JWTAuthenticationView(APIView):
+    """
+    user authentication
+    """
+    permission_classes = [AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        user = authenticate(username=request.data['username'],
+                            password=request.data['password'])
+        if user is None:
+            data = {
+                'error': 'Invalid credentials'
+            }
+            return Response(data, status=400)
+
+        refresh = RefreshToken.for_user(user)
+        return Response({
+            'refresh': str(refresh),
+            'access': str(refresh.access_token),
+        })

--- a/docker/srcs/uwsgi-django/accounts/views/oauth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/oauth.py
@@ -76,7 +76,7 @@ class OAuthWith42(View):
             user.save()
 
         if user.enable_2fa:
-            request.session['temp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
+            request.session['tmp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
             return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
 
         login(request, user, backend='django.contrib.auth.backends.ModelBackend')

--- a/docker/srcs/uwsgi-django/accounts/views/oauth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/oauth.py
@@ -79,7 +79,7 @@ class OAuthWith42(View):
             request.session['tmp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
             return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
 
-        login(request, user, backend='django.contrib.auth.backends.ModelBackend')
+        # login(request, user, backend='django.contrib.auth.backends.ModelBackend')  # jwt: login() unused
         return response_with_jwt(user, self.authenticated_redirect_to)
 
 

--- a/docker/srcs/uwsgi-django/accounts/views/oauth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/oauth.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views import View
-from accounts.views.jwt import response_with_jwt
+from accounts.views.jwt import set_jwt_to_cookie
 
 
 logging.basicConfig(
@@ -76,11 +76,13 @@ class OAuthWith42(View):
             user.save()
 
         if user.enable_2fa:
-            request.session['tmp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
-            return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
+            request.session['tmp_auth_user_id'] = user.id
+            return redirect(to='accounts:verify_2fa')
 
         # login(request, user, backend='django.contrib.auth.backends.ModelBackend')  # jwt: login() unused
-        return response_with_jwt(user, self.authenticated_redirect_to)
+        response = redirect(to=self.authenticated_redirect_to)
+        set_jwt_to_cookie(user, response)
+        return response
 
 
     def _is_valid_state(self, request: HttpRequest) -> bool:

--- a/docker/srcs/uwsgi-django/accounts/views/oauth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/oauth.py
@@ -14,6 +14,7 @@ from django.http import HttpRequest
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views import View
+from accounts.views.jwt import response_with_jwt
 
 
 logging.basicConfig(
@@ -78,9 +79,8 @@ class OAuthWith42(View):
             request.session['temp_auth_user_id'] = user.id  # 一時的な認証情報をセッションに保存
             return redirect(to='accounts:verify_2fa')  # OTP検証ページへリダイレクト
 
-        # login(request, user)  # 2FAが無効ならば、通常通りログイン
         login(request, user, backend='django.contrib.auth.backends.ModelBackend')
-        return redirect(to=self.authenticated_redirect_to)
+        return response_with_jwt(user, self.authenticated_redirect_to)
 
 
     def _is_valid_state(self, request: HttpRequest) -> bool:

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -196,7 +196,7 @@ class Verify2FaAPIView(APIView):
         user, devices = self._get_user_and_devices(request)
         if user is None:
             data = {
-                'error': 'No valid session found.',
+                'error': 'No valid session found',
                 'redirect': '/accounts/login/',
             }
             return Response(data, status=401)
@@ -219,58 +219,6 @@ class Verify2FaAPIView(APIView):
     def _get_user_and_devices(self, request):
         tmp_user_id = request.session.get('tmp_auth_user_id')
 
-        if tmp_user_id is None:
-            user = None
-            devices = []
-        else:
-            User = get_user_model()
-            try:
-                user = User.objects.get(id=tmp_user_id)
-                devices = list(devices_for_user(user, confirmed=True))
-            except User.DoesNotExist:
-                user = None
-                devices = []
-        return user, devices
-
-
-# todo: JWT認証への切り替えで不要に。testなどの呼び出しを変更後、削除予定
-class Verify2FaView(View):
-    template_name = 'verify/verify_2fa.html'
-    login_page_path = 'accounts:login'
-    authenticated_redirect_to = "/pong/"
-
-    def get(self, request, *args, **kwargs):
-        form = Verify2FAForm()
-        user, _ = self._get_user_and_devices(request)
-
-        if user is None or user.enable_2fa is False:
-            return redirect(to=self.login_page_path)
-
-        param = {
-            'form': form,
-        }
-        return render(request, self.template_name, param)
-
-    def post(self, request, *args, **kwargs):
-        user, devices = self._get_user_and_devices(request)
-        if user is None or user.enable_2fa is False:
-            return redirect(to=self.login_page_path)
-
-        form = Verify2FAForm(request.POST, devices=devices)
-        if form.is_valid():
-            login(request, user)
-            del request.session['tmp_auth_user_id']
-            return response_with_jwt(user, self.authenticated_redirect_to)
-
-        else:
-            form.add_error(None, 'Invalid token')
-            param = {
-                'form': form,
-            }
-            return render(request, self.template_name, param)
-
-    def _get_user_and_devices(self, request):
-        tmp_user_id = request.session.get('tmp_auth_user_id')
         if tmp_user_id is None:
             user = None
             devices = []

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -163,7 +163,6 @@ class Verify2FaTepmlateView(TemplateView):
 
 
 class Verify2FaAPIView(APIView):
-    authentication_classes = [JWTAuthentication]
     permission_classes = [AllowAny]  # Non-Login before verify 2FA
 
     def post(self, request, *args, **kwargs):

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -131,7 +131,7 @@ class Verify2FaView(View):
         form = Verify2FAForm()
         user, _ = self._get_user_and_devices(request)
 
-        if user.enable_2fa is False:
+        if user is None or user.enable_2fa is False:
             return redirect(to=self.login_page_path)
 
         param = {
@@ -143,7 +143,7 @@ class Verify2FaView(View):
         form = Verify2FAForm(request.POST)
         user, devices = self._get_user_and_devices(request)
 
-        if user.enable_2fa is False:
+        if user is None or user.enable_2fa is False:
             return redirect(to=self.login_page_path)
 
         if form.is_valid():

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -130,14 +130,16 @@ class Enable2FaView(LoginRequiredMixin, View):
         user.save()
 
 
-class Disable2FaView(LoginRequiredMixin, View):
+class Disable2FaView(APIView):
+    permission_classes = [IsAuthenticated]
     redirect_to = 'accounts:user'
 
     def get(self, request, *args, **kwargs):
         user = request.user
-        self._delete_totp_devices(user)
-        self._disable_user_2fa(user)
-        return redirect(to=self.redirect_to)
+        if user.enable_2fa:
+            self._delete_totp_devices(user)
+            self._disable_user_2fa(user)
+        return redirect(self.redirect_to)
 
     def _delete_totp_devices(self, user):
         devices = TOTPDevice.objects.filter(user=user, confirmed=True)

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -28,7 +28,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from accounts.forms import Enable2FAForm, Verify2FAForm
 from accounts.models import CustomUser, UserManager
-from accounts.views.jwt import response_with_jwt, get_jwt_response
+from accounts.views.jwt import get_jwt_response
 
 
 class Enable2FaTemplateView(TemplateView):

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -20,6 +20,7 @@ from django.views import View
 
 from accounts.forms import Enable2FAForm, Verify2FAForm
 from accounts.models import CustomUser, UserManager
+from accounts.views.jwt import response_with_jwt
 
 
 class Enable2FaView(LoginRequiredMixin, View):
@@ -167,7 +168,8 @@ class Verify2FaView(View):
         if form.is_valid():
             login(request, user)
             del request.session['temp_auth_user_id']
-            return redirect(to=self.authenticated_redirect_to)
+            return response_with_jwt(user, self.authenticated_redirect_to)
+
         else:
             form.add_error(None, 'Invalid token')
             param = {

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -23,7 +23,7 @@ from accounts.forms import UserEditForm, CustomPasswordChangeForm
 logger = logging.getLogger(__name__)
 
 
-class UserProfileView(LoginRequiredMixin, TemplateView):
+class UserProfileView(TemplateView):
     template_name = "accounts/user.html"
 
     def get(self, request, *args, **kwargs):

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -37,7 +37,6 @@ class UserProfileView(TemplateView):
 
 
 class UserProfileAPIView(APIView):
-    authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -71,7 +70,6 @@ class EditUserProfileTemplateView(TemplateView):
 
 
 class EditUserProfileAPIView(APIView):
-    authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request, *args, **kwargs):

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -8,7 +8,7 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import check_password
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpRequest
+from django.http import HttpRequest, JsonResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
 from django.views import View
@@ -39,14 +39,14 @@ class UserProfileView(TemplateView):
 class UserProfileAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request):
+    def get(self, request) -> JsonResponse:
         user = request.user
         params = {
             'email': user.email,
             'nickname': user.nickname,
             'enable_2fa': user.enable_2fa,
         }
-        return Response(params)
+        return JsonResponse(params)
 
 
 class EditUserProfileTemplateView(TemplateView):
@@ -132,70 +132,3 @@ class EditUserProfileAPIView(APIView):
         update_session_auth_hash(request, user)  # password更新によるsessionを継続
         user.save()
         return True, "password updat successfully"
-
-
-
-
-# todo: rm
-class EditUserProfileView(LoginRequiredMixin, View):
-    """
-    render edit user profile page
-    user is not authenticated, redirect to LOGIN_URL written in setting.py
-    """
-    edit_url = "accounts/edit_profile.html"
-    redirect_to = "accounts:edit"
-
-    def get(self, request, *args, **kwargs):
-        user_form = UserEditForm(instance=request.user)
-
-        if self._is_42auth_user(request):
-            password_form = None
-        else:
-            password_form = CustomPasswordChangeForm(user=request.user)
-
-        params = {
-            'user_form': user_form,
-            'password_form': password_form,
-        }
-        return render(request, self.edit_url, params)
-
-
-    def post(self, request, *args, **kwargs):
-        if self._is_42auth_user(request):
-            password_form = None
-            password_form_is_valid = False
-        else:
-            password_form = CustomPasswordChangeForm(user=request.user,
-                                                     data=request.POST)
-            password_form_is_valid = password_form.is_valid()
-
-        old_nickname = request.user.nickname
-        user_form = UserEditForm(request.POST, instance=request.user)
-        if user_form.is_valid() and not password_form_is_valid:
-            user = user_form.save(commit=False)
-            new_nickname = user_form.cleaned_data.get('nickname')
-
-            if old_nickname == new_nickname:
-                messages.warning(request,
-                                 'Your nickname has not changed')
-            else:
-                user.save()
-                messages.success(request,
-                                 f'Your nickname was successfully updated from "{old_nickname}" to "{new_nickname}"')
-                return redirect(reverse_lazy(self.redirect_to))
-
-        elif password_form_is_valid:
-            user = password_form.save()
-            update_session_auth_hash(request, user)
-            messages.success(request, 'Your password was successfully updated!')
-            return redirect(reverse_lazy(self.redirect_to))
-
-        params = {
-            'user_form': user_form,
-            'password_form': password_form,
-        }
-        return render(request, self.edit_url, params)
-
-
-    def _is_42auth_user(self, request: HttpRequest) -> bool:
-        return not request.user.has_usable_password()

--- a/docker/srcs/uwsgi-django/django-entrypoint.sh
+++ b/docker/srcs/uwsgi-django/django-entrypoint.sh
@@ -6,26 +6,19 @@ set -o nounset
 set -o pipefail
 
 
-_wait_db_start_up() {
-  i=30
-  while [ $i -gt 0 ]; do
-      if pg_isready -h postgres -p 5432; then
-          break
-      fi
-      echo "Waiting for PostgreSQL to become available..."
-      sleep 1
-      i=$(( i - 1 ))
-  done
-  if [ $i -eq 0 ]; then
-      echo >&2 'PostgreSQL did not start'
-      exit 1
-  fi
-  echo "PostgreSQL is available. Continuing with database migrations."
+_setting_log_file() {
+  touch /code/django_debug.log && chown www-data:www-data /code/django_debug.log
+  chown www-data:www-data /code/django_debug.log
+  chmod 664 /code/django_debug.log
 }
 
 
 _migrate_db() {
-  python manage.py makemigrations
+# DBスキーマの変更に基づきマイグレーションファイルを生成
+# モデル変更時のみ実行
+#  python manage.py makemigrations
+
+# マイグレーションファイルをDBに適用、DBを最新の状態で再構築
   python manage.py migrate --noinput
 }
 
@@ -39,17 +32,18 @@ _add_user_to_db() {
 }
 
 
-_collect_staic_to_root() {
+_collect_static_to_root() {
   # 全部の"static/"から、ルートのstatic/に集める
   python manage.py collectstatic --noinput
 }
 
 _main() {
-  _wait_db_start_up
+  _setting_log_file
 
   _migrate_db
+
   _add_user_to_db
-  _collect_staic_to_root
+  _collect_static_to_root
 }
 
 

--- a/docker/srcs/uwsgi-django/pong/templates/pong/index.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/index.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,8 +13,8 @@
 
         <h1>welcome, [{{ nickname }}]</h1>
         <ul>
-            <li><a href="{% url 'accounts:user' %}">user information</a></li>
-            <li><a href="{% url 'accounts:logout' %}">logout</a></li>
+            <p><a href="{% url 'accounts:user' %}">user information</a></p>
+            <p><button onclick="handleLogout()">Logout</button></p>
         </ul>
 
     {% else %}
@@ -39,6 +40,9 @@
         <li><a href="/pong/bootstrap_index/">[test] index(bootstrap)</a></li>
         <li><a href="/pong/bootstrap_sign-in/">[test] sign-in(bootstrap)</a></li>
     </ul>
+
+
+    <script src="{% static 'accounts/js/logout.js' %}"></script>
 
 </body>
 </html>

--- a/docker/srcs/uwsgi-django/requirements.txt
+++ b/docker/srcs/uwsgi-django/requirements.txt
@@ -21,9 +21,10 @@ myst-parser
 
 requests
 
-# OAuth
-# django-allauth==0.61.1
 # 2FA
 django-otp==1.3.0
 qrcode==7.4.2
 pyotp==2.9.0
+
+# JWT
+djangorestframework-simplejwt==5.3.1

--- a/docker/srcs/uwsgi-django/requirements.txt
+++ b/docker/srcs/uwsgi-django/requirements.txt
@@ -5,21 +5,22 @@
 Django==5.0.2
 
 # PostgreSQLデータベース用
-psycopg2
+psycopg2==2.9.9
 
 # WSGIサーバー
 uwsgi>=2.0
 
-django-prometheus
-python-logstash
-web3
-python-dotenv
+django-prometheus==2.3.1
+python-logstash==0.4.8
+web3==6.17.0
+python-dotenv==1.0.1
 
-Sphinx
-sphinx-rtd-theme
-myst-parser
+Sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+myst-parser==2.0.0
 
-requests
+requests==2.31.0
+parsimonious==0.10.0
 
 # 2FA
 django-otp==1.3.0

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 import os
+from datetime import timedelta
 from pathlib import Path
 from django.core.exceptions import ImproperlyConfigured
 
@@ -106,6 +107,24 @@ AUTHENTICATION_BACKENDS = [
 # 	'django.contrib.auth.backends.ModelBackend',  # allauth
 # 	'allauth.account.auth_backends.AuthenticationBackend',  # allauth
 ]
+
+
+SIMPLE_JWT = {
+	'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),  # アクセストークンの有効期間
+	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
+	'ROTATE_REFRESH_TOKENS': False,
+	'BLACKLIST_AFTER_ROTATION': True,
+	'UPDATE_LAST_LOGIN': False,
+
+	'ALGORITHM': 'HS256',
+	'SIGNING_KEY': SECRET_KEY,
+	'VERIFYING_KEY': None,
+	'AUDIENCE': None,
+	'ISSUER': None,
+	'JWK_URL': None,
+	'LEEWAY': 0,
+}
+
 
 OTP_TOTP_ISSUER = 'trans_pj'
 

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -46,7 +46,6 @@ ALLOWED_HOSTS = ['*']
 
 
 # Application definition
-
 INSTALLED_APPS = [
 	'django.contrib.admin',
 	'django.contrib.auth',
@@ -59,23 +58,10 @@ INSTALLED_APPS = [
 	'accounts',  # user_accounts
 	'django_otp',  						# 2fa
 	'django_otp.plugins.otp_totp',  	# 2fa
-	'django_otp.plugins.otp_hotp',  	# 2fa
 	'django_otp.plugins.otp_static',  	# 2fa
-	# 'django.contrib.sites',  # allauth
-	# 'allauth',  # allauth
-	# 'allauth.account',  # allauth
-	# 'allauth.socialaccount',  # allauth
-	# 'socialaccount.providers.ft',  # 42auth with allauth
 ]
 
 
-# allauth
-# SOCIALACCOUNT_PROVIDERS = {
-# 	'ft': {
-# 		'CLIENT_ID': get_env_variable('FT_UID'),
-# 		'SECRET': get_env_variable('FT_SECRET'),
-# 	}
-# }
 FT_CLIENT_ID = get_env_variable('FT_UID')
 FT_SECRET = get_env_variable('FT_SECRET')
 
@@ -95,7 +81,6 @@ MIDDLEWARE = [
 	'django_prometheus.middleware.PrometheusAfterMiddleware',
 	# --------------------
 	'django_otp.middleware.OTPMiddleware',  # 2fa
-	# 'allauth.account.middleware.AccountMiddleware',  # allauth
 	'accounts.middleware.JWTAuthenticationMiddleware',  # jwt
 ]
 
@@ -103,9 +88,6 @@ MIDDLEWARE = [
 AUTHENTICATION_BACKENDS = [
 	'accounts.authentication_backend.JWTAuthenticationBackend',
 	'django.contrib.auth.backends.ModelBackend',  # Optional
-	# 'django_otp.backends.OTPAuthenticationBackend',  # 2fa
-# 	'django.contrib.auth.backends.ModelBackend',  # allauth
-# 	'allauth.account.auth_backends.AuthenticationBackend',  # allauth
 ]
 
 
@@ -141,7 +123,6 @@ TEMPLATES = [
 				'django.template.context_processors.request',
 				'django.contrib.auth.context_processors.auth',
 				'django.contrib.messages.context_processors.messages',
-				# 'django.template.context_processors.request',  # allauth
 			],
 		},
 	},
@@ -164,7 +145,6 @@ WSGI_APPLICATION = 'trans_pj.wsgi.application'
 #         'NAME': BASE_DIR / 'db.sqlite3',
 #     }
 # }
-
 
 
 DATABASES = {
@@ -292,24 +272,6 @@ LOGGING = {
 },
 }
 
-
-# # allauth setting --------------------------------------------------------------
-# ## sitesフレームワーク用のサイトID
-# SITE_ID = 1
-#
-# ## ログイン・ログアウト時のリダイレクト先
-# LOGIN_REDIRECT_URL = '/pong/'
-# ACCOUNT_LOGOUT_REDIRECT_URL = '/pong/'
-#
-# ## 認証方式を「メルアドとパスワード」に設定
-# ACCOUNT_AUTHENTICATION_METHOD = 'email'
-# ## ユーザ名は使用しない
-# ACCOUNT_USERNAME_REQUIRED = False
-#
-# ## ユーザ登録時に確認メールを送信するか(none=送信しない, mandatory=送信する)
-# ACCOUNT_EMAIL_VERIFICATION = 'none'
-# ACCOUNT_EMAIL_REQUIRED = True   # ユーザ登録にメルアド必須にする
-# # allauth setting --------------------------------------------------------------
 
 # JWT
 REST_FRAMEWORK = {

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -99,11 +99,13 @@ MIDDLEWARE = [
 ]
 
 
-# AUTHENTICATION_BACKENDS = [
+AUTHENTICATION_BACKENDS = [
+	'accounts.authentication_backend.JWTAuthenticationBackend',
+	'django.contrib.auth.backends.ModelBackend',  # Optional
 	# 'django_otp.backends.OTPAuthenticationBackend',  # 2fa
 # 	'django.contrib.auth.backends.ModelBackend',  # allauth
 # 	'allauth.account.auth_backends.AuthenticationBackend',  # allauth
-# ]
+]
 
 OTP_TOTP_ISSUER = 'trans_pj'
 

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -95,6 +95,7 @@ MIDDLEWARE = [
 	# --------------------
 	'django_otp.middleware.OTPMiddleware',  # 2fa
 	# 'allauth.account.middleware.AccountMiddleware',  # allauth
+	'accounts.middleware.JWTAuthenticationMiddleware',  # jwt
 ]
 
 
@@ -288,6 +289,13 @@ LOGGING = {
 # ACCOUNT_EMAIL_VERIFICATION = 'none'
 # ACCOUNT_EMAIL_REQUIRED = True   # ユーザ登録にメルアド必須にする
 # # allauth setting --------------------------------------------------------------
+
+# JWT
+REST_FRAMEWORK = {
+	'DEFAULT_AUTHENTICATION_CLASSES': [
+		'rest_framework_simplejwt.authentication.JWTAuthentication',
+	],
+}
 
 LOGIN_URL = '/accounts/login/'
 

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -112,7 +112,7 @@ AUTHENTICATION_BACKENDS = [
 SIMPLE_JWT = {
 	'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),  # アクセストークンの有効期間
 	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
-	'ROTATE_REFRESH_TOKENS': False,
+	'ROTATE_REFRESH_TOKENS': True,
 	'BLACKLIST_AFTER_ROTATION': True,
 	'UPDATE_LAST_LOGIN': False,
 


### PR DESCRIPTION
# 概要
* JWTの実装
* `feature/2fa`にmerge予定

## JWT
### 目的
* トークンベースの認証
* email, passwordによる認証後にJWTを発行し、ログイン中のリクエストでJTWを認証手段として使用する


### フロー
* Login page -> Basic認証/OAuth2.0 -> (2FA; OTP) -> **JWT** -> User page

### 実装概要
* Login認証後、CookieにJWTをセットする（ブラウザが管理するらしい？）

### todo
- [x] JWT
  - [x] prototype
  - [x] refactoring
  - [x] viewsの変更（View -> TemplateView and APIViewに切り分け） 
    - [x] accounts/edit_profile
    - [x] accounts/login
    - [x] accounts/logout
    - [x] accounts/signup
    - [x] accounts/user_profile
    - [x] verify/enable 2fa
    - [x] verify/verify 2fa
    - [x] verify/disable 2fa
  - [x] view変更に伴うtest更新(backend用のtestに絞りupdate)
    - [x] 2fa
    - [x] ~custom_user~
    - [x] login
    - [x] logout
    - [x] signup
    - [x] user_profile
  - [x] test for JWT
    - [x] JWT発行
    - [x] JWTを使用する認証（残課題）
    - [x] Token Refresh Endpoint（残課題）
    - [x] Invalid token（残課題）
  - [ ] ほか
    - [ ] 管理ページにadmin login後にpong logoutからlogoutできない
    - [ ] 稀にJWT認証が数分で切れる？再loginのためにcookie削除が必要...なぜ？

<br>

# memo
- 現状はAPIViewがないため使用機会がない？（よくわからない）
  - APIView: JSONまたはXMLフォーマットなど、データを返すAPI
- `IsAuthenticated`でuserのTokenによる認証が可能らしい。現状はtemplate viewを描画するView classしかないため、LoginequiredMixinで認証が検証でき、JWTで認証するタイミングがない
  ```python
  # views.py
  from rest_framework.views import APIView
  from rest_framework.permissions import IsAuthenticated
  from rest_framework.response import Response
  
  class UserProfileAPIView(APIView):
      permission_classes = [IsAuthenticated]
  
      def get(self, request, *args, **kwargs):
          user = request.user
          data = {
              'email': user.email,
              'nickname': user.nickname,
              # 他のユーザーデータ...
          }
          return Response(data)
  ```
- HTMLページをレンダリングするViewは従来型のview -> フロント/バックエンドを切り分けた方が良いのか？
  - Backend APIで情報を取得するページはSSR -> SPAにした方が良さそう
- JWT発行APIを作成し、認証完了後にフロントエンドがAPIを叩く形式が一般的？
- 一通りHTML + JSに書き換えたらBootstrapを使用したSPAにしてみる？
  - だるすぎ...🥺

<br>

# subject
## 6 Cybersecurity
- [x] Major module: Implement Two-Factor Authentication (2FA) and JWT.
  - [x] Implement Two-Factor Authentication (2FA) as an additional layer of security for user accounts, requiring users to provide a secondary verification method, such as a one-time code, in addition to their password.
  - [x] Utilize JSON Web Tokens (JWT) as a secure method for authentication and authorization, ensuring that user sessions and access to resources are managed securely.
  - [x] Provide a user-friendly setup process for enabling 2FA, with options for SMS codes, authenticator apps, or email-based verification.
  - [x] Ensure that JWT tokens are issued and validated securely to prevent unau- thorized access to user accounts and sensitive data.

<br>

# Ref
* [1] [RFC7519](https://tex2e.github.io/rfc-translater/html/rfc7519.html)
* [2] [JWT認証の流れを理解する](https://qiita.com/asagohan2301/items/cef8bcb969fef9064a5c)
* [3] [JWTは使うべきではない　〜 SPAにおける本当にセキュアな認証方式 〜](https://qiita.com/nyandora/items/8174891f52ec0ea15bc1)