### PR TITLE
Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Docker and Docker Compose
+      - name: Display system architecture
+        run: |
+          echo "Operating System: $(uname -o)"
+          echo "Machine Hardware Name: $(uname -m)"
+          echo "Kernel Release: $(uname -r)"
+          echo "Processor Type: $(uname -p)"      
+
+      - name: Install Docker engine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          docker --version
+
+      - name: Set up Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: Docker Compose CI
+on: [push]
+jobs:
+  docker-compose-ci-test:
+    runs-on: ubuntu-22.04
+    environment:
+      name: CREDENTIALS
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker and Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
+      - name: create .env_credentials file
+        run: |
+          cat << EOF >> docker/srcs/.env_src_credentials
+          # ------------------------------------------------------------------------------
+          # CREDENTIALS
+          # ------------------------------------------------------------------------------
+          
+          # Auth0
+          GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${{ secrets.GF_AUTH_GENERIC_OAUTH_CLIENT_ID }}
+          GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${{ secrets.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET }}
+          
+          # grafana alert
+          GRAFANA_CONTACT_POINT_SLACK=${{ secrets.GRAFANA_CONTACT_POINT_SLACK }}
+          GRAFANA_CONTACT_POINT_DISCORD=${{ secrets.GRAFANA_CONTACT_POINT_DISCORD }}
+            
+          # API_KEY
+          INFURA_API_KEY=${{ secrets.INFURA_API_KEY }}
+          SEPOLIA_PRIVATE_KEY=${{ secrets.SEPOLIA_PRIVATE_KEY }}
+          GANACHE_PRIVATE_KEY=${{ secrets.GANACHE_PRIVATE_KEY }}
+          
+          # 42; Valid until 1st/Mar/2024
+          FT_UID=${{ secrets.FT_UID }}
+          FT_SECRET=${{ secrets.FT_SECRET }}
+          
+          # ------------------------------------------------------------------------------
+          EOF
+
+      - name: Build and start containers
+        run: make build_up_default || make logs
+
+      - name: wait for start up django container
+        run: |
+          timeout=300
+          elapsed=0
+          while [ "$(docker inspect --format='{{.State.Health.Status}}' uwsgi-django)" != "healthy" ]; do
+            if [ $elapsed -ge $timeout ]; then
+              echo -e "\e[31m[NG] Timeout waiting for uwsgi-django to finish starting up\e[0m"
+              exit 1
+            fi
+              echo -e "\e[q33mWaiting for uwsgi-django to finish starting up... remain:${$(( $timeout - $elapsed ))}sec\e[0m"
+            sleep 10
+            elapsed=$(($elapsed + 10))
+          done
+          echo -e "\e[32mAll uwsgi-django container is finish starting up\e[0m"
+
+      - name: Run Django Tests
+        run: |
+          docker exec uwsgi-django python manage.py test accounts.tests
+          if [ $? -eq 0 ]; then
+            echo -e "\e[32m[OK] ALL TEST SUCCESS\e[0m"
+          else
+            echo -e "\e[31m[NG] TEST FAILURE\e[0m"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -148,13 +148,13 @@ docker_rm:
 	-@docker volume rm $$(docker volume ls -q) 2>/dev/null
 	-@docker system prune -af --volumes
 
-.PHONY: remove_mount_volume_mac
-remove_mount_volume_mac:
-	rm -rf mount_volume
+.PHONY: remove_mount_volume
+remove_mount_volume:
+	sudo rm -rf mount_volume
 
 .PHONY: rm
 rm:
-	make remove_mount_volume_mac
+	make remove_mount_volume
 
 .PYHONY: ps
 ps:
@@ -177,6 +177,7 @@ logs:
 .PHONY: init
 init: env cert_key
 	@chmod +x init/add_host.sh && ./init/add_host.sh init/.os_env
+	@chmod +x init/make_dir.sh && ./init/make_dir.sh init/.os_env
 
 .PHONY: env
 env:

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,12 @@ reset_logstash:
 # -----------------------------------------------
 .PHONY: docker_rm
 docker_rm:
-	@if [ -n "$$(docker ps -qa)" ]; then docker stop $$(docker ps -qa); fi
-	@if [ -n "$$(docker ps -qa)" ]; then docker rm -f $$(docker ps -qa); fi
-	@if [ -n "$$(docker images -qa)" ]; then docker rmi -f $$(docker images -qa); fi
-	@if [ -n "$$(docker images -f "dangling=true" -q)" ]; then docker rmi -f $$(docker images -f "dangling=true" -q); fi
-	@docker network rm $$(docker network ls -q) 2>/dev/null || true
-	@docker volume prune -f
+	-@docker stop $$(docker ps -qa) 2>/dev/null
+	-@docker rm -f $$(docker ps -qa) 2>/dev/null
+	-@docker rmi -f $$(docker images -qa) 2>/dev/null
+	-@docker network rm $$(docker network ls -q) 2>/dev/null
+	-@docker volume rm $$(docker volume ls -q) 2>/dev/null
+	-@docker system prune -af --volumes
 
 .PHONY: remove_mount_volume_mac
 remove_mount_volume_mac:

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ ps_a:
 logs:
 	docker-compose $(COMPOSE_FILES_ARGS) logs
 
