### PR TITLE
[subject] SPA

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
@@ -2,6 +2,7 @@
 
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 export function loginUser(event) {
@@ -23,16 +24,15 @@ export function loginUser(event) {
 				document.getElementById('message-area').textContent = data.error;
 				if (data.redirect) {
 					alert(`Redirecting to ${data.redirect}. Check console logs before proceeding.`);  // debug
-					window.location.href = data.redirect;
-					// switchPage(data.redirect)
+					switchPage(data.redirect);
 				} else {
 					console.error('Error:', data.error);
 				}
 			} else if (data.message) {
 				// Verified
 				console.log(data.message);
-				window.location.href = data.redirect;
-				// switchPage(data.redirect)  // Redirect on successful verification
+				switchPage(data.redirect);  // Redirect on successful verification
+				updateHeader();
 			}
 		})
 		.catch(error => console.error('Error:', error));

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
@@ -3,6 +3,7 @@
 import { disconnectOnlineStatusWebSocket } from "./online-status.js";
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 function handleLogout() {
@@ -24,8 +25,8 @@ function handleLogout() {
 			disconnectOnlineStatusWebSocket(data.user_id)
 
 			// alert(`Redirecting to ${data.redirect}. Check console logs before proceeding.`);  // debug
-			window.location.href = data.redirect;
-			// switchPage(data.redirect)
+			switchPage(data.redirect);
+			updateHeader();
 		} else {
 			throw new Error('No message in response');
 		}
@@ -36,6 +37,17 @@ function handleLogout() {
 	});
 }
 
+
+export function setupLogoutEventListener() {
+	console.log("Setup logout event listeners");
+	const button = document.querySelector('.logoutButton');
+	if (button) {
+		button.addEventListener('click', function(event) {
+			event.preventDefault();
+			handleLogout();
+		});
+	}
+}
 
 // header
 document.addEventListener('DOMContentLoaded', function() {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
@@ -1,5 +1,6 @@
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 function signupUser(event) {
@@ -22,16 +23,15 @@ function signupUser(event) {
 			// Error
 			document.getElementById('message-area').textContent = data.error;
 			if (data.redirect) {
-				window.location.href = data.redirect;
-				// switchPage(data.redirect)
+				switchPage(data.redirect)
 			} else {
 				console.error('Error:', data.error);
 			}
 		} else if (data.message) {
 			// Verified
 			console.log(data.message);
-			window.location.href = data.redirect;
-			// switchPage(data.redirect)  // Redirect on successful verification
+			switchPage(data.redirect)  // Redirect on successful verification
+			updateHeader();
 		}
 	})
 	.catch(error => console.error('Error:', error));

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
@@ -1,4 +1,8 @@
 // verify_2fa.js
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
+
 
 function verify2FA() {
 	const token = document.getElementById('token').value;
@@ -15,14 +19,15 @@ function verify2FA() {
 				// Error
 				document.getElementById('error-message').textContent = data.error;
 				if (data.redirect) {
-					window.location.href = data.redirect;
+					switchPage(data.redirect);
 				} else {
 					console.error('Error:', data.error);
 				}
 			} else if (data.message) {
 				// Verified
 				console.log(data.message);
-				window.location.href = data.redirect;  // Redirect on successful verification
+				switchPage(data.redirect);
+				updateHeader();
 			}
 		})
 		.catch(error => console.error("Error:", error));
@@ -39,7 +44,7 @@ export function clearForm() {
 // window.verify2FA = verify2FA;
 
 export function setupVerify2FaEventListener() {
-	console.log("Setup logout event listeners");
+	console.log("Setup verify2fa event listeners");
 	const verify2FaButton = document.querySelector('.hth-btn.verify2FaButton');
 	if (verify2FaButton) {
 		verify2FaButton.addEventListener('click', (event) => {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
@@ -1,8 +1,13 @@
+import { setupLogoutEventListener } from "/static/accounts/js/logout.js"
+
 // headerを取得し差し替え
 export function updateHeader() {
     fetch('/spa/header/')
         .then(response => response.text())
         .then(headerHtml => {
             document.querySelector('header').innerHTML = headerHtml;
+
+            // logout buttonのイベントリスナーを設定
+            setupLogoutEventListener();
         });
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
@@ -1,0 +1,8 @@
+// headerを取得し差し替え
+export function updateHeader() {
+    fetch('/spa/header/')
+        .then(response => response.text())
+        .then(headerHtml => {
+            document.querySelector('header').innerHTML = headerHtml;
+        });
+}

--- a/docker/srcs/uwsgi-django/trans_pj/urls.py
+++ b/docker/srcs/uwsgi-django/trans_pj/urls.py
@@ -58,6 +58,7 @@ urlpatterns += _set_i18n_url(
 		path('view/lang/', main_views.lang, name='lang'),
 		path('view/script1/', main_views.script1, name='script1'),
 		path('view/script2/', main_views.script2, name='script2'),
+		path('spa/header/', main_views.header, name='header'),
 
 		# SPA
 		path('', main_views.spa, name='index'),

--- a/docker/srcs/uwsgi-django/trans_pj/views/main_views.py
+++ b/docker/srcs/uwsgi-django/trans_pj/views/main_views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.conf import settings
 from django.http import HttpResponse
 from django.http import JsonResponse
+from django.template.loader import render_to_string
 
 # def index(request):
 #     return HttpResponse("<h1>[Django]</h1> <p>index pageです</p>")
@@ -92,3 +93,8 @@ def home(request):
 		"content": "Welcome to the home page!"
 	}
 	return JsonResponse(data)
+
+
+def header(request):
+	url_config = settings.URL_CONFIG
+	return render(request, 'header.html', {'url_config': url_config})


### PR DESCRIPTION
#180 

## 要件
* Your website must be a [single-page application](https://en.wikipedia.org/wiki/Single-page_application).
* The user should be able to use the Back and Forward buttons of the browser.


## SPA定義(wikipedia)
* 単一のWebページのみから構成する
* 必要なコード（HTML、JavaScript、CSS）は最初にまとめて読み込むか、ユーザの操作などに応じて動的にサーバと通信し、必要なものだけ読み込みを行う


## todo
- [ ] Auth操作
  - [x] basic login
  - [ ] login with 42
  - [x] login with 2FA
  - [x] sign up
  - [x] logout
- [ ] 3D Pong
  - [ ] End Gameボタン


## memo
- Auth
  - ページ遷移のSPA化は実装済み（コメントアウト）
  - SPA Area更新だけでは、naviがGuest/User向けに更新されない。naviの部分的な更新の追加が必要。→ OK
  - 42authは42へのリダイレクト必須、一時的にSPA外れるが許容するか？
- 3D Pong
  - EndGame押下後のページ遷移のSPA化は未実装
  - viteコンテナ内のPongEngineMatch.jsでdjangoコンテナのspa/renderView.jsをimportし、switchView()を呼び出す必要がある。どうする...?
  - イベントリスナーを嚙ませるか？