### PR TITLE
[update] nickname, password, emailの最大・最小文字数

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -114,6 +114,9 @@ class UserManager(BaseUserManager):
             return False, "The password cannot be None"
         if not password:
             return False, "The password cannot be set"
+        if CustomUser.kPASSWORD_MAX_LENGTH < len(password):
+            err = f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less"
+            return False, err
         try:
             validate_password(password, user=tmp_user)
             return True, None
@@ -178,6 +181,7 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     kNICKNAME_MAX_LENGTH = 30
     kEMAIL_MIN_LENGTH = 5   # 最小構成: a@b.c
     kEMAIL_MAX_LENGTH = 64  # RFC5321: local@domain, local:max64, domain:max255
+    kPASSWORD_MAX_LENGTH = 64
     email = models.EmailField(_("email address"), unique=True)
     nickname = models.CharField(_("nickname"), max_length=kNICKNAME_MAX_LENGTH, unique=True)
     enable_2fa = models.BooleanField(_("enable 2fa"), default=False)

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -70,7 +70,17 @@ class UserManager(BaseUserManager):
         if CustomUser.objects.filter(email=email).exists():
             return False, "This email is already in use"
 
+        # 長さの判定
+        if len(email) < CustomUser.kEMAIL_MIN_LENGTH:
+            err = f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters"
+            return False, err
+        if CustomUser.kEMAIL_MAX_LENGTH < len(email):
+            err = f"The email must be {CustomUser.kEMAIL_MAX_LENGTH} characters or less"
+            return False, err
+
         try:
+            # local@domainの判定
+            # https://docs.djangoproject.com/en/5.0/ref/validators/#emailvalidator
             validate_email(email)
             return True, None
         except ValidationError as e:
@@ -166,6 +176,8 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     """
     kNICKNAME_MIN_LENGTH = 3
     kNICKNAME_MAX_LENGTH = 30
+    kEMAIL_MIN_LENGTH = 5   # 最小構成: a@b.c
+    kEMAIL_MAX_LENGTH = 64  # RFC5321: local@domain, local:max64, domain:max255
     email = models.EmailField(_("email address"), unique=True)
     nickname = models.CharField(_("nickname"), max_length=kNICKNAME_MAX_LENGTH, unique=True)
     enable_2fa = models.BooleanField(_("enable 2fa"), default=False)

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -81,6 +81,9 @@ class UserManager(BaseUserManager):
     def _is_valid_nickname(self, nickname):
         if not nickname:
             return False, "The given nickname must be set"
+        if len(nickname) < CustomUser.kNICKNAME_MIN_LENGTH:
+            err = f"The nickname must be at least {CustomUser.kNICKNAME_MIN_LENGTH} characters"
+            return False, err
         if CustomUser.kNICKNAME_MAX_LENGTH < len(nickname):
             err = f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"
             return False, err
@@ -161,6 +164,7 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     - nickname: A unique nickname for the user. if OAuth with 42 used, 42-login by default.
     - bloking_users: A list of bloking users
     """
+    kNICKNAME_MIN_LENGTH = 3
     kNICKNAME_MAX_LENGTH = 30
     email = models.EmailField(_("email address"), unique=True)
     nickname = models.CharField(_("nickname"), max_length=kNICKNAME_MAX_LENGTH, unique=True)

--- a/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
@@ -85,6 +85,26 @@ class SignUpAPITests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("This nickname is already in use", response.json()['error'])
 