+.PHONY: fclean
+fclean: down docker_rm remove_mount_volume
 
 # -----------------------------------------------
 #  init

--- a/docker/srcs/compose-yaml/compose-exporter.yaml
+++ b/docker/srcs/compose-yaml/compose-exporter.yaml
@@ -26,10 +26,10 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.ignored-mount-points'
-      - '^/(sys|proc|dev|host|etc)($|/)'
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.ignored-mount-points"
+      - "^/(sys|proc|dev|host|etc)($$|/)"
     ports:
       - 9100:9100
     networks:

--- a/docker/srcs/compose-yaml/compose-web.yaml
+++ b/docker/srcs/compose-yaml/compose-web.yaml
@@ -25,7 +25,8 @@ services:
     restart: unless-stopped
     depends_on:
       # - pgadmin
-      - uwsgi-django
+      uwsgi-django:
+        condition: service_healthy
     init: true
 
   frontend:
@@ -68,6 +69,11 @@ services:
         condition: service_healthy
     #      - postgres
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8001 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
     init: true
     volumes:
       - '${VOLUME_PATH:?}/log_django_vol:/src/logs'

--- a/docker/srcs/uwsgi-django/django-entrypoint.sh
+++ b/docker/srcs/uwsgi-django/django-entrypoint.sh
@@ -6,21 +6,10 @@ set -o nounset
 set -o pipefail
 
 
