### PR TITLE
みづらいドロップシャドウを修正 dm, tournament-create

### DIFF
--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -34,8 +34,10 @@
 
 
         {% if not isSystemUser %}
-        <input id="message-input" type="text">
-        <input id="message-submit" type="button" value="Send">
+        <div class="message-container">
+            <input id="message-input" type="text">
+            <input id="message-submit" type="button" value="Send">
+        </div>
     {% endif %}
 
     </div>

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -2,104 +2,6 @@
 
 {% load static %}
 
-     {% comment %} メッセージのスタイル（仮仕様）  {% endcomment %}
-    <style>
-        /* DM表示領域 */
-        #dm-log {
-            width: 600px; /* メッセージログの幅を入力フィールドと同じにする */
-            max-height: 400px; /* メッセージログの最大高さを設定 */
-            overflow-y: auto; /* 縦方向にスクロールバーを表示 */
-            padding: 10px; /* 内側に余白を設定 */
-            box-sizing: border-box; /* paddingを含む全体のwidthとheightが600pxと400pxになるように設定 */
-        }
-
-        /* DM送信フォーム */
-        #message-input {
-            width: 600px;               /* 幅を600pxに設定 */
-        }
-
-        /*!* メッセージコンテンツのスタイル *!*/
-        .message-content {
-            display: flex;
-            flex-direction: column;
-            max-width: 100%;             /* メッセージの最大幅を設定 */
-            width: fit-content; /* コンテンツの幅に合わせて自動調整 */
-            word-wrap: break-word; /* 長い単語を折り返す */
-            overflow-wrap: break-word; /* 長い非単語も折り返す */
-            word-break: break-all; /* 長い単語を強制的に折り返す */
-        }
-
-        /* アバターとsender名を含むコンテナ */
-        .avatar-and-sender {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            margin-right: 10px;
-        }
-
-        .sender-name {
-            font-size: 0.8em;               /* 小さめのフォントサイズ */
-            color: #666;                    /* 色は暗めに設定 */
-            margin-top: 5px;  /* アバターと名前の間に少しスペースを追加 */
-        }
-
-        #dm-log li {
-            display: flex;
-            align-items: flex-start;  /* アバターとメッセージ内容を上端で揃える */
-            margin-bottom: 1.3em;     /* メッセージ間の間隔を1.5倍に設定 */
-            padding: 5px;             /* 内側の余白を設定 */
-            border-radius: 5px;       /* 角の丸みを10pxで設定 */
-            clear: both;              /* 他の要素との重なりを防ぐ */
-            background-color: #f0f0f0;/* メッセージの背景色を設定 */
-            max-width: 100%;              /* リストの幅を100%に設定 */
-        }
-
-        .timestamp {
-            font-size: 0.5em;               /* 小さめのフォントサイズ */
-            color: #666;                    /* 色は暗めに設定 */
-            align-self: flex-end;     /* タイムスタンプを右揃え */
-            text-align: right;        /* テキストも右揃え */
-            width: 100%;              /* 幅を親要素の幅いっぱいに広げる */
-            padding-top: 5px;         /* メッセージとの間隔を設定 */
-        }
-
-        .avatar {
-            width: 30px;              /* 幅を30pxに設定 */
-            height: 30px;             /* 高さを30pxに設定 */
-            border-radius: 50%;       /* 角を円形にする */
-            object-fit: cover;        /* 画像のアスペクト比を維持しながら、設定された領域に収まるようにする */
-        }
-
-        /* 受信者側のメッセージ */
-        #dm-log li.dm-to {
-            text-align: left;           /* dmToのメッセージを左詰め */
-            float: left;                /* 左側に配置 */
-            background-color: #808080;  /* 背景色 */
-            color: white;               /* 文字色 */
-            max-width: 70%;             /* DM表示領域の70%の幅 */
-        }
-
-        /* 送信者側のメッセージ */
-        #dm-log li.dm-from {
-            text-align: left;           /* 自分のメッセージを右詰め */
-            float: right;               /* 右側に配置 */
-            background-color: #b0c4de;  /* 背景色 */
-            color: white;               /* 文字色 */
-            max-width: 70%;             /* DM表示領域の70%の幅 */
-        }
-
-        /* 受信者側のメッセージ */
-        #dm-log li.system-message {
-            text-align: left;           /* dmToのメッセージを左詰め */
-            float: left;                /* 左側に配置 */
-            background-color: #483d8b;  /* 背景色 */
-            color: white;               /* 文字色 */
-            max-width: 70%;             /* DM表示領域の70%の幅 */
-        }
-
-    </style>
-
-
 {% if not isSystemUser %}
     <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/">{{ target_nickname }}</a></h2>
 {% else %}
