### PR TITLE
Django imageの軽量化

### DIFF
--- a/docker/srcs/compose-yaml/compose-web.yaml
+++ b/docker/srcs/compose-yaml/compose-web.yaml
@@ -70,7 +70,7 @@ services:
     #      - postgres
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:8001 || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8001 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker/srcs/uwsgi-django/Dockerfile
+++ b/docker/srcs/uwsgi-django/Dockerfile
@@ -1,10 +1,8 @@
 # docker/srcs/uwsgi-django/Dockerfile
-#FROM python:3.12-slim-bullseye AS builder
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bullseye AS builder
+#FROM python:3.12-slim-bullseye
 
 RUN apt-get update && apt-get install -y \
-	tzdata \
-	curl \
 #	net-tools \
 #	iputils-ping \
 #	telnet \
@@ -13,9 +11,9 @@ RUN apt-get update && apt-get install -y \
 #	postgresql-client \
     gcc \
     libc6-dev \
-    libpq5  \
     libpq-dev \
     python3-dev \
+    libpcre3-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # 環境変数を設定
@@ -29,16 +27,36 @@ WORKDIR /code
 COPY requirements.txt .
 
 RUN pip install --upgrade pip && pip install --no-cache-dir -r /code/requirements.txt
+# RUN pip install --no-cache-dir -r requirements.txt
 
 # 不要なパッケージを削除
 RUN apt-get purge -y --auto-remove gcc libc6-dev python3-dev
 
 # プロジェクトファイルをコピー
 COPY . .
-
 RUN mv /code/django-entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
 
+# 実行ステージ
+FROM python:3.12-slim-bullseye
+RUN apt-get update && apt-get install -y \
+	tzdata \
+	curl \
+    libpq5  \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PATH="/usr/local/bin:${PATH}"
+
+WORKDIR /code
+
+# ビルドステージから必要なファイルをコピー
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /code /code
+COPY --from=builder /entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
+
 CMD ["uwsgi", "--ini", "/code/uwsgi.ini"]

--- a/docker/srcs/uwsgi-django/Dockerfile
+++ b/docker/srcs/uwsgi-django/Dockerfile
@@ -1,29 +1,44 @@
 # docker/srcs/uwsgi-django/Dockerfile
-FROM python:3.12-bullseye
+#FROM python:3.12-slim-bullseye AS builder
+FROM python:3.12-slim-bullseye
+
 RUN apt-get update && apt-get install -y \
 	tzdata \
 	curl \
-	net-tools \
-	iputils-ping \
-	telnet \
-	netcat \
-	lsof \
-	postgresql-client \
+#	net-tools \
+#	iputils-ping \
+#	telnet \
+#	netcat \
+#	lsof \
+#	postgresql-client \
+    gcc \
+    libc6-dev \
+    libpq5  \
+    libpq-dev \
+    python3-dev \
 	&& rm -rf /var/lib/apt/lists/*
+
 # 環境変数を設定
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # 作業ディレクトリを設定
 WORKDIR /code
+
 # 依存関係ファイルをコピーし、パッケージをインストール
-COPY requirements.txt /code/
-RUN pip install -r /code/requirements.txt
-# RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && pip install --no-cache-dir -r /code/requirements.txt
+
+# 不要なパッケージを削除
+RUN apt-get purge -y --auto-remove gcc libc6-dev python3-dev
 
 # プロジェクトファイルをコピー
-COPY . /code/
+COPY . .
 
-COPY django-entrypoint.sh /entrypoint.sh
+RUN mv /code/django-entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["uwsgi", "--ini", "/code/uwsgi.ini"]


### PR DESCRIPTION
Base imageを`python:3.12-bullseye` -> `python:3.12-slim-bullseye`に変更
  * 1.14GB -> 531MB
マルチステージビルド化
  * 531MB -> 362MB