### PR TITLE
[fix] friend pageのfriend nameのリンクを/app/ URLに修正

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -1,6 +1,7 @@
 // online-status.js
 
 import { deleteFriend, createActionButton } from "./friend.js"
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
 
 
 let socket = null;
@@ -133,7 +134,7 @@ function updateOrCreateFriendListItem(friend) {
 
     // <link-to-user-info>
     const link = document.createElement('a');
-    link.href = `/user-info/${friend.nickname}/`;
+    link.href = `${routeTable['userInfoBase'].path}${friend.nickname}/`;
     link.className = 'nav__link';
     link.setAttribute('data-link', '');
     link.textContent = friend.nickname;

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
@@ -87,6 +87,9 @@ class FriendTest(TestConfig):
         friends_div = self._element(By.ID, "friends-container")
         friend_item = friends_div.find_element(By.XPATH, f".//li[contains(., '{self.test_user1_nickname}')]")
         delete_button = friend_item.find_element(By.CSS_SELECTOR, ".deleteButton")
+        # friend nameのlink: info page
+        user_name_link_url = self._text_link_url(self.test_user1_nickname)
+        self.assertEqual(user_name_link_url, f"{self.user_info_base_url}{self.test_user1_nickname}/")
 
         # delete buttonのチェック
         # ConfirmでCancelしDelete中断


### PR DESCRIPTION
#109 
- [x] friend nameのURLを検証するテストを追加（まずはtest fail）
- [x] friend nameのURLを修正（test pass）

<br>

memo
- SPA統合、SPA Testがopenのため、`add-spa-test` をbranch元、merge先としています
- close状況次第でbranch元, merge先を変更します