### PR TITLE
[fix] SPA遷移

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build_up_three: init
 	COMPOSE_PROFILES=three docker-compose $(COMPOSE_FILES_ARGS) up -d
 	
 .PHONY: build_up_default
-build_up_default: init
+build_up_default: init build_up_three vite_npm_run_build django_collectstatic
 	docker-compose $(COMPOSE_FILES_ARGS) build
 	docker-compose $(COMPOSE_FILES_ARGS) up -d
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -79,6 +79,7 @@ function createDMSessionLinks(data) {
 
         // リンクの設定
         link.href = `${routeTable['dmSessions'].path}${dmSession.target_nickname}/`;
+        link.setAttribute('data-link', '');
 
         // システムメッセージの場合は表示を変更
         if (dmSession.is_system_message) {

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -1,6 +1,7 @@
 // dm_sessions.js
 
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { switchPage } from "/static/spa/js/routing/renderView.js"
 
 
 export function fetchDMList() {
@@ -59,7 +60,8 @@ export function startDMwithUser() {
                         throw new Error(data.error);
                     });
                 }
-                window.location.pathname = routeTable['dmWithUserBase'].path + dmTargetNickname + '/';
+                const routePath = routeTable['dmWithUserBase'].path + dmTargetNickname + '/'
+                switchPage(routePath)
             })
             .catch(error => {
                 messageArea.textContent = error.message;

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -101,7 +101,7 @@
 
 
 {% if not isSystemUser %}
-    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/">{{ target_nickname }}</a></h2>
+    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/" data-link>{{ target_nickname }}</a></h2>
 {% else %}
     <h2>System Message</h2>
 {% endif %}

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
@@ -88,7 +88,7 @@ class StateBaseRound
 			} else {
 				if (match.can_start) {
 					// Pong gameへのリンク APIにmatch.idを渡す。
-					matchDetails += `<a class="hth-btn px-3 mx-4 mt-2 mb-3" href="/pong/play/${match.id}">Start Match</a>`;
+					matchDetails += `<a class="hth-btn px-3 mx-4 mt-2 mb-3" href="/app/game/match/${match.id}/" data-link>Start Match</a>`;
 				} else {
 					matchDetails += `<p class="px-4 pb-2" >On Hold</p>`;
 				}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -6,6 +6,7 @@ import FreePlay     from "../views/pong/FreePlay.js";
 import Tournament   from "../views/pong/Tournament.js";
 import Game2D       from "../views/pong/Game2D.js";
 import Game3D       from "../views/pong/Game3D.js";
+import GameMatch    from "../views/pong/GameMatch.js";
 
 import GameHistory  from "../views/user/GameHistory.js";
 
@@ -44,6 +45,7 @@ export const routeTable = {
   tournament    : { path: "/app/game/tournament/",   view: Tournament },
   game2d        : { path: "/app/game/game-2d/",      view: Game2D },
   game3d        : { path: "/app/game/game-3d/",      view: Game3D },
+  gameMatch     : { path: "/app/game/match/:matchId/",  view: GameMatch },
 
   gameHistory   : { path: "/app/user/game-history/", view: GameHistory },
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
@@ -1,0 +1,28 @@
+// Game1vs1.js
+
+import AbstractView from "../AbstractView.js";
+import fetchData from "../../utility/fetch.js";
+import { getUrl } from "../../utility/url.js";
+import { loadAndExecuteScript } from "../../utility/script.js";
+
+
+export default class extends AbstractView {
+  constructor(params) {
+    super(params);
+    this.params = params
+    this.setTitle("GameMatch");
+  }
+
+  async getHtml() {
+    const matchId = this.params.matchId;
+    const uri = `/pong/play/${matchId}`;
+    const data = await fetchData(uri);
+    //console.log("Pong:" + data);
+    return data;
+  }
+
+  async executeScript() {
+    loadAndExecuteScript("/static/pong/three/assets/index.js", true);
+  }
+
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
@@ -5,6 +5,8 @@
   "kSpaTournamentUrl"   : "/app/game/tournament/",
   "kSpaGame2D"          : "/app/game/game-2d/",
   "kSpaGame3D"          : "/app/game/game-3d/",
+  "kSpaGameMatchBase"   : "/app/game/match/",
+  "kSpaGameMatchUrl"    : "/app/game/match/:matchId/",
 
   "kSpaGameHistoryUrl"  : "/app/user/game-history/",
   "kSpaUserProfileUrl"  : "/app/user/profile/",


### PR DESCRIPTION
#138 

ページ遷移の際、DOM全体の更新となり、SPA遷移になっていない点を修正
- [x] DM with -> Enter
- [x] DM Session List -> user選択で/dm/user/
- [x] DM画面 -> user名で/user/info/
- [x] Tournament StartMatch

<br>

3DのStartMatchボタンのhref変更のついでに...
Makefile `build_up_default`でvite buildし`/static/pong/three/` へ3Dの変更を確実に反映するようにしました