@@ -108,36 +10,38 @@
 
 
 {% if not isBlockingUser %}
-     {% comment %} DM logを表示  {% endcomment %}
-    <ul id="dm-log" style="list-style: none;">
-        {% for message in messages %}
-        <li class="{{ message.sender.nickname|slugify }}" data-sender-name="{{ message.sender.nickname }}">
-            <div class="avatar-and-sender">
-                {% if message.sender.nickname == target_nickname %}
-                    <img src="{{ other_avatar_url }}" alt="Avatar" class="avatar">
-                {% else %}
-                    <img src="{{ user_avatar_url }}" alt="Avatar" class="avatar">
-                {% endif %}
-                <span class="sender-name">{{ message.sender.nickname }}</span>
-            </div>
-            <div class="message-content">
-                <span>{{ message.message|escape }}</span>
-                <span class="timestamp">{{ message.timestamp|date:"Y-m-d H:i:s" }}</span>
-            </div>
-        </li>
-        {% endfor %}
-    </ul>
+    <div id="dm-container">
+    
+        {% comment %} DM logを表示  {% endcomment %}
+        <ul id="dm-log" style="list-style: none;">
+            {% for message in messages %}
+            <li class="{{ message.sender.nickname|slugify }}" data-sender-name="{{ message.sender.nickname }}">
+                <div class="avatar-and-sender">
+                    {% if message.sender.nickname == target_nickname %}
+                        <img src="{{ other_avatar_url }}" alt="Avatar" class="avatar">
+                    {% else %}
+                        <img src="{{ user_avatar_url }}" alt="Avatar" class="avatar">
+                    {% endif %}
+                    <span class="sender-name">{{ message.sender.nickname }}</span>
+                </div>
+                <div class="message-content">
+                    <span>{{ message.message|escape }}</span>
+                    <span class="timestamp">{{ message.timestamp|date:"Y-m-d H:i:s" }}</span>
+                </div>
+            </li>
+            {% endfor %}
+        </ul>
 
-    {% if not isSystemUser %}
-    <input id="message-input" type="text">
-    <input id="message-submit" type="button" value="Send">
+
+        {% if not isSystemUser %}
+        <input id="message-input" type="text">
+        <input id="message-submit" type="button" value="Send">
     {% endif %}
 
+    </div>
 {% else %}
     <p>[blocking user]</p>
 {% endif %}
 
 
 {{ target_nickname|json_script:"target_nickname" }}
-
-{% comment %} <script type="module" src="{% static 'chat/js/dm-with-user.js' %}"></script> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
@@ -15,10 +15,24 @@
 	box-sizing: border-box; /* paddingを含む全体のwidthとheightが600pxと400pxになるように設定 */
 }
 
+/* DM送信フォームとボタンのコンテナ */
+.message-container {
+	display: flex;
+	align-items: center;
+}
+
 /* DM送信フォーム */
 #message-input {
