### PR TITLE
[fix] E2Eテスト _create_new_user()のfail対策

### DIFF
--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -208,8 +208,7 @@ class TestConfig(LiveServerTestCase):
         )
 
     def _send_to_elem(self, by, elem_value, send_value, retries=5):
-        wait = WebDriverWait(driver=self.driver, timeout=10)
-        wait.until(EC.presence_of_element_located((by, elem_value)))
+        wait = WebDriverWait(driver=self.driver, timeout=20)
 
         for attempt in range(retries):
             try:
@@ -230,6 +229,7 @@ class TestConfig(LiveServerTestCase):
     def _click_link(self, target, wait_for_link_invisible=False):
         url = target.get_attribute("href")
         self.driver.execute_script("arguments[0].click();", target)
+        time.sleep(1)  # 明示的に待機
 
         if wait_for_link_invisible:
             self._wait_invisible(target)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -219,6 +219,7 @@ class TestConfig(LiveServerTestCase):
                 return
             except (StaleElementReferenceException, TimeoutException):
                 if attempt < retries - 1:
+                    print(f"send_to_elem(): {elem_value}, retry: {attempt + 1}/{retries}")
                     time.sleep(3)  # 少し待ってから再試行
                 else:
                     raise


### PR DESCRIPTION
ちょくちょく失敗しているので再修正を...

基本的に`_create_new_user()`でemail input formが見つからずtimeoutしている模様
Re-runするとpassすることも

https://github.com/42trans/ft_transcendence/actions/runs/9394801153/job/25874607054#step:9:21

```
Traceback (most recent call last):
  File "/code/trans_pj/tests/test_2fa.py", line 13, in setUp
    self._create_new_user(email=self.email,
  File "/code/trans_pj/tests/__init__.py", line 333, in _create_new_user
    self._send_to_elem(By.ID, "password1", password)
  File "/code/trans_pj/tests/__init__.py", line 217, in _send_to_elem
    elem = wait.until(EC.presence_of_element_located((by, elem_value)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/selenium/webdriver/support/wait.py", line 105, in until
    raise TimeoutException(message, screen, stacktrace)
selenium.common.exceptions.TimeoutException: Message: 
```

<hr>

変更点
* timeout 10->20secに延長
* リンククリック遷移後に明示的に1sec待機