### PR TITLE
[fix] input formへの全角入力

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: CREDENTIALS
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -84,6 +84,8 @@ class UserManager(BaseUserManager):
         if CustomUser.kNICKNAME_MAX_LENGTH < len(nickname):
             err = f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"
             return False, err
+        if not nickname.isascii():
+            return False, "The nickname can only contain ASCII characters"
         if not nickname.isalnum():
             return False, "Invalid nickname format"
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
@@ -1,7 +1,7 @@
 // chat/js/dm-with-user.js
 import { applyStylesToInitialLoadMessages } from './module/apply-message-style.js';
 import { setupDmWebsocket } from './module/setup-dm-websocket.js';
-import { setupDOMEventListeners, scrollToBottom } from './module/ui-util.js';
+import { setupSendKeyEventListener, scrollToBottom } from './module/ui-util.js';
 
 
 function isDMwithBlockingUser() {
@@ -22,7 +22,7 @@ export function initDM() {
     scrollToBottom();  // 受信時にスクロール位置を調整
 
     setupDmWebsocket(dmTargetNickname);
-    setupDOMEventListeners();
+    setupSendKeyEventListener();
 }
 
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
@@ -1,15 +1,20 @@
 // chat/js/ui-util.js
 
-export { setupDOMEventListeners, scrollToBottom };
+export { setupSendKeyEventListener, scrollToBottom };
 
 
-// DOMイベントリスナーの設定
-function setupDOMEventListeners() {
-    document.querySelector('#message-input').onkeyup = function(e) {
-        if (e.keyCode === 13) {  // enter, return
-            document.querySelector('#message-submit').click();
+// メッセージ送信のイベントを制御
+function setupSendKeyEventListener() {
+    const input = document.getElementById('message-input');
+    const submitButton = document.getElementById('message-submit');
+
+    // Enterキーで送信
+    input.addEventListener('keydown', (event) => {
+        if (event.keyCode === 13) {
+            // console.log("sendKeyEventListener send")
+            submitButton.click();
         }
-    };
+    });
 }
 
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
@@ -11,6 +11,11 @@ function setupSendKeyEventListener() {
     // Enterキーで送信
     input.addEventListener('keydown', (event) => {
         if (event.keyCode === 13) {
+            // 空文字列の送信はしない
+            if (input.value === '') {
+                return
+            }
+
             // console.log("sendKeyEventListener send")
             submitButton.click();
         }

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
@@ -93,6 +93,7 @@ class BasicAuthTest(TestConfig):
     def test_signup_failure(self):
         self._move_top_to_signup()
 
+        # すでに存在するemail
         user1_email = "user1@example.com"
         nickname = self._generate_random_string()
         password1 = "pass0123"
@@ -104,6 +105,62 @@ class BasicAuthTest(TestConfig):
                      password2,
                      wait_for_button_invisible=False)
         self._assert_message("This email is already in use")
+        self._assert_current_url(self.signup_url)
+
+        # すでに存在するnicknmae
+        new_email = "new_user@example.com"
+        user1_nickname = "user1"
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(new_email,
+                     user1_nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message("This nickname is already in use")
+        self._assert_current_url(self.signup_url)
+
+        # 不正なニックネーム（alnum以外）
+        new_email = "new_user@example.com"
+        invalid_nickname = "nick_name"
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(new_email,
+                     invalid_nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message("Invalid nickname format")
+        self._assert_current_url(self.signup_url)
+
+        # 不正なニックネーム（全角）
+        new_email = "new_user@example.com"
+        invalid_nickname = "ニックネーム"
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(new_email,
+                     invalid_nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message("The nickname can only contain ASCII characters")
+        self._assert_current_url(self.signup_url)
+
+        # 不正なpassword
+        new_email = "new_user@example.com"
+        new_nickname = "newTestUser"
+        password1 = "pass0123"
+        password2 = "0123pass"
+
+        self._signup(new_email,
+                     new_nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message("passwords don't match")
         self._assert_current_url(self.signup_url)
 
     def _signup(self,

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
@@ -86,6 +86,13 @@ class ProfileTest(TestConfig):
         self._assert_current_url(self.edit_profile_url)
         # self._screenshot("edit_nickname_4")
 
+        # user1 -> invalid nickname format
+        multi_byte_nickname = "ニックネーム"
+        self._edit_nickname(multi_byte_nickname, wait_for_button_invisible=False)
+        self._assert_message("The nickname can only contain ASCII characters")
+        self._assert_current_url(self.edit_profile_url)
+        # self._screenshot("edit_nickname_5")
+
         # nicknameはuser1から不変のはず
         self._move_top_to_profile()
         self._assert_profile_nickname(current_nickname)


### PR DESCRIPTION
#114 

IME変換確定のリターンで送信される現象を修正

- [x] DM: message入力
- [ ] ~Sign-up: nickname入力~ 全角許容しない
- [ ] ~Edit user: update nickname入力~ 全角許容しない

<br>

残課題
- Sendクリックで空文字列を送信できる #141 