### PR TITLE
[fix] DM sendボタンで空文字列を送信不可に修正

### DIFF
--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -39,6 +39,13 @@ function handleSendMessage(dmSocket) {
     const messageInputDom = document.querySelector('#message-input');
     const message = messageInputDom.value;
 
+    // console.log('message: ' + message)
+    // 空文字列、空白のみのメッセージの送信はしない
+    if (message.trim() === '') {
+        // console.log(' smessage is empty')
+        return;
+    }
+
     dmSocket.send(JSON.stringify({
         'message': message
     }));

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
@@ -11,12 +11,6 @@ function setupSendKeyEventListener() {
     // Enterキーで送信
     input.addEventListener('keydown', (event) => {
         if (event.keyCode === 13) {
-            // 空文字列の送信はしない
-            if (input.value === '') {
-                return
-            }
-
-            // console.log("sendKeyEventListener send")
             submitButton.click();
         }
     });


### PR DESCRIPTION
#141 

`handleSendMessage()`で、Enter, Clickともに空文字列の送信を制御するように変更