### PR TITLE
3D-ballServe-#169

### DIFF
--- a/docker/srcs/compose-yaml/compose-web.yaml
+++ b/docker/srcs/compose-yaml/compose-web.yaml
@@ -118,7 +118,10 @@ services:
     ports:
       - "${VITE_PORT:?}:5173"
     environment:
-      - NODE_ENV=development
+      # TODO_ft 
+      # - NODE_ENV=development
+      # - VITE_MODE=development
+      - VITE_MODE=production
     profiles:
       - three
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-main.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-main.css
@@ -1,5 +1,5 @@
 :root {
-	--header-height: 80px;
+	--header-height: 50px;
 	--footer-height: 50px;
 }
 

--- a/docker/srcs/uwsgi-django/pong/templates/pong/play-tournament.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/play-tournament.html
@@ -1,18 +1,7 @@
-{% extends 'base.html' %}
-{% load static %}
-{% block extra_css %}
-<link rel="stylesheet" crossorigin href="{% static 'pong/three/assets/index.css' %}">
-{% endblock %}
-{% block title %}Play - hth Pong{% endblock title %}
-{% block content %}
-	{% csrf_token %}
-	<canvas id="threejs-canvas-container"></canvas>
+<canvas id="threejs-canvas-container"></canvas>
 <script type="application/json" id="match-data">
 	{{ match_json|safe }}
 </script>	
 <script>
 	window.isDevServer = "{{ is_dev_server }}";
-	{% comment %} console.log('window.isDevServer', window.isDevServer); {% endcomment %}
 </script>
-<script type="module" crossorigin src="{% static 'pong/three/assets/index.js' %}"></script>
-{% endblock %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/pong-online.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/pong-online.html
@@ -1,5 +1,3 @@
-{% comment %} docker/srcs/uwsgi-django/pong/templates/pong/pong-online.html {% endcomment %}
 <canvas id="pong-online-canvas-container"></canvas>
 <button id="hth-pong-online-start-game-btn" class="hth-btn" >Start Game</button>
-{% comment %} <button id="hth-pong-online-start-game-btn" class="hth-btn" style="display: none;" >Start Game</button> {% endcomment %}
 <button id="hth-pong-online-back-to-home-btn" class="hth-btn mt-4" style="display: none;" >Back to Home</button>

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -114,11 +114,11 @@ class PongApp
 
 // errorが出るし、ページ遷移の問題は違う箇所で解消したのでコメントアウト
 // Three.jsのアニメーションループを制御するためのグローバルな関数を定義
-// window.controlThreeAnimation = {
-// 	stopAnimation: function() {
-// 		PongApp.getInstance().stopRenderLoop();
-// 	},
-// };
+window.controlThreeAnimation = {
+	stopAnimation: function() {
+		PongApp.getInstance().stopRenderLoop();
+	},
+};
 
 
 export default PongApp;

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -8,7 +8,7 @@ import AnimationMixersManager from './manager/AnimationMixersManager'
 import GameStateManager from './manager/GameStateManager'
 import LoopManager from './manager/LoopManager'
 import RendererManager from './manager/RendererManager'
-// import { routeTable } from "../static/spa/js/routing/routeTable.js";
+
 //dev用GUI
 import * as lil from 'lil-gui'; 
 import ControlsGUI from './ControlsGUI';
@@ -22,37 +22,9 @@ class PongApp
 	constructor(env) 
 	{
 		this.env = env;
-
-		// const matchDataElement = document.getElementById('match-data');
-		// if (matchDataElement) {
-		// 	this.matchData = JSON.parse(matchDataElement.textContent);
-		// 	console.log('Match Data:', this.matchData);
-		// }
-
-		// this.loadRouteTable().then(routeTable => {
-		// 	this.routeTable = routeTable;
-		// }).catch(error => {
-		// 	console.error('Failed to load route table:', error);
-		// });
-		// // ゲームの終了状態をチェックして、必要に応じてリダイレクト
-		// if (this.matchData && this.matchData.is_finished) {
-		// 	window.location.href = this.routeTable['tournament'].path;
-		// 	// window.location.href = 'https://localhost/app/game/tournament/';
-		// 	return;  // リダイレクト後の処理を停止
-		// }
-		
 		this.init();
 		this.boundInit = this.init.bind(this);
 		window.addEventListener('switchPageResetState', this.boundInit);
-		// // 無限ループでアニメーションの更新を担当。シングルトン
-		// this.renderLoop = LoopManager.getInstance(this);
-		// this.renderLoop.start();
-
-		// 			//dev用　index.jsで`PongApp.main('dev');`で呼び出す
-		// 			if (env === 'dev'){
-		// 				this.setupDevEnv();
-		// 			}
-
 	}
 
 	async loadRouteTable() {
@@ -85,11 +57,12 @@ class PongApp
 
 		this.routeTable = await this.loadRouteTable();
 
-		// ゲームの終了状態をチェックして、必要に応じてリダイレクト
+		// ゲームが終了状態の場合リダイレクト
 		if (this.matchData && this.matchData.is_finished) {
 			window.location.href = this.routeTable['top'].path;
 			// window.location.href = 'https://localhost/app/game/tournament/';
-			return;  // リダイレクト後の処理を停止
+			// リダイレクト後の処理を停止
+			return;
 		}
 
 		// ピクセルへの描画を担当。処理が重いので一つに制限。シングルトン
@@ -100,7 +73,7 @@ class PongApp
 		this.allScenesManager = AllScenesManager.getInstance(this.animationMixersManager);
 		// 3D空間（カメラ、照明、オブジェクト）を担当
 		// TODO_ft:開幕はモデルを読み込まないようにしたい。もう少し遅延できないものか。要設計
-		this.allScenesManager.setupScenes();
+		await this.allScenesManager.setupScenes();
 		// ゲームの状態（待機、Play、終了）を担当。シングルトン
 		this.gameStateManager = GameStateManager.getInstance(this, this.allScenesManager); 
 
@@ -111,9 +84,11 @@ class PongApp
 					//dev用　index.jsで`PongApp.main('dev');`で呼び出す
 					if (this.env === 'dev'){
 						this.setupDevEnv();
-					}
+					} 
+		
+		window.addEventListener('resize', this.allScenesManager.handleResize.bind(this.allScenesManager), false);
 	}
