### PR TITLE
2D-Pongページ以外でパスクリックのイベントに反応してたバグ修正。応急処置

### DIFF
--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
@@ -65,7 +65,7 @@ class PongOnlineClientApp
 
 			this.startGameButton = document.getElementById('hth-pong-online-start-game-btn');
 			if (!this.startGameButton) {
-				throw new Error('Start Game button not found');
+				return;
 			}
 			this.startGameButton.style.display = 'block' 
 


### PR DESCRIPTION
しないよう、スタートボタンがなければリターン。

たくさん出るならば、包括的にルーター側でlistenerをリセットするなどの対応が良いのかもしれない。

テスト修正したものを別ブランチで動いてるので後でマージでも。
https://github.com/42trans/ft_transcendence/pull/158
急ぐならこれを。