### PR TITLE
[fix] SPA DM

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: CREDENTIALS
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -39,8 +39,32 @@ export function startDMwithUser() {
     // ボタンクリックでDM画面へのリダイレクト
     submitButton.onclick = function() {
         const dmTargetNickname = input.value;
-        window.location.pathname = routeTable['dmWithUserBase'].path + dmTargetNickname + '/';
-    };
+        const messageArea = document.getElementById('message-area');
+
+        if (!dmTargetNickname) {
+            messageArea.textContent = "Nickname cannot be empty";
+            return;
+        }
+
+        fetch(`/chat/api/validate-dm-target/${dmTargetNickname}/`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(data => {
+                        throw new Error(data.error);
+                    });
+                }
+                window.location.pathname = routeTable['dmWithUserBase'].path + dmTargetNickname + '/';
+            })
+            .catch(error => {
+                messageArea.textContent = error.message;
+            });
+    }
 }
 
 

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_sessions.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_sessions.html
@@ -4,13 +4,7 @@
 <h2>Start DM</h2>
 
 <!-- エラーメッセージの表示 -->
-{% if messages %}
-<ul>
-    {% for message in messages %}
-    <li {% if message.tags %}class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
+<p id="message-area"></p>
 
 <!-- DM相手を指定して開始するtext field -->
 <label for="nickname-input">DM with:</label>

--- a/docker/srcs/uwsgi-django/chat/urls_api.py
+++ b/docker/srcs/uwsgi-django/chat/urls_api.py
@@ -4,6 +4,7 @@ from django.urls import path, re_path
 from . import views, consumers
 from chat.views.get_dm_sessions import GetDMSessionsAPI
 from chat.views.system_message import SystemMessageAPI
+from chat.views.views import ValidateDmTargetAPI
 
 
 app_name = 'api_chat'
@@ -11,4 +12,5 @@ app_name = 'api_chat'
 urlpatterns = [
     path('api/dm-sessions/', GetDMSessionsAPI.as_view(), name='dm_sessions'),
     path('api/system-message/', SystemMessageAPI.as_view(), name='dm_system'),
+    path('api/validate-dm-target/<str:target_nickname>/', ValidateDmTargetAPI.as_view(), name='valid_dm_target'),
 ]

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -8,7 +8,11 @@ from django.db import models
 from django.shortcuts import render, redirect
 from django.templatetags.static import static
 from django.views.generic import TemplateView
+
+from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from accounts.models import CustomUser
 from chat.models import DMSession, Message
@@ -19,6 +23,37 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _get_dm_users(request, target_nickname):
+    try:
+        if not target_nickname:
+            err = "Nickname cannot be empty"
+            return None, None, err
+
+        user = request.user
+        other_user = CustomUser.objects.get(nickname=target_nickname)
+        err = None
+
+        if target_nickname == user.nickname:
+            err = "You cannot send a message to yourself"
+        return user, other_user, err
+
+    except CustomUser.DoesNotExist:
+        err = "The specified user does not exist"
+    except Exception as e:
+        err = str(e)
+    return None, None, err
+
+
+class ValidateDmTargetAPI(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, target_nickname) -> Response:
+        user, other_user, err = _get_dm_users(request, target_nickname)
+        if err is not None:
+            return Response({'error': err}, status=400)
+        return Response({'status': 'ok'}, status=200)
 
 
 class DMView(LoginRequiredMixin, TemplateView):
@@ -33,10 +68,10 @@ class DMView(LoginRequiredMixin, TemplateView):
     def get(self, request, target_nickname):
         # user, other_userを取得
         # dm targetのnicknameがuser.nicknameである場合はerr
-        user, other_user, err = self._get_dm_users(request, target_nickname)
+        user, other_user, err = _get_dm_users(request, target_nickname)
         if err is not None:
-            messages.error(request, err)
-            return redirect(self.error_occurred_redirect_to)
+            # messages.error(request, err)
+            return redirect(self.error_occurred_redirect_to)  # ValidateDmTargetAPIで判定済み
 
         # DBから user, other_userのメッセージを取得。検索パターンは
         #  1) sender=user,       receiver=other_user
@@ -60,22 +95,6 @@ class DMView(LoginRequiredMixin, TemplateView):
         # logging.error(f'dm_room: user: {user.nickname}, dm_to: {nickname}, blocking: {is_blocking_user}')
         return render(request, self.template_name, data)
 
-
-    def _get_dm_users(self, request, target_nickname):
-        try:
-            user = request.user
-            other_user = CustomUser.objects.get(nickname=target_nickname)
-            err = None
-
-            if target_nickname == user.nickname:
-                err = "You cannot send a message to yourself"
-            return user, other_user, err
-
-        except CustomUser.DoesNotExist:
-            err = "The specified user does not exist"
-        except Exception as e:
-            err = str(e)
-        return None, None, err
 
 
 class DMSessionsView(LoginRequiredMixin, TemplateView):

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
@@ -59,7 +59,42 @@ class DMTest(TestConfig):
         self.assertEqual(received_message.text, message)
         # self._screenshot("dm3")
 
+    def test_input_nickname(self):
+        """
+        StartDMでnicknameを入力した時の挙動を評価
+        """
+        self._login(email=self.test_user1_email, password=self.password)
+        self._move_top_to_dm()
+
+        empty_nickname = ""
+        self._send_nickname(empty_nickname, wait_for_button_invisible=False)
+        self._assert_message("Nickname cannot be empty")
+        self._assert_current_url(self.dm_url)
+        self._screenshot("dm1")
+
+        invalid_nickname = "invalid"
+        self._send_nickname(invalid_nickname, wait_for_button_invisible=False)
+        self._assert_message("The specified user does not exist")
+        self._assert_current_url(self.dm_url)
+        self._screenshot("dm2")
+
+        own_nickname = self.test_user1_nickname
+        self._send_nickname(own_nickname, wait_for_button_invisible=False)
+        self._assert_message("You cannot send a message to yourself")
+        self._assert_current_url(self.dm_url)
+        self._screenshot("dm3")
+
+        valid_nickname = "user2"
+        self._send_nickname(valid_nickname, wait_for_button_invisible=True)
+        self._assert_current_url(f"{self.dm_with_base_url}{valid_nickname}/")
+        self._screenshot("dm4")
+
     def _send_message(self, message):
         self._send_to_elem(By.ID, "message-input", message)
         send_button = self._element(By.ID, "message-submit")
         self._click_button(send_button, wait_for_button_invisible=False)
+
+    def _send_nickname(self, nickname, wait_for_button_invisible: bool):
+        self._send_to_elem(By.ID, "nickname-input", nickname)
+        send_button = self._element(By.ID, "nickname-submit")
+        self._click_button(send_button, wait_for_button_invisible)


### PR DESCRIPTION
#113 

- StartDMで不正なnicknameを入力した時、/dm/に戻らず/dm-with/nickname/に留まる点を修正
- Start With nickname入力テストを追加

<br>

残課題（別issue）
- StartDMの遷移がDOM更新でSPA遷移になっていない