-
+	
 	stopRenderLoop() {
 		if (this.renderLoop) {
 			this.renderLoop.stop();
@@ -125,7 +100,6 @@ class PongApp
 	{
 		new PongApp(env);
 	}
-				// TODO_ft: dev用GUI: カメラと照明をコントロールするパネルを表示　レビュー時削除
 				setupDevEnv()
 				{
 					this.gui = new lil.GUI();
@@ -138,13 +112,13 @@ class PongApp
 				}
 }
 
-
+// errorが出るし、ページ遷移の問題は違う箇所で解消したのでコメントアウト
 // Three.jsのアニメーションループを制御するためのグローバルな関数を定義
-window.controlThreeAnimation = {
-	stopAnimation: function() {
-		PongApp.getInstance().stopRenderLoop();
-	},
-};
+// window.controlThreeAnimation = {
+// 	stopAnimation: function() {
+// 		PongApp.getInstance().stopRenderLoop();
+// 	},
+// };
 
 
 export default PongApp;

--- a/docker/srcs/vite/pong-three/src/js/config/PongEngineConfig.js
+++ b/docker/srcs/vite/pong-three/src/js/config/PongEngineConfig.js
@@ -4,6 +4,8 @@
  */
 
 import * as THREE from 'three';
+let TEST_MAX_PADDLE_HEIGHT = 0;
+let TEST_END_GAME = 1;
 
 /**
  * ゲームに必要な初期値を設定
@@ -15,6 +17,22 @@ class PongEngineConfig
 {
 	constructor() 
 	{
+		if (TEST_END_GAME)
+		{
+			this.ball_speed  = 9
+			this.max_score   = 1
+		} else {
+			this.ball_speed = 2
+			this.max_score   = 15
+		}
+		
+		if (TEST_MAX_PADDLE_HEIGHT)
+		{
+			this.paddle_height = 300
+		} else {
+			this.paddle_height = 30
+		}
+
 		this.fields = 
 		{
 			WIDTH: 400,
@@ -64,7 +82,8 @@ class PongEngineConfig
 				transparent: false,
 				opacity: 1.0,
 			},
-			SPEED: 2,
+			// SPEED: 2,
+			SPEED: this.ball_speed,
 			DIRECTION: { x: 1, y: 0.1 },
 			RECEIVE_SHADOW: true,
 			CAST_SHADOW: true,
@@ -73,8 +92,8 @@ class PongEngineConfig
 		this.paddle1 = 
 		{
 			WIDTH: 10,
-			// HEIGHT: this.fields.HEIGHT, //for psycs test
-			HEIGHT: 30,
+			// HEIGHT: 30,
+			HEIGHT: this.paddle_height,
 			DEPTH: 10,
 			SEGMENTS: 1,
 			MATERIAL: {
@@ -86,15 +105,15 @@ class PongEngineConfig
 			},
 			RECEIVE_SHADOW: true, 
 			CAST_SHADOW: true,
-			SPEED: 10, //  
+			SPEED: 10, 
 			DirY: 0,
 		};
 		
 		this.paddle2 = 
 		{
 			WIDTH: 10,
-			// HEIGHT: this.fields.HEIGHT,
-			HEIGHT: 30,
+			// HEIGHT: 30,
+			HEIGHT: this.paddle_height,
 			DEPTH: 10,
 			SEGMENTS: 1,
 			MATERIAL: {
@@ -113,10 +132,10 @@ class PongEngineConfig
 		this.gameSettings = 
 		{
 			// MAX_SCORE: 15,
-			MAX_SCORE: 5, // for test
-			INIT_BALL_SPEED: 2,
-			MAX_BALL_SPEED: 10, //10を超えると衝突判定がバグります
-			// TOD_ft:
+			MAX_SCORE: this.max_score,
+			INIT_BALL_SPEED: this.ball_speed,
+			// INIT_BALL_SPEED: 2,
+			MAX_BALL_SPEED: 9.9, //10を超えると衝突判定がバグります
 			ABSOLUTE_MAX_SPEED: 9.9, // init時にpddle.WIDTH を超えないよう補正されます。
 			DIFFICULTY: 0.5,
 		};

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
@@ -51,13 +51,13 @@ class PongEngine
 		this.update		= new PongEngineUpdate(this.data, this.physics, this.match);
 	}
 
-	animate() 
+	async animate() 
 	{
 		if (this.isRunning)
 		{
 			requestAnimationFrame(this.animate);
 		}
-		this.update.updateGame();
+		await this.update.updateGame();
 	}
 }
 

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineInit.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineInit.js
@@ -94,11 +94,11 @@ class PongEngineInit
 		Object.keys(this.objects).forEach(key => {
 			this.scene.add(this.objects[key]);
 		});
-		this.scene.traverse(obj => {
-			if (obj instanceof THREE.Mesh) {
-				console.log('Object in scene:', obj.name); // デバッグのためにオブジェクト名を出力
-			}
-		});
+		// this.scene.traverse(obj => {
+		// 	if (obj instanceof THREE.Mesh) {
+		// 		console.log('Object in scene:', obj.name); // デバッグのためにオブジェクト名を出力
+		// 	}
+		// });
 	}
 
 	// 参考:【MeshStandardMaterial – three.js docs】 <https://threejs.org/docs/#api/en/materials/MeshStandardMaterial>

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -7,18 +7,12 @@ import AllScenesManager from '../manager/AllScenesManager';
 import * as THREE from "three";
 import ZoomTable from '../effect/ZoomTable';
 
+let DEBUG_FLOW 		= 0;
+let DEBUG_DETAIL 	= 0;
+let TEST_TRY1 		= 0;
+
 class GameplayState extends BaseGameState 
 {
-	static zoomParams = 
-	{
-		zoomInDistance: 1000,
-		zoomOutDistance: 420,
-		duration: 1500,
-		pauseDuration: 100,
-		initialPolarAngle: Math.PI / 4,
-		finalPolarAngle: 0
-	};
-
 	constructor (PongApp)
 	{
 		super(PongApp);
@@ -26,22 +20,49 @@ class GameplayState extends BaseGameState
 		this.camera = this.scenesMgr.gameScene.camera;
 		this.controls = this.scenesMgr.gameScene.controls;
 	}
-	
+
+	static zoomParams = 
+	{
+		duration: 1500,
+		pauseDuration: 100,
+		initialPolarAngle: Math.PI / 4,
+		finalPolarAngle: 0
+	};
+
 	enter() 
 	{
-		// console.log("Entering GamePlay state");
+					if (DEBUG_FLOW){	console.log("Entering GamePlay state");	 };
 		this.scenesMgr.gameScene.refreshScene(new GameSceneConfig());
-		this.pongEngine = new PongEngine(this.PongApp);
+		this.pongEngine	= new PongEngine(this.PongApp);
+		this.camera 	= this.scenesMgr.getGameSceneCamera()
+					if (DEBUG_DETAIL)
+					{
+						console.log('this.camera.z', this.camera.position.z);
+						console.log('this.camera', this.camera);
+					}
+		this.scenesMgr.handleResize();
+					if (DEBUG_DETAIL)
+					{
+						console.log('this.camera.z', this.camera.position.z);
+						console.log('this.camera', this.camera);
+					}
+		const targetPosition = new THREE.Vector3();
+		// テーブルの中心位置を取得　実際は0,0,0
+		this.pongEngine.data.objects.plane.getWorldPosition(targetPosition); 
+		// 初期距離を計算
+		this.initialDistance = this.camera.position.distanceTo(targetPosition);
 
 		const zoomParams = 
 		{
 			...GameplayState.zoomParams,
-			targetPosition: new THREE.Vector3(),
-			startDistance: this.camera.position.distanceTo(new THREE.Vector3()), // Assuming some target position
+			zoomInDistance: this.initialDistance * 1.5,
+			zoomOutDistance: this.initialDistance * 0.5,
+			targetPosition: targetPosition,
+			initialDistance: this.initialDistance,
 		};
-		this.pongEngine.data.objects.plane.getWorldPosition(zoomParams.targetPosition);
 
-		const zoomController = new ZoomTable(
+		const zoomController = new ZoomTable
+		(
 			this.pongEngine,
 			this.camera,
 			this.controls
@@ -67,8 +88,7 @@ class GameplayState extends BaseGameState
 
 	exit() 
 	{
-		// console.log("Exiting GamePlay state");
-		// this.PongApp.allScenesManager.backgroundScene.clearScene();
+					if (DEBUG_FLOW){	console.log("Exiting GamePlay state");	 };
 		this.PongApp.allScenesManager.gameScene.clearScene();
 	}
 


### PR DESCRIPTION
#169
All Device:最初の描画がウィンドウサイズからはみ出てしまう件
ゲームテーブルだけズーム（カメラ位置）をウインドウサイズで別判定　=> オーラ球は画面いっぱいに描画されるキャンバスサイズ判定
テーブルの読み込みは状態パターンの遷移で遅れて行われるので、その行でリサイズ発火 (App.init()ではなく、ChangeState後のGameScene.entry()の位置)
アニメーションに使用されるパラメータをウィンドウサイズ起点での計算に変更

修正したバグ:
 サーブボールのリセット時方向 self.ball["direction"]["y"] = random.uniform(-0.5, 0.5)
 サーブボールの開始タイミングを少し遅らせる await asyncio.sleep(1)
 最初の描画がウィンドウサイズからはみ出る。
 リロード時、終了した試合がリセットされてしまう
 
 