-	width: 80%;   
-	/* width: 600px;    */
+	flex: 1;
+	margin-right: 10px;
+	/* width: 90%; */
+	/* width: 600px; */
+}
+
+/* DM送信ボタン */
+#message-submit {
+	width: 60px;
+	/*width: 6%;*/
 }
 
 /*!* メッセージコンテンツのスタイル *!*/

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
@@ -1,0 +1,112 @@
+/* docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css */
+
+#dm-container {
+	padding-bottom: 20px;
+}
+/* DM表示領域 */
+#dm-log {
+	/* width: 600px; メッセージログの幅を入力フィールドと同じにする */
+	/* メッセージログの最大高さを設定 */
+	max-height: 50vh; 
+	/* max-height: 400px;  */
+	/* 縦方向にスクロールバーを表示 */
+	overflow-y: auto; 
+	padding: 10px; 
+	box-sizing: border-box; /* paddingを含む全体のwidthとheightが600pxと400pxになるように設定 */
+}
+
+/* DM送信フォーム */
+#message-input {
+	width: 80%;   
+	/* width: 600px;    */
+}
+
+/*!* メッセージコンテンツのスタイル *!*/
+.message-content {
+	display: flex;
+	flex-direction: column;
+	/* max-width: 100%;             メッセージの最大幅を設定 */
+	width: fit-content; /* コンテンツの幅に合わせて自動調整 */
+	word-wrap: break-word; /* 長い単語を折り返す */
+	overflow-wrap: break-word; /* 長い非単語も折り返す */
+	word-break: break-all; /* 長い単語を強制的に折り返す */
+}
+
+/* アバターとsender名を含むコンテナ */
+.avatar-and-sender {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-right: 10px;
+}
+
+.sender-name {
+	font-size: 0.8em;               /* 小さめのフォントサイズ */
+	/* color: #666;                    色は暗めに設定 */
+	/* color: #131313; */
+	margin-top: 5px;  /* アバターと名前の間に少しスペースを追加 */
+}
+
+#dm-log li {
+	display: flex;
+	align-items: flex-start;  /* アバターとメッセージ内容を上端で揃える */
+	margin-bottom: 1.3em;     /* メッセージ間の間隔を1.5倍に設定 */
+	padding: 5px;             /* 内側の余白を設定 */
+	border-radius: 5px;       /* 角の丸みを10pxで設定 */
+	clear: both;              /* 他の要素との重なりを防ぐ */
+	background-color: #f0f0f0;/* メッセージの背景色を設定 */
+	max-width: 100%;              /* リストの幅を100%に設定 */
+}
+
+#dm-log li.system-message,
+#dm-log li.dm-from,
+#dm-log li.dm-to,
+#dm-log .sender-name,
+#dm-log .timestamp {
+	text-shadow: none;
+	background-color: var(--btn-bg-color);
+	color: var(--form-text-color); 
+}
+
+.timestamp {
+	font-size: 0.8em;               /* 小さめのフォントサイズ */
+	/* color: #666;                    色は暗めに設定 */
+	/* color: #131313; */
+	align-self: flex-end;     /* タイムスタンプを右揃え */
+	text-align: right;        /* テキストも右揃え */
+	width: 100%;              /* 幅を親要素の幅いっぱいに広げる */
+	padding-top: 5px;         /* メッセージとの間隔を設定 */
+}
+
+.avatar {
+	width: 30px;              /* 幅を30pxに設定 */
+	height: 30px;             /* 高さを30pxに設定 */
+	border-radius: 50%;       /* 角を円形にする */
+	object-fit: cover;        /* 画像のアスペクト比を維持しながら、設定された領域に収まるようにする */
+}
+
+/* 受信者側のメッセージ */
+#dm-log li.dm-to {
+	text-align: left;           /* dmToのメッセージを左詰め */
+	float: left;                /* 左側に配置 */
+	/* background-color: #808080;  背景色 */
+	/* color: white;               文字色 */
+	max-width: 70%;             /* DM表示領域の70%の幅 */
+}
+
+/* 送信者側のメッセージ */
+#dm-log li.dm-from {
+	text-align: left;           /* 自分のメッセージを右詰め */
+	float: right;               /* 右側に配置 */
+	/* background-color: #b0c4de;  背景色 */
+	/* color: #131313;               文字色 */
+	max-width: 70%;             /* DM表示領域の70%の幅 */
+}
+
+#dm-log li.system-message {
+	text-align: left;           /* dmToのメッセージを左詰め */
+	float: left;                /* 左側に配置 */
+	/* background-color: #483d8b;  背景色 */
+	/* color: white;               文字色 */
+	max-width: 70%;             /* DM表示領域の70%の幅 */
+}

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-tournament.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-tournament.css
@@ -1,0 +1,4 @@
+#tournament-create-form label {
+	text-shadow: none;
+}
+

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -37,54 +37,54 @@ class TournamentCreator
 	_generateFormHTML(csrfToken, organizerNickname)
 	{
 		return `
-		<main class="form-sign m-auto" id="signup-form">
+		<div class="form-sign m-auto" id="tournament-create-form">
 				<form class="hth-sign-form" onsubmit="signupUser(event)">
 					<h2 class="slideup-text mb-3">Create Tournament</h2>
 					
 					<input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">
-					<input type="hidden" id="date" name="date" readonly>
+					<input type="hidden"  name="date" readonly>
 
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="name" name="name" placeholder="Tournament Name" value="My Tournament">
+						<input type="text" class="form-control" name="name" placeholder="Tournament Name" value="My Tournament">
 						<label for="floatingInput">My Tournament</label>
 	 				</div>
 					
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="${organizerNickname}" readonly>
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="${organizerNickname}" readonly>
 						<label for="floatingInput">Nickname1</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname2">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname2">
 						<label for="floatingInput">Player2</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname3">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname3">
 						<label for="floatingInput">Player3</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname4">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname4">
 						<label for="floatingInput">Player4</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname5">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname5">
 						<label for="floatingInput">Player5</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname6">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname6">
 						<label for="floatingInput">Player6</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname7">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname7">
 						<label for="floatingInput">Player7</label>
 	 				</div>
 					<div class="slideup-text form-floating">
-						<input type="text" class="form-control" id="nickname" name="nickname" placeholder="Nickname" value="Nickname8">
+						<input type="text" class="form-control" name="nickname" placeholder="Nickname" value="Nickname8">
 						<label for="floatingInput">Player8</label>
 	 				</div>
 					
 					<button class="hth-btn my-4" type="submit">Submit</button>
 			</form>
-		</main>
+		</div>
 		`;
 	}
 	/** トーナメントを保存する */