-_wait_db_start_up() {
-  i=30
-  while [ $i -gt 0 ]; do
-      if pg_isready -h postgres -p 5432; then
-          break
-      fi
-      echo "Waiting for PostgreSQL to become available..."
-      sleep 1
-      i=$(( i - 1 ))
-  done
-  if [ $i -eq 0 ]; then
-      echo >&2 'PostgreSQL did not start'
-      exit 1
-  fi
-  echo "PostgreSQL is available. Continuing with database migrations."
+_setting_log_file() {
+  touch /code/django_debug.log && chown www-data:www-data /code/django_debug.log
+  chown www-data:www-data /code/django_debug.log
+  chmod 664 /code/django_debug.log
 }
 
 
@@ -39,17 +28,18 @@ _add_user_to_db() {
 }
 
 
-_collect_staic_to_root() {
+_collect_static_to_root() {
   # 全部の"static/"から、ルートのstatic/に集める
   python manage.py collectstatic --noinput
 }
 
 _main() {
-  _wait_db_start_up
+  _setting_log_file
 
   _migrate_db
+
   _add_user_to_db
-  _collect_staic_to_root
+  _collect_static_to_root
 }
 
 

--- a/docker/srcs/uwsgi-django/django-entrypoint.sh
+++ b/docker/srcs/uwsgi-django/django-entrypoint.sh
@@ -14,7 +14,11 @@ _setting_log_file() {
 
 
 _migrate_db() {
-  python manage.py makemigrations
+# DBスキーマの変更に基づきマイグレーションファイルを生成
+# モデル変更時のみ実行
+#  python manage.py makemigrations
+
+# マイグレーションファイルをDBに適用、DBを最新の状態で再構築
   python manage.py migrate --noinput
 }
 

--- a/docker/srcs/uwsgi-django/requirements.txt
+++ b/docker/srcs/uwsgi-django/requirements.txt
@@ -5,21 +5,22 @@
 Django==5.0.2
 
 # PostgreSQLデータベース用
-psycopg2
+psycopg2==2.9.9
 
 # WSGIサーバー
 uwsgi>=2.0
 
-django-prometheus
-python-logstash
-web3
-python-dotenv
+django-prometheus==2.3.1
+python-logstash==0.4.8
+web3==6.17.0
+python-dotenv==1.0.1
 
-Sphinx
-sphinx-rtd-theme
-myst-parser
+Sphinx==7.2.6
+sphinx-rtd-theme==2.0.0
+myst-parser==2.0.0
 
-requests
+requests==2.31.0
+parsimonious==0.10.0
 
 # 2FA
 django-otp==1.3.0

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -46,7 +46,6 @@ ALLOWED_HOSTS = ['*']
 
 
 # Application definition
-
 INSTALLED_APPS = [
 	'django.contrib.admin',
 	'django.contrib.auth',
@@ -59,23 +58,10 @@ INSTALLED_APPS = [
 	'accounts',  # user_accounts
 	'django_otp',  						# 2fa
 	'django_otp.plugins.otp_totp',  	# 2fa
-	'django_otp.plugins.otp_hotp',  	# 2fa
 	'django_otp.plugins.otp_static',  	# 2fa
-	# 'django.contrib.sites',  # allauth
-	# 'allauth',  # allauth
-	# 'allauth.account',  # allauth
-	# 'allauth.socialaccount',  # allauth
-	# 'socialaccount.providers.ft',  # 42auth with allauth
 ]
 
 
-# allauth
-# SOCIALACCOUNT_PROVIDERS = {
-# 	'ft': {
-# 		'CLIENT_ID': get_env_variable('FT_UID'),
-# 		'SECRET': get_env_variable('FT_SECRET'),
-# 	}
-# }
 FT_CLIENT_ID = get_env_variable('FT_UID')
 FT_SECRET = get_env_variable('FT_SECRET')
 
@@ -95,7 +81,6 @@ MIDDLEWARE = [
 	'django_prometheus.middleware.PrometheusAfterMiddleware',
 	# --------------------
 	'django_otp.middleware.OTPMiddleware',  # 2fa
-	# 'allauth.account.middleware.AccountMiddleware',  # allauth
 	'accounts.middleware.JWTAuthenticationMiddleware',  # jwt
 ]
 
@@ -103,9 +88,6 @@ MIDDLEWARE = [
 AUTHENTICATION_BACKENDS = [
 	'accounts.authentication_backend.JWTAuthenticationBackend',
 	'django.contrib.auth.backends.ModelBackend',  # Optional
-	# 'django_otp.backends.OTPAuthenticationBackend',  # 2fa
-# 	'django.contrib.auth.backends.ModelBackend',  # allauth
-# 	'allauth.account.auth_backends.AuthenticationBackend',  # allauth
 ]
 
 
@@ -141,7 +123,6 @@ TEMPLATES = [
 				'django.template.context_processors.request',
 				'django.contrib.auth.context_processors.auth',
 				'django.contrib.messages.context_processors.messages',
-				# 'django.template.context_processors.request',  # allauth
 			],
 		},
 	},
@@ -164,7 +145,6 @@ WSGI_APPLICATION = 'trans_pj.wsgi.application'
 #         'NAME': BASE_DIR / 'db.sqlite3',
 #     }
 # }
-
 
 
 DATABASES = {
@@ -292,24 +272,6 @@ LOGGING = {
 },
 }
 
-
-# # allauth setting --------------------------------------------------------------
-# ## sitesフレームワーク用のサイトID
-# SITE_ID = 1
-#
-# ## ログイン・ログアウト時のリダイレクト先
-# LOGIN_REDIRECT_URL = '/pong/'
-# ACCOUNT_LOGOUT_REDIRECT_URL = '/pong/'
-#
-# ## 認証方式を「メルアドとパスワード」に設定
-# ACCOUNT_AUTHENTICATION_METHOD = 'email'
-# ## ユーザ名は使用しない
-# ACCOUNT_USERNAME_REQUIRED = False
-#
-# ## ユーザ登録時に確認メールを送信するか(none=送信しない, mandatory=送信する)
-# ACCOUNT_EMAIL_VERIFICATION = 'none'
-# ACCOUNT_EMAIL_REQUIRED = True   # ユーザ登録にメルアド必須にする
-# # allauth setting --------------------------------------------------------------
 
 # JWT
 REST_FRAMEWORK = {


### PR DESCRIPTION
# Github actionsのお試し

## 目的
* CIテスト自動化
  * pushごとに自動テストが実行される
  * OK✅ / NG❌ が記録されるため、commit段階での動作の保証になる & 意図せぬ破壊に気づける
* とりあえず、Djangoのaccounts周りのテストのみを対象としています

<br>

## 追加変更
* `.github/workflows/ci.yml`を追加
* credential valueをSECRETで管理 ![Screenshot 2024-04-14 at 16 45 37](https://github.com/42trans/ft_transcendence/assets/51146172/cea90947-0719-42f8-a3fe-e960e3796350)
  * `.yml`でenvironmentの指定が必要だった（はまった）
* Djangoのtest実行のためにstart-upを判定する必要あり -> healthcheckを追加
* Ubuntu(actions, 42VM for mac)のエラー対策のために権限周りを変更 83ce9dc
  * sanoさんのVMでは別種のエラーあり。まだ対応しきれていない。
    * module not found 'pong.urls'
    * docker volumeが生成されない

<br>

## memo
* buildまで2分程度、思ったよりもはやい
* macOSのDockerはサポート外らしい

<br>

## Ref
* [1] [デプロイに環境を使用する](https://docs.github.com/ja/actions/deployment/targeting-different-environments/using-environments-for-deployment)
* [2] [GitHub Actionsで機密情報を扱う方法](https://qiita.com/ak2ie/items/4fbcdf74e7760c49c1af)