+    def test_invalid_password_too_short(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = 'test1@signup.com'
+        user_data['nickname'] = 'test1'
+        user_data['password1'] = "pass0"
+        user_data['password2'] = "pass0"
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("このパスワードは短すぎます。最低 8 文字以上必要です。", response.json()['error'])
+
+    def test_invalid_password_too_long(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = 'test1@signup.com'
+        user_data['nickname'] = 'test1'
+        user_data['password1'] = "pass0" + "0123456789" * 6
+        user_data['password2'] = "pass0" + "0123456789" * 6
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less", response.json()['error'])
+
     def test_successful_signup(self):
         user_data = self.user_data.copy()
         user_data['email'] = 'test1@signup.com'

--- a/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
+from accounts.models import CustomUser
 
 
 class SignUpAPITests(TestCase):
@@ -55,6 +56,27 @@ class SignUpAPITests(TestCase):
         response = self.client.post(self.signup_api_url, user_data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('error', response.json())
+
+    def test_invalid_email_empty(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = ''
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.json())
+
+    def test_invalid_email_too_short(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = 'a@b'
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters", response.json()['error'])
+
+    def test_invalid_email_too_long(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = f"a@{'b' * 64}.com"
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(f"The email must be {CustomUser.kEMAIL_MAX_LENGTH} characters or less", response.json()['error'])
 
     def test_invalid_nickname_already_use(self):
         user_data = self.user_data.copy()

--- a/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
@@ -94,8 +94,13 @@ class EditUserProfileAPITests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('This nickname is already in use', response.data['error'])
 
-    def test_update_nickname_fail_invalid_nickname(self):
-        response = self.client.post(self.edit_user_profile_url, {'nickname': '*'})
+    def test_update_nickname_fail_invalid_nickname_len(self):
+        response = self.client.post(self.edit_user_profile_url, {'nickname': 'aa'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('The nickname must be at least 3 characters', response.data['error'])
+
+    def test_update_nickname_fail_invalid_nickname_char(self):
+        response = self.client.post(self.edit_user_profile_url, {'nickname': '***'})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('Invalid nickname format', response.data['error'])
 

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
@@ -107,6 +107,48 @@ class BasicAuthTest(TestConfig):
         self._assert_message("This email is already in use")
         self._assert_current_url(self.signup_url)
 
+        # 不正なemail
+        user1_email = "invalid-email.com"
+        nickname = self._generate_random_string()
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(user1_email,
+                     nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message("有効なメールアドレスを入力してください。")  # todo message
+        self._assert_current_url(self.signup_url)
+
+        # 不正なemail（too short）
+        user1_email = "a@b"
+        nickname = self._generate_random_string()
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(user1_email,
+                     nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message(f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters")
+        self._assert_current_url(self.signup_url)
+
+        # 不正なemail（too long）
+        user1_email = f"a@{'b' * 64}.com"
+        nickname = self._generate_random_string()
+        password1 = "pass0123"
+        password2 = "pass0123"
+
+        self._signup(user1_email,
+                     nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message(f"The email must be {CustomUser.kEMAIL_MAX_LENGTH} characters or less")
+        self._assert_current_url(self.signup_url)
+
         # すでに存在するnicknmae
         new_email = "new_user@example.com"
         user1_nickname = "user1"

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
@@ -205,6 +205,20 @@ class BasicAuthTest(TestConfig):
         self._assert_message("passwords don't match")
         self._assert_current_url(self.signup_url)
 
+        # 不正なpassword（too long）
+        new_email = "new_user@example.com"
+        new_nickname = "newTestUser"
+        password1 = "pass0" + "0123456789" * 6
+        password2 = "pass0" + "0123456789" * 6
+
+        self._signup(new_email,
+                     new_nickname,
+                     password1,
+                     password2,
+                     wait_for_button_invisible=False)
+        self._assert_message(f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less")
+        self._assert_current_url(self.signup_url)
+
     def _signup(self,
                 email,
                 nickname,

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
@@ -70,24 +70,24 @@ class DMTest(TestConfig):
         self._send_nickname(empty_nickname, wait_for_button_invisible=False)
         self._assert_message("Nickname cannot be empty")
         self._assert_current_url(self.dm_url)
-        self._screenshot("dm1")
+        # self._screenshot("dm1")
 
         invalid_nickname = "invalid"
         self._send_nickname(invalid_nickname, wait_for_button_invisible=False)
         self._assert_message("The specified user does not exist")
         self._assert_current_url(self.dm_url)
-        self._screenshot("dm2")
+        # self._screenshot("dm2")
 
         own_nickname = self.test_user1_nickname
         self._send_nickname(own_nickname, wait_for_button_invisible=False)
         self._assert_message("You cannot send a message to yourself")
         self._assert_current_url(self.dm_url)
-        self._screenshot("dm3")
+        # self._screenshot("dm3")
 
         valid_nickname = "user2"
         self._send_nickname(valid_nickname, wait_for_button_invisible=True)
         self._assert_current_url(f"{self.dm_with_base_url}{valid_nickname}/")
-        self._screenshot("dm4")
+        # self._screenshot("dm4")
 
     def _send_message(self, message):
         self._send_to_elem(By.ID, "message-input", message)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
@@ -162,6 +162,14 @@ class ProfileTest(TestConfig):
         self._assert_current_url(self.edit_profile_url)
         # self._screenshot("edit_pass_3")
 
+        # new passwordが不正(too long)
+        current_pass = "pass0123"
+        new_pass = "pass0" + "0123456789" * 6
+        self._edit_password(current_pass, new_pass, wait_for_button_invisible=False)
+        self._assert_message(f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less")
+        self._assert_current_url(self.edit_profile_url)
+        # self._screenshot("edit_pass_3")
+
     ############################################################################
 
     def _assert_profile_email(self, expected_email):


### PR DESCRIPTION
#140 

## password
  - min: 8: settings.py AUTH_PASSWORD_VALIDATORSで設定済み
   - [x] max: 64文字に設定

## nickname
  - [x] min: 最低3文字以上に設定
  -  max: accounts/models.py kNICKNAME_MAX_LENGTH=30で設定済み

## email
  - [x] min: 5文字`a@b.c`を最小構成に
  - [x] max: 64（djangoのvalidate_emailでは320がmaxだが、制限厳しめに）