--- a/docker/srcs/uwsgi-django/trans_pj/templates/spa.html
+++ b/docker/srcs/uwsgi-django/trans_pj/templates/spa.html
@@ -6,11 +6,12 @@
     <link rel="stylesheet" href="{% static 'spa/css/spa.css' %}" />
     <link rel="stylesheet" crossorigin href="{% static 'pong/three/assets/index.css' %}">
     <link rel="stylesheet" crossorigin href="{% static 'pong/css/hth-online.css' %}">
+    <link rel="stylesheet" crossorigin href="{% static 'pong/css/hth-tournament.css' %}">
+    <link rel="stylesheet" crossorigin href="{% static 'pong/css/hth-dm.css' %}">
 {% endblock %}
 
 
 {% block content %}
-    {% comment %} <header>{% include 'header.html' with url_config=url_config %}</header> {% endcomment %}
 
         <div id="spa" class="spa_area">
             {% comment %} SPA AREA 動的に生成される内容を表示  {% endcomment %}


### PR DESCRIPTION
#163

ついでにDMにテーマ適用

---
 DMのシャドウがぼやけて見えない
 同じくtournament新規作成も微妙。OKだけど。loginと同じシャドウオフにするのがベスト
 どちらも.hth-containerの継承なので、影響考慮し、上書きする形の修正が望ましい