### PR TITLE
[E2E Test] 全URLへの直接アクセス時の挙動を評価

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -147,12 +147,12 @@ class EditUserProfileAPIView(APIView):
 # todo: tmp, API and FBV -> CBV
 def get_user_info(request, nickname):
     if not nickname:
-        return redirect('/pong/')
+        return redirect('/accounts/login/')
 
     try:
         user = request.user
         if not user.is_authenticated:
-            return redirect(to='/pong/')
+            return redirect(to='/accounts/login/')
 
         info_user = CustomUser.objects.get(nickname=nickname)
         avatar_url = info_user.avatar.url
@@ -185,7 +185,7 @@ def get_user_info(request, nickname):
 
     except Exception as e:
         logging.error(f"API request failed: {e}")
-        return redirect('/pong/')
+        return redirect('/accounts/login/')
 
 
 class ChangeAvatarView(LoginRequiredMixin, TemplateView):

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
@@ -1,5 +1,8 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentManager.js
 import { config }	from '../ConfigTournament.js';
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { switchPage } from "/static/spa/js/routing/renderView.js"
+
 
 class TournamentManager 
 {
@@ -104,7 +107,7 @@ class TournamentManager
 
 	/** ゲストユーザーへ表示する内容 */
 	_handleGuestUser() {
-		window.location.href = "/login/"  // loginへ移動
+		switchPage(routeTable['login'].path)
 		// document.getElementById('tournament-container').innerHTML = `
 		// 	<p>Please log in to manage or create tournaments.</p>
 		// 	<p><a href="/accounts/login">Log in</a> or <a href="/accounts/signup">Sign up</a></p>

--- a/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
@@ -1,4 +1,38 @@
 <hr>
+<h4>SPA-LINKS</h4>
+<ul class="dev-link">
+	<li><a href="https://localhost/app/" class="nav__link" data-link>kSpaPongTopUrl</a></li>
+	<li><a href="https://localhost/app/home/" class="nav__link" data-link>kSpaHomeUrl</a></li>
+	<hr>
+	<li><a href="https://localhost/app/game/tournament/" class="nav__link" data-link>kSpaTournamentUrl</a></li>
+	<li><a href="https://localhost/app/game/game-2d/" class="nav__link" data-link>kSpaGame2D</a></li>
+	<li><a href="https://localhost/app/game/game-3d/" class="nav__link" data-link>kSpaGame3D</a></li>
+<!--	<li><a href="https://localhost/app/game/match/" class="nav__link" data-link>kSpaGameMatchBase</a></li>-->
+<!--	<li><a href="https://localhost/app/game/match/:matchId/" class="nav__link" data-link>kSpaGameMatchUrl</a></li>-->
+	<hr>
+	<li><a href="https://localhost/app/user/game-history/" class="nav__link" data-link>kSpaGameHistoryUrl</a></li>
+	<li><a href="https://localhost/app/user/profile/" class="nav__link" data-link>kSpaUserProfileUrl</a></li>
+	<li><a href="https://localhost/app/user/info/user2/" class="nav__link" data-link>kSpaUserInfoUrl->user2</a></li>
+<!--	<li><a href="https://localhost/app/user/info/" class="nav__link" data-link>kSpaUserInfoUrlBase</a></li>-->
+	<li><a href="https://localhost/app/user/friends/" class="nav__link" data-link>kSpaUserFriendUrl</a></li>
+	<li><a href="https://localhost/app/user/profile/edit/" class="nav__link" data-link>kSpaEditProfileUrl</a></li>
+	<li><a href="https://localhost/app/user/profile/change-avatar/" class="nav__link" data-link>kSpaChangeAvatarUrl</a></li>
+	<hr>
+	<li><a href="https://localhost/app/dm/" class="nav__link" data-link>kSpaDmUrl</a></li>
+	<li><a href="https://localhost/app/dm/user2" class="nav__link" data-link>kSpaDmWithUrl->user2</a></li>
+<!--	<li><a href="https://localhost/app/dm/" class="nav__link" data-link>kSpaDmWithUrlBase</a></li>-->
+	<hr>
+	<li><a href="https://localhost/app/auth/enable-2fa/" class="nav__link" data-link>kSpaAuthEnable2FaUrl</a></li>
+	<li><a href="https://localhost/app/auth/verify-2fa/" class="nav__link" data-link>kSpaAuthVerify2FaUrl</a></li>
+	<li><a href="https://localhost/app/auth/signup/" class="nav__link" data-link>kSpaAuthSignupUrl</a></li>
+	<li><a href="https://localhost/app/auth/login/" class="nav__link" data-link>kSpaAuthLoginUrl</a></li>
+	<hr>
+	<li><a href="https://localhost/app/game/match/1" class="nav__link" data-link>Nothing-GameMatch</a></li>
+	<li><a href="https://localhost/app/user/info/nothing" class="nav__link" data-link>Nothing-UserInfo</a></li>
+	<li><a href="https://localhost/app/dm/nothing" class="nav__link" data-link>Nothing-DM</a></li>
+	<li><a href="https://localhost/app/nothing" class="nav__link" data-link>Nothing-page</a></li>
+	<hr>
+</ul>
 <h4>Server/pong</h4>
 <ul class="dev-link">
 	<li><a href="https://localhost/pong" class="nav__link" data-link>Nginx https</a></li>
@@ -20,7 +54,6 @@
 	<li><a href="/pong/online/" class="nav__link" data-link>pong/online/</a></li>
 	<li><a href="/app/game/game-3d/" class="nav__link" data-link>/app/game/game-3d/</a></li>
 	<li><a href="/app/home/" class="nav__link" data-link>/app/home/</a></li>
-	
 </ul>
 <h5>MEMO:TODO_ft</h5>
 <ul class="dev-link">

--- a/docker/srcs/uwsgi-django/pong/views/navi_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/navi_views.py
@@ -31,6 +31,9 @@ def pong_view(request):
 
 # 3D
 def play_tournament(request, match_id):
+	if not request.user.is_authenticated:
+		return redirect(to='/accounts/login/')
+
 	match = get_object_or_404(Match, id=match_id)
 	match_data = {
 		"id": match.id,

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -234,10 +234,11 @@ class TestConfig(LiveServerTestCase):
                 else:
                     raise
 
-    def _access_to(self, url):
+    def _access_to(self, url, wait_to_be_url=True):
         self.driver.get(url)
         time.sleep(0.1)  # 明示的に待機
-        self._wait_to_be_url(url)
+        if wait_to_be_url:
+            self._wait_to_be_url(url)
 
     def _click_link(self, target, wait_for_link_invisible=False):
         url = target.get_attribute("href")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -176,6 +176,14 @@ class TestConfig(LiveServerTestCase):
         self._wait_display_message(expected_message)
         self.assertEqual(message_area.text, expected_message)
 
+    def _assert_is_2fa_enabled(self, expected_2fa_enabled: bool):
+        twofa_status_element = self._element(By.ID, "2fa-status")
+        actual_status_text = twofa_status_element.text
+
+        # Disable2FA, Enable2FAリンク含む要素になっている
+        expected_status_text = "2FA: ✅Enabled Disable2FA" if expected_2fa_enabled else "2FA: Disabled Enable2FA"
+        self.assertEqual(actual_status_text, expected_status_text)
+
     ############################################################################
     # ページ遷移、操作 要素
 
@@ -226,6 +234,7 @@ class TestConfig(LiveServerTestCase):
 
     def _access_to(self, url):
         self.driver.get(url)
+        time.sleep(0.1)  # 明示的に待機
         self._wait_to_be_url(url)
 
     def _click_link(self, target, wait_for_link_invisible=False):
@@ -327,7 +336,7 @@ class TestConfig(LiveServerTestCase):
         self._wait_invisible(logout_page_button)
         # self._screenshot("logout 2")
 
-    def _create_new_user(self, email, nickname, password):
+    def _create_new_user(self, email, nickname, password, is_enable_2fa=False):
         self._move_top_to_signup()
 
         self._send_to_elem(By.ID, "email", email)
@@ -337,7 +346,51 @@ class TestConfig(LiveServerTestCase):
 
         signup_button = self._element(By.ID, "sign-submit")
         self._click_button(signup_button, wait_for_button_invisible=True)
+
+        if is_enable_2fa:
+            self._move_top_to_profile()
+            self._setting_enable_2fa()
+            self._assert_is_2fa_enabled(expected_2fa_enabled=True)
+
         self._logout()
+
+    def _setting_enable_2fa(self):
+        """
+        user profile pageから2FAを有効にする
+        """
+        # user profile page -> enable2fa page
+        enable2fa_link = self._text_link("Enable2FA")
+        self.assertTrue(enable2fa_link.text, "Enable2FA")
+        self._click_link(enable2fa_link)
+        self._assert_current_url(self.enable_2fa_url)
+
+        # あらかじめbutton要素を取得しておく
+        enable2ba_button = self._button(By.CSS_SELECTOR, ".verifyTokenButton")
+
+        set_up_key_element = self._element(By.CSS_SELECTOR, ".pb-1")
+        set_up_key = set_up_key_element.text
+
+        # otpを送信（11 sec以上の余裕あり）
+        otp_token = self._get_otp_token(set_up_key)
+        self._send_to_elem(By.ID, "token", otp_token)
+
+        # 有効化
+        self._click_button(enable2ba_button)
+        return set_up_key
+
+    def _get_otp_token(self, set_up_key: str):
+        update_interval = 30
+        current_timestamp = int(time.time())
+        remaining_sec = update_interval - (current_timestamp % update_interval)
+
+        # otpの更新まで10sec以上を保証（html要素取得のdefault timeout = 10sec）
+        if remaining_sec <= 10:
+            time.sleep(remaining_sec + 1)
+
+        totp = TOTP(set_up_key)
+        otp_token = totp.now()
+        # print(f"otp_token: {otp_token}")
+        return otp_token
 
     def _send_dm_with_form(self, target_nickname):
         self._send_to_elem(By.ID, "nickname-input", target_nickname)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -19,6 +19,10 @@ from django.conf import settings
 from django.test import LiveServerTestCase
 from accounts.models import CustomUser
 
+# uwsgi-djangoコンテナからアクセスできないためnginxコンテナ経由とする
+kURL_PREFIX = "https://nginx"
+#                            ^^^^ /app/などのURL要素をurl_configと比較評価する
+
 # test_*.pyで使用するために__all__にも定義
 __all__ = [
     'json', 'datetime', 'random', 'string', 'time',
@@ -29,11 +33,9 @@ __all__ = [
     'TOTP',
     'settings', 'LiveServerTestCase', 'CustomUser',
     'TestConfig',
+    'kURL_PREFIX',
 ]
 
-# uwsgi-djangoコンテナからアクセスできないためnginxコンテナ経由とする
-kURL_PREFIX = "https://nginx"
-#                            ^^^^ /app/などのURL要素をurl_configと比較評価する
 
 # selemiumのlink.click()が失敗するため、JSによるクリック↓ を使用する
 # self.driver.execute_script("arguments[0].click();", link)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -226,6 +226,7 @@ class TestConfig(LiveServerTestCase):
 
     def _access_to(self, url):
         self.driver.get(url)
+        self._wait_to_be_url(url)
 
     def _click_link(self, target, wait_for_link_invisible=False):
         url = target.get_attribute("href")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -350,12 +350,16 @@ class TestConfig(LiveServerTestCase):
         signup_button = self._element(By.ID, "sign-submit")
         self._click_button(signup_button, wait_for_button_invisible=True)
 
+        set_up_key = None
         if is_enable_2fa:
+            self.driver.refresh()
             self._move_top_to_profile()
-            self._setting_enable_2fa()
+            self.driver.refresh()
+            set_up_key = self._setting_enable_2fa()
             self._assert_is_2fa_enabled(expected_2fa_enabled=True)
 
         self._logout()
+        return set_up_key
 
     def _setting_enable_2fa(self):
         """
@@ -380,6 +384,14 @@ class TestConfig(LiveServerTestCase):
         # 有効化
         self._click_button(enable2ba_button)
         return set_up_key
+
+    def _verify_login_2fa(self, set_up_key: str):
+        verify2fa_button = self._button(By.CSS_SELECTOR, ".verify2FaButton")
+
+        otp_token = self._get_otp_token(set_up_key)
+        self._send_to_elem(By.ID, "token", otp_token)
+
+        self._click_button(verify2fa_button)
 
     def _get_otp_token(self, set_up_key: str):
         update_interval = 30

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_2fa.py
@@ -74,11 +74,3 @@ class TwoFactorAuthTest(TestConfig):
         self._click_button(disable2fa_button, wait_for_button_invisible=False)
         self._close_alert("Are you sure you want to Disable2FA ?")
         self._close_alert("2FA disable successful")
-
-    def _verify_login_2fa(self, set_up_key: str):
-        verify2fa_button = self._button(By.CSS_SELECTOR, ".verify2FaButton")
-
-        otp_token = self._get_otp_token(set_up_key)
-        self._send_to_elem(By.ID, "token", otp_token)
-
-        self._click_button(verify2fa_button)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_2fa.py
@@ -57,38 +57,6 @@ class TwoFactorAuthTest(TestConfig):
         # verify2faではなくtopに遷移
         self._assert_current_url(self.top_url)
 
-    def _assert_is_2fa_enabled(self, expected_2fa_enabled: bool):
-        twofa_status_element = self._element(By.ID, "2fa-status")
-        actual_status_text = twofa_status_element.text
-
-        # Disable2FA, Enable2FAリンク含む要素になっている
-        expected_status_text = "2FA: ✅Enabled Disable2FA" if expected_2fa_enabled else "2FA: Disabled Enable2FA"
-        self.assertEqual(actual_status_text, expected_status_text)
-
-    def _setting_enable_2fa(self):
-        """
-        user profile pageから2FAを有効にする
-        """
-        # user profile page -> enable2fa page
-        enable2fa_link = self._text_link("Enable2FA")
-        self.assertTrue(enable2fa_link.text, "Enable2FA")
-        self._click_link(enable2fa_link)
-        self._assert_current_url(self.enable_2fa_url)
-
-        # あらかじめbutton要素を取得しておく
-        enable2ba_button = self._button(By.CSS_SELECTOR, ".verifyTokenButton")
-
-        set_up_key_element = self._element(By.CSS_SELECTOR, ".pb-1")
-        set_up_key = set_up_key_element.text
-
-        # otpを送信（11 sec以上の余裕あり）
-        otp_token = self._get_otp_token(set_up_key)
-        self._send_to_elem(By.ID, "token", otp_token)
-
-        # 有効化
-        self._click_button(enable2ba_button)
-        return set_up_key
-
     def _setting_disable_2fa(self):
         """
         user profile pageから2FAを無効にする
@@ -106,20 +74,6 @@ class TwoFactorAuthTest(TestConfig):
         self._click_button(disable2fa_button, wait_for_button_invisible=False)
         self._close_alert("Are you sure you want to Disable2FA ?")
         self._close_alert("2FA disable successful")
-
-    def _get_otp_token(self, set_up_key: str):
-        update_interval = 30
-        current_timestamp = int(time.time())
-        remaining_sec = update_interval - (current_timestamp % update_interval)
-
-        # otpの更新まで10sec以上を保証（html要素取得のdefault timeout = 10sec）
-        if remaining_sec <= 10:
-            time.sleep(remaining_sec + 1)
-
-        totp = TOTP(set_up_key)
-        otp_token = totp.now()
-        # print(f"otp_token: {otp_token}")
-        return otp_token
 
     def _verify_login_2fa(self, set_up_key: str):
         verify2fa_button = self._button(By.CSS_SELECTOR, ".verify2FaButton")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -76,7 +76,7 @@ class UrlAccessTest(TestConfig):
             url = self._get_url(page_name, page_path)
             self._access_to(url)
             time.sleep(0.5)  # 明示的に待機
-            self._screenshot(f"user1_{page_name}")
+            # self._screenshot(f"user1_{page_name}")
 
             if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
                 expected_url = self.top_url

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -1,52 +1,142 @@
-import time
-
 from . import *
-
-kURL_PREFIX = "https://nginx"
 
 
 class UrlAccessTest(TestConfig):
-    # def test_access_by_guest(self):
-    #     for page_name, page_path in self.url_config.items():
-    #         url = f"{kURL_PREFIX}{page_path}"
-    #         print(f"{page_name} {page_path}")
-    #
-    #         # url with `:param`
-    #         if self._is_url_base_with_param(page_name):
-    #             continue
-    #         if self._is_url_with_param(page_name):
-    #             url = f"{kURL_PREFIX}{self.url_config[page_name]}user2/"
-    #
-    #         self._access_to(url)
-    #         time.sleep(1)
-    #
-    #         self._screenshot(f"test_access_by_guest_{page_name}")
-    #
-    #         if self._login_required_page(page_name):
-    #             self._is_login_page()
-    #         else:
-    #             self._assert_current_url(url)
+    def setUp(self):
+        super().setUp()
 
-    def test_access_by_user(self):
-        self._login_user1_from_top_page()
+        self.user1_nickname = self._generate_random_string(20)
+        self.user1_email = f"{self.user1_nickname}@example.com"
+
+        self.user2_nickname = self._generate_random_string(20)
+        self.user2_email = f"{self.user2_nickname}@example.com"
+
+        # 2FA Enable user
+        self.user3_nickname = self._generate_random_string(30)
+        self.user3_email = f"{self.user3_nickname}@example.com"
+
+        self.password = "pass0123"
+
+        self._create_new_user(email=self.user1_email,
+                              nickname=self.user1_nickname,
+                              password=self.password)
+
+        self._create_new_user(email=self.user2_email,
+                              nickname=self.user2_nickname,
+                              password=self.password)
+
+        self._create_new_user(email=self.user3_email,
+                              nickname=self.user3_nickname,
+                              password=self.password,
+                              is_enable_2fa=True)
+
+    ############################################################################
+
+    def test_access_by_guest(self):
+        print(f"[GUEST]")
+        for page_name, page_path in self.url_config.items():
+            print(f" [Testing] page_name    : {page_name}")
+            print(f"           page_path    : {page_path}")
+
+            if self._except_test_page(page_name):
+                print(f"           skip")
+                continue
+
+            url = self._get_url(page_name, page_path)
+            self._access_to(url)
+            time.sleep(0.5)  # 明示的に待機
+            # self._screenshot(f"guest_{page_name}")
+
+            if self._is_page_login_required(page_name):
+                expected_url = self.login_url
+            elif self._is_url_with_param(page_name):
+                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            else:
+                expected_url = f"{kURL_PREFIX}{page_path}"
+
+            print(f"           expected_url : {expected_url}")
+            print(f"           current_url  : {self.driver.current_url}")
+            self._assert_current_url(expected_url)
+
+    def test_access_by_2fa_disabled_user_(self):
+        """
+        2FA無効userでのアクセス
+        """
+        print(f"[USER: 2FA Disabled]")
+        self._login(email=self.user1_email, password=self.password)
 
         for page_name, page_path in self.url_config.items():
-            url = f"{kURL_PREFIX}{page_path}"
+            print(f" [Testing] page_name    : {page_name}")
+            print(f"           page_path    : {page_path}")
 
-            # url with `:param`
-            if self._is_url_base_with_param(page_name):
+            if self._except_test_page(page_name):
+                print(f"           skip")
                 continue
-            if self._is_url_with_param(page_name):
-                url = f"{kURL_PREFIX}{self.url_config[page_name]}user2/"
 
+            url = self._get_url(page_name, page_path)
             self._access_to(url)
-            self._assert_current_url(url)
+            time.sleep(0.5)  # 明示的に待機
+            self._screenshot(f"user1_{page_name}")
 
-    def _login_required_page(self, page_name):
-        login_required_page_names = {
+            if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
+                expected_url = self.top_url
+            elif self._is_url_with_param(page_name):
+                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            else:
+                expected_url = f"{kURL_PREFIX}{page_path}"
+
+            print(f"           expected_url : {expected_url}")
+            print(f"           current_url  : {self.driver.current_url}")
+            self._assert_current_url(expected_url)
+
+    def test_access_by_2fa_enabled_user(self):
+        """
+        2FA有効userでのアクセス
+        """
+        print(f"[USER: 2FA Enabled]")
+        self._login(email=self.user1_email, password=self.password)
+
+        for page_name, page_path in self.url_config.items():
+            print(f" [Testing] page_name    : {page_name}")
+            print(f"           page_path    : {page_path}")
+
+            if self._except_test_page(page_name, page_name):
+                print(f"           skip")
+                continue
+
+            url = self._get_url(page_name, page_path)
+            self._access_to(url)
+            time.sleep(0.5)  # 明示的に待機
+            # self._screenshot(f"user3_{page_name}")
+
+            if self._is_page_redirect_to_top(page_name, is_enable_2fa=True):
+                expected_url = self.top_url
+            elif self._is_url_with_param(page_name):
+                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            else:
+                expected_url = f"{kURL_PREFIX}{page_path}"
+
+            print(f"           expected_url : {expected_url}")
+            print(f"           current_url  : {self.driver.current_url}")
+            self._assert_current_url(expected_url)
+
+    def _except_test_page(self, page_name):
+        """
+        本テストから除外するurl
+        """
+        except_test_pages = {
+            "kSpaGameMatchBase",
+            "kSpaGameMatchUrl",
+            "kSpaUserInfoUrl",
+            "kSpaDmWithUrl",
+        }
+        return page_name in except_test_pages
+
+    def _is_page_login_required(self, page_name):
+        login_required_pages = {
             "kSpaTournamentUrl",
             # "kSpaGame3D",
-            # "kSpaGameHistoryUrl",
+            "kSpaGameHistoryUrl",
             "kSpaUserProfileUrl",
             "kSpaUserInfoUrl",
             "kSpaUserFriendUrl",
@@ -59,21 +149,34 @@ class UrlAccessTest(TestConfig):
             "kSpaAuthSignupUrl",
             "kSpaAuthLoginUrl",
         }
-        return page_name in login_required_page_names
+        return page_name in login_required_pages
+
+    def _is_page_redirect_to_top(self, page_name, is_enable_2fa):
+        if is_enable_2fa:
+            login_user_redirect_to_top_pages = {
+                "kSpaAuthEnable2FaUrl",
+                "kSpaAuthVerify2FaUrl",
+                "kSpaAuthSignupUrl",
+                "kSpaAuthLoginUrl",
+            }
+        else:
+            login_user_redirect_to_top_pages = {
+                "kSpaAuthVerify2FaUrl",
+                "kSpaAuthSignupUrl",
+                "kSpaAuthLoginUrl",
+            }
+        return page_name in login_user_redirect_to_top_pages
 
     def _is_url_with_param(self, page_name):
-        url_with_param_page_names = {
-            "kSpaDmWithUrl",
-            "kSpaDmWithUrl",
-        }
-        return page_name in url_with_param_page_names
-
-    def _is_url_base_with_param(self, page_name):
-        url_base_with_param_page_names = {
-            "kSpaDmWithUrlBase",
+        """
+        `/url/:param` を検証するケース
+        UrlBaseにparamを結合する
+        """
+        url_with_param_pages = {
+            "kSpaUserInfoUrlBase",
             "kSpaDmWithUrlBase",
         }
-        return page_name in url_base_with_param_page_names
+        return page_name in url_with_param_pages
 
     def _is_login_page(self):
         """
@@ -81,3 +184,10 @@ class UrlAccessTest(TestConfig):
         """
         login_button = self._element(By.ID, "login-btn")
         self.assertTrue(login_button.is_displayed())
+
+    def _get_url(self, page_name, page_path):
+        if self._is_url_with_param(page_name):
+            url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+        else:
+            url = f"{kURL_PREFIX}{page_path}"
+        return url

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -43,7 +43,7 @@ class UrlAccessTest(TestConfig):
                 continue
 
             url = self._get_url(page_name, page_path)
-            self._access_to(url)
+            self._access_to(url, wait_to_be_url=False)
             time.sleep(0.5)  # 明示的に待機
             # self._screenshot(f"guest_{page_name}")
 
@@ -56,69 +56,88 @@ class UrlAccessTest(TestConfig):
 
             print(f"           expected_url : {expected_url}")
             print(f"           current_url  : {self.driver.current_url}")
-            self._assert_current_url(expected_url)
+            # self._assert_current_url(expected_url)
 
-    def test_access_by_2fa_disabled_user_(self):
-        """
-        2FA無効userでのアクセス
-        """
-        print(f"[USER: 2FA Disabled]")
-        self._login(email=self.user1_email, password=self.password)
-
-        for page_name, page_path in self.url_config.items():
-            print(f" [Testing] page_name    : {page_name}")
-            print(f"           page_path    : {page_path}")
-
-            if self._except_test_page(page_name):
-                print(f"           skip")
-                continue
-
-            url = self._get_url(page_name, page_path)
-            self._access_to(url)
-            time.sleep(0.5)  # 明示的に待機
-            # self._screenshot(f"user1_{page_name}")
-
-            if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
-                expected_url = self.top_url
-            elif self._is_url_with_param(page_name):
-                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            # 無理やり表示内容を評価
+            if expected_url == self.login_url:
+                self._is_login_page()
             else:
-                expected_url = f"{kURL_PREFIX}{page_path}"
+                self._assert_current_url(expected_url)
 
-            print(f"           expected_url : {expected_url}")
-            print(f"           current_url  : {self.driver.current_url}")
-            self._assert_current_url(expected_url)
-
-    def test_access_by_2fa_enabled_user(self):
-        """
-        2FA有効userでのアクセス
-        """
-        print(f"[USER: 2FA Enabled]")
-        self._login(email=self.user1_email, password=self.password)
-
-        for page_name, page_path in self.url_config.items():
-            print(f" [Testing] page_name    : {page_name}")
-            print(f"           page_path    : {page_path}")
-
-            if self._except_test_page(page_name, page_name):
-                print(f"           skip")
-                continue
-
-            url = self._get_url(page_name, page_path)
-            self._access_to(url)
-            time.sleep(0.5)  # 明示的に待機
-            # self._screenshot(f"user3_{page_name}")
-
-            if self._is_page_redirect_to_top(page_name, is_enable_2fa=True):
-                expected_url = self.top_url
-            elif self._is_url_with_param(page_name):
-                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
-            else:
-                expected_url = f"{kURL_PREFIX}{page_path}"
-
-            print(f"           expected_url : {expected_url}")
-            print(f"           current_url  : {self.driver.current_url}")
-            self._assert_current_url(expected_url)
+    # def test_access_by_2fa_disabled_user_(self):
+    #     """
+    #     2FA無効userでのアクセス
+    #     """
+    #     print(f"[USER: 2FA Disabled]")
+    #     self._login(email=self.user1_email, password=self.password)
+    #
+    #     for page_name, page_path in self.url_config.items():
+    #         print(f" [Testing] page_name    : {page_name}")
+    #         print(f"           page_path    : {page_path}")
+    #
+    #         if self._except_test_page(page_name):
+    #             print(f"           skip")
+    #             continue
+    #
+    #         url = self._get_url(page_name, page_path)
+    #         self._access_to(url, wait_to_be_url=False)
+    #         time.sleep(0.5)  # 明示的に待機
+    #         # self._screenshot(f"user1_{page_name}")
+    #
+    #         if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
+    #             expected_url = self.top_url
+    #         elif self._is_url_with_param(page_name):
+    #             expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+    #         else:
+    #             expected_url = f"{kURL_PREFIX}{page_path}"
+    #
+    #         print(f"           expected_url : {expected_url}")
+    #         print(f"           current_url  : {self.driver.current_url}")
+    #         # self._assert_current_url(expected_url)
+    #
+    #         # 無理やり表示内容を評価
+    #         if expected_url == self.top_url:
+    #             self._is_top_page()
+    #         else:
+    #             self._assert_current_url(expected_url)
+    #
+    #
+    # def test_access_by_2fa_enabled_user(self):
+    #     """
+    #     2FA有効userでのアクセス
+    #     """
+    #     print(f"[USER: 2FA Enabled]")
+    #     self._login(email=self.user1_email, password=self.password)
+    #
+    #     for page_name, page_path in self.url_config.items():
+    #         print(f" [Testing] page_name    : {page_name}")
+    #         print(f"           page_path    : {page_path}")
+    #
+    #         if self._except_test_page(page_name, page_name):
+    #             print(f"           skip")
+    #             continue
+    #
+    #         url = self._get_url(page_name, page_path)
+    #         self._access_to(url, wait_to_be_url=False)
+    #         time.sleep(0.5)  # 明示的に待機
+    #         # self._screenshot(f"user3_{page_name}")
+    #
+    #         if self._is_page_redirect_to_top(page_name, is_enable_2fa=True):
+    #             expected_url = self.top_url
+    #         elif self._is_url_with_param(page_name):
+    #             expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+    #         else:
+    #             expected_url = f"{kURL_PREFIX}{page_path}"
+    #
+    #         print(f"           expected_url : {expected_url}")
+    #         print(f"           current_url  : {self.driver.current_url}")
+    #         # self._assert_current_url(expected_url)
+    #
+    #         # 無理やり表示内容を評価
+    #         if expected_url == self.top_url:
+    #             self._is_top_page()
+    #         else:
+    #             self._assert_current_url(expected_url)
 
     def _except_test_page(self, page_name):
         """
@@ -146,8 +165,6 @@ class UrlAccessTest(TestConfig):
             "kSpaDmWithUrl",
             "kSpaAuthEnable2FaUrl",
             "kSpaAuthVerify2FaUrl",
-            "kSpaAuthSignupUrl",
-            "kSpaAuthLoginUrl",
         }
         return page_name in login_required_pages
 
@@ -180,10 +197,17 @@ class UrlAccessTest(TestConfig):
 
     def _is_login_page(self):
         """
-        login buttonが表示されている場合はlogin pageとみなす
+        'Please log in'が表示されている場合はlogin pageとみなす
         """
-        login_button = self._element(By.ID, "login-btn")
-        self.assertTrue(login_button.is_displayed())
+        h1_element = self._element(By.CSS_SELECTOR, "h1.slideup-text")
+        self.assertIn("Please log in", h1_element.text)
+
+    def _is_top_page(self):
+        """
+        'Unrivaled hth Pong Experience'が表示されている場合は/app/とみなす
+        """
+        h2_element = self._element(By.CSS_SELECTOR, "h2.slideup-text.text-shadow-primary")
+        self.assertIn("Unrivaled hth Pong Experience", h2_element.text)
 
     def _get_url(self, page_name, page_path):
         if self._is_url_with_param(page_name):

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -1,0 +1,83 @@
+import time
+
+from . import *
+
+kURL_PREFIX = "https://nginx"
+
+
+class UrlAccessTest(TestConfig):
+    # def test_access_by_guest(self):
+    #     for page_name, page_path in self.url_config.items():
+    #         url = f"{kURL_PREFIX}{page_path}"
+    #         print(f"{page_name} {page_path}")
+    #
+    #         # url with `:param`
+    #         if self._is_url_base_with_param(page_name):
+    #             continue
+    #         if self._is_url_with_param(page_name):
+    #             url = f"{kURL_PREFIX}{self.url_config[page_name]}user2/"
+    #
+    #         self._access_to(url)
+    #         time.sleep(1)
+    #
+    #         self._screenshot(f"test_access_by_guest_{page_name}")
+    #
+    #         if self._login_required_page(page_name):
+    #             self._is_login_page()
+    #         else:
+    #             self._assert_current_url(url)
+
+    def test_access_by_user(self):
+        self._login_user1_from_top_page()
+
+        for page_name, page_path in self.url_config.items():
+            url = f"{kURL_PREFIX}{page_path}"
+
+            # url with `:param`
+            if self._is_url_base_with_param(page_name):
+                continue
+            if self._is_url_with_param(page_name):
+                url = f"{kURL_PREFIX}{self.url_config[page_name]}user2/"
+
+            self._access_to(url)
+            self._assert_current_url(url)
+
+    def _login_required_page(self, page_name):
+        login_required_page_names = {
+            "kSpaTournamentUrl",
+            # "kSpaGame3D",
+            # "kSpaGameHistoryUrl",
+            "kSpaUserProfileUrl",
+            "kSpaUserInfoUrl",
+            "kSpaUserFriendUrl",
+            "kSpaEditProfileUrl",
+            "kSpaChangeAvatarUrl",
+            "kSpaDmUrl",
+            "kSpaDmWithUrl",
+            "kSpaAuthEnable2FaUrl",
+            "kSpaAuthVerify2FaUrl",
+            "kSpaAuthSignupUrl",
+            "kSpaAuthLoginUrl",
+        }
+        return page_name in login_required_page_names
+
+    def _is_url_with_param(self, page_name):
+        url_with_param_page_names = {
+            "kSpaDmWithUrl",
+            "kSpaDmWithUrl",
+        }
+        return page_name in url_with_param_page_names
+
+    def _is_url_base_with_param(self, page_name):
+        url_base_with_param_page_names = {
+            "kSpaDmWithUrlBase",
+            "kSpaDmWithUrlBase",
+        }
+        return page_name in url_base_with_param_page_names
+
+    def _is_login_page(self):
+        """
+        login buttonが表示されている場合はlogin pageとみなす
+        """
+        login_button = self._element(By.ID, "login-btn")
+        self.assertTrue(login_button.is_displayed())

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -25,7 +25,8 @@ class UrlAccessTest(TestConfig):
                               nickname=self.user2_nickname,
                               password=self.password)
 
-        self._create_new_user(email=self.user3_email,
+        self.set_up_key = self._create_new_user(
+                              email=self.user3_email,
                               nickname=self.user3_nickname,
                               password=self.password,
                               is_enable_2fa=True)
@@ -61,83 +62,86 @@ class UrlAccessTest(TestConfig):
             # 無理やり表示内容を評価
             if expected_url == self.login_url:
                 self._is_login_page()
+                print(f"           expected login: ok")
             else:
                 self._assert_current_url(expected_url)
 
-    # def test_access_by_2fa_disabled_user_(self):
-    #     """
-    #     2FA無効userでのアクセス
-    #     """
-    #     print(f"[USER: 2FA Disabled]")
-    #     self._login(email=self.user1_email, password=self.password)
-    #
-    #     for page_name, page_path in self.url_config.items():
-    #         print(f" [Testing] page_name    : {page_name}")
-    #         print(f"           page_path    : {page_path}")
-    #
-    #         if self._except_test_page(page_name):
-    #             print(f"           skip")
-    #             continue
-    #
-    #         url = self._get_url(page_name, page_path)
-    #         self._access_to(url, wait_to_be_url=False)
-    #         time.sleep(0.5)  # 明示的に待機
-    #         # self._screenshot(f"user1_{page_name}")
-    #
-    #         if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
-    #             expected_url = self.top_url
-    #         elif self._is_url_with_param(page_name):
-    #             expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
-    #         else:
-    #             expected_url = f"{kURL_PREFIX}{page_path}"
-    #
-    #         print(f"           expected_url : {expected_url}")
-    #         print(f"           current_url  : {self.driver.current_url}")
-    #         # self._assert_current_url(expected_url)
-    #
-    #         # 無理やり表示内容を評価
-    #         if expected_url == self.top_url:
-    #             self._is_top_page()
-    #         else:
-    #             self._assert_current_url(expected_url)
-    #
-    #
-    # def test_access_by_2fa_enabled_user(self):
-    #     """
-    #     2FA有効userでのアクセス
-    #     """
-    #     print(f"[USER: 2FA Enabled]")
-    #     self._login(email=self.user1_email, password=self.password)
-    #
-    #     for page_name, page_path in self.url_config.items():
-    #         print(f" [Testing] page_name    : {page_name}")
-    #         print(f"           page_path    : {page_path}")
-    #
-    #         if self._except_test_page(page_name, page_name):
-    #             print(f"           skip")
-    #             continue
-    #
-    #         url = self._get_url(page_name, page_path)
-    #         self._access_to(url, wait_to_be_url=False)
-    #         time.sleep(0.5)  # 明示的に待機
-    #         # self._screenshot(f"user3_{page_name}")
-    #
-    #         if self._is_page_redirect_to_top(page_name, is_enable_2fa=True):
-    #             expected_url = self.top_url
-    #         elif self._is_url_with_param(page_name):
-    #             expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
-    #         else:
-    #             expected_url = f"{kURL_PREFIX}{page_path}"
-    #
-    #         print(f"           expected_url : {expected_url}")
-    #         print(f"           current_url  : {self.driver.current_url}")
-    #         # self._assert_current_url(expected_url)
-    #
-    #         # 無理やり表示内容を評価
-    #         if expected_url == self.top_url:
-    #             self._is_top_page()
-    #         else:
-    #             self._assert_current_url(expected_url)
+    def test_access_by_2fa_disabled_user_(self):
+        """
+        2FA無効userでのアクセス
+        """
+        print(f"[USER: 2FA Disabled]")
+        self._login(email=self.user1_email, password=self.password)
+
+        for page_name, page_path in self.url_config.items():
+            print(f" [Testing] page_name    : {page_name}")
+            print(f"           page_path    : {page_path}")
+
+            if self._except_test_page(page_name):
+                print(f"           skip")
+                continue
+
+            url = self._get_url(page_name, page_path)
+            self._access_to(url, wait_to_be_url=False)
+            time.sleep(0.5)  # 明示的に待機
+            # self._screenshot(f"user1_{page_name}")
+
+            if self._is_page_redirect_to_top(page_name, is_enable_2fa=False):
+                expected_url = self.top_url
+            elif self._is_url_with_param(page_name):
+                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            else:
+                expected_url = f"{kURL_PREFIX}{page_path}"
+
+            print(f"           expected_url : {expected_url}")
+            print(f"           current_url  : {self.driver.current_url}")
+            # self._assert_current_url(expected_url)
+
+            # 無理やり表示内容を評価
+            if expected_url == self.top_url:
+                self._is_top_page()
+                print(f"           expected top : ok")
+            else:
+                self._assert_current_url(expected_url)
+
+    def test_access_by_2fa_enabled_user(self):
+        """
+        2FA有効userでのアクセス
+        """
+        print(f"[USER: 2FA Enabled]")
+        self._login(email=self.user3_email, password=self.password)
+        self._verify_login_2fa(self.set_up_key)
+
+        for page_name, page_path in self.url_config.items():
+            print(f" [Testing] page_name    : {page_name}")
+            print(f"           page_path    : {page_path}")
+
+            if self._except_test_page(page_name):
+                print(f"           skip")
+                continue
+
+            url = self._get_url(page_name, page_path)
+            self._access_to(url, wait_to_be_url=False)
+            time.sleep(0.5)  # 明示的に待機
+            # self._screenshot(f"user3_{page_name}")
+
+            if self._is_page_redirect_to_top(page_name, is_enable_2fa=True):
+                expected_url = self.top_url
+            elif self._is_url_with_param(page_name):
+                expected_url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            else:
+                expected_url = f"{kURL_PREFIX}{page_path}"
+
+            print(f"           expected_url : {expected_url}")
+            print(f"           current_url  : {self.driver.current_url}")
+            # self._assert_current_url(expected_url)
+
+            # 無理やり表示内容を評価
+            if expected_url == self.top_url:
+                self._is_top_page()
+                print(f"           expected top : ok")
+            else:
+                self._assert_current_url(expected_url)
 
     def _except_test_page(self, page_name):
         """
@@ -199,6 +203,7 @@ class UrlAccessTest(TestConfig):
         """
         'Please log in'が表示されている場合はlogin pageとみなす
         """
+        self.driver.refresh()
         h1_element = self._element(By.CSS_SELECTOR, "h1.slideup-text")
         self.assertIn("Please log in", h1_element.text)
 
@@ -206,6 +211,7 @@ class UrlAccessTest(TestConfig):
         """
         'Unrivaled hth Pong Experience'が表示されている場合は/app/とみなす
         """
+        self.driver.refresh()
         h2_element = self._element(By.CSS_SELECTOR, "h2.slideup-text.text-shadow-primary")
         self.assertIn("Unrivaled hth Pong Experience", h2_element.text)
 


### PR DESCRIPTION
#168 

全URLへの直接アクセス時の挙動を評価 
- リンクを貼っていなくとも、URLコピペで移動できるため、念のために確認しておく
- 要認証ページではguestをloginにリダイレクト
- login済みuserはlogin -> /app/にリダイレクト
- ... などの挙動を確認

<br>

## SPA遷移確認済みのリダイレクト先
- guest, user(2fa on/off)の3パターンを検証
- `-`はURL通りの遷移
- `/url/`はリダイレクト先 page
  -  `o`でpage, urlともに移動
  - `△`でpageのみ移動, urlはリダイレクト前のまま
- `:nickname`は`user2`で検証 

| access url                                      | guest                      | user (2fa off )| user (2fa on) | 
|---------------------------------|-----------------------|----------|---------|
| /app/                                               |  -                                   |  -             |  -            |  
| /app/home/                                     |  -                                   |  -            |  -             | 
| /app/game/tournament/                | `o /app/auth/login/`    | -              | -              |
| /app/game/game-2d/                    |  -                                   |  -             |  -             | 
| /app/game/game-3d/                    |  -                                   |  -             |  -             | 
| /app/game/match/:matchId/         |  `△ /app/auth/login/`   |  -             |  -              | 
| /app/user/game-history/               |  `△ /app/auth/login/`   |  -             |  -              |  
| /app/user/profile/                           |  `△ /app/auth/login/`   |  -             |  -              | 
| /app/user/info/:nickname/             |  `△ /app/auth/login/`   |  -              |  -             | 
| /app/user/friends/                          |  `△ /app/auth/login/`   |  -              |  -             |
| /app/user/profile/edit/                   |  `△ /app/auth/login/`   |  -              |  -              | 
| /app/user/profile/change-avatar/ |  `△ /app/auth/login/`   |  -              |  -              |  
| /app/dm/                                        |  `△ /app/auth/login/`   |  -               |  -              |  
| /app/dm/:nickname                       |  `△ /app/auth/login/`   |  -               |  -              |  
| /app/auth/enable-2fa/                  |  `△ /app/auth/login/`   |  -               |  `△ /app/` | 
| /app/auth/verify-2fa/                    |  `△ /app/auth/login/`   |  `△ /app/` |  `△ /app/` | 
| /app/auth/signup/                         |  -                                    |  `△ /app/` |  `△ /app/` | 
| /app/auth/login/                            |  -                                    |  `△ /app/` |  `△ /app/` | 

<br>

## memo
- /app/home/は本番環境に持ち込まないと思うので、検証不要だったかも
- djangoのview関数でリダイレクトしている場合、switchPageを呼んでいないため、SPAエリアのみ更新されURLが上書きされない。厄介。許容する？ ~許容したとして、URLがリダイレクト先に上書きされないため、E2Eテストで評価しにくい...~
- 許容しない場合、django view関数がJSを呼び、JSでのレンダリングに統一する必要がある。移行は重め。template変数も使用不可になるため、ページに依り大幅変更が必要そう。
- 評価するurlはリダイレクト先/app/, /login/ or それ以外のため/app/, /login/はページ表示要素を照合して判断することに。とりあえずテスト完成
  https://github.com/42trans/ft_transcendence/blob/b2592e65e6e5c729e6a35ba9471301bfab631ff1/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py#L202-L216 

<br>

## 不具合（修正可否は要検討？）
- guestでTournament -> loginへリダイレクトされるため、ブラウザ戻るボタンでTournamentに戻る->loginが繰り返される。リダイレクトの仕様上しかたない？ djangoのview関数(`navi/views.tournament`)でguest userをloginにリダイレクトすればこれは解決するが、urlがloginにならなくなる