### PR TITLE
[subject] SPA

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
@@ -2,6 +2,7 @@
 
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 // ブラウザURLがloginでない（=リダイレクトでloginへ遷移した）場合は、元のURLに戻す
@@ -39,10 +40,8 @@ export function loginUser(event) {
 				// Error
 				document.getElementById('message-area').textContent = data.error;
 				if (data.redirect) {
-					// alert(`Redirecting to ${data.redirect}. Check console logs before proceeding.`);  // debug
-					// alert('[tmp] login failure')
-					window.location.href = data.redirect;
-					// switchPage(data.redirect)
+                    // alert('[tmp] login failure')
+					switchPage(data.redirect)
 				} else {
 					// alert('[tmp] error: ' + data.error)
 					console.error('Error:', data.error);
@@ -51,10 +50,11 @@ export function loginUser(event) {
 				// Verified
 				console.log(data.message);
 				const nextUrl = getNextUrl(data.redirect);
-				console.log('login: next=' + nextUrl)
+				// console.log('login: next=' + nextUrl)
 				// alert('[tmp] login success, next:' + nextUrl)
 				// window.location.href = nextUrl
 				switchPage(nextUrl)  // Redirect on successful verification
+                updateHeader();
 			}
 		})
 		.catch(error => console.error('Error:', error));

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
@@ -3,6 +3,7 @@
 import { disconnectOnlineStatusWebSocket } from "./online-status.js";
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 function handleLogout() {
@@ -24,8 +25,8 @@ function handleLogout() {
 			disconnectOnlineStatusWebSocket(data.user_id)
 
 			// alert(`Redirecting to ${data.redirect}. Check console logs before proceeding.`);  // debug
-			window.location.href = data.redirect;
-			// switchPage(data.redirect)
+			switchPage(data.redirect);
+			updateHeader();
 		} else {
 			throw new Error('No message in response');
 		}
@@ -36,6 +37,17 @@ function handleLogout() {
 	});
 }
 
+
+export function setupLogoutEventListener() {
+	console.log("Setup logout event listeners");
+	const button = document.querySelector('.logoutButton');
+	if (button) {
+		button.addEventListener('click', function(event) {
+			event.preventDefault();
+			handleLogout();
+		});
+	}
+}
 
 // header
 document.addEventListener('DOMContentLoaded', function() {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
@@ -1,5 +1,6 @@
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 function signupUser(event) {
@@ -22,16 +23,15 @@ function signupUser(event) {
 			// Error
 			document.getElementById('message-area').textContent = data.error;
 			if (data.redirect) {
-				window.location.href = data.redirect;
-				// switchPage(data.redirect)
+				switchPage(data.redirect)
 			} else {
 				console.error('Error:', data.error);
 			}
 		} else if (data.message) {
 			// Verified
 			console.log(data.message);
-			window.location.href = data.redirect;
-			// switchPage(data.redirect)  // Redirect on successful verification
+			switchPage(data.redirect)  // Redirect on successful verification
+			updateHeader();
 		}
 	})
 	.catch(error => console.error('Error:', error));

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
@@ -1,6 +1,7 @@
 // verify_2fa.js
-
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 function getNextUrl() {
@@ -28,7 +29,7 @@ function verify2FA() {
 				document.getElementById('error-message').textContent = data.error;
 				if (data.redirect) {
 					// alert('[tmp] varify2fa error: redirectTo:' + data.redirect)
-					window.location.href = data.redirect;
+					switchPage(data.redirect);
 				} else {
 					// alert('[tmp] varify2fa error' + data.error)
 					console.error('Error:', data.error);
@@ -38,6 +39,7 @@ function verify2FA() {
 				console.log(data.message);
 				// alert('[tmp] varify2fa success, redirect:' + data.redirect)
 				switchPage(data.redirect)  // Redirect on successful verification
+                updateHeader();
 			}
 		})
 		.catch(error => console.error("Error:", error));
@@ -54,7 +56,7 @@ export function clearForm() {
 // window.verify2FA = verify2FA;
 
 export function setupVerify2FaEventListener() {
-	console.log("Setup logout event listeners");
+	console.log("Setup verify2fa event listeners");
 	const verify2FaButton = document.querySelector('.hth-btn.verify2FaButton');
 	if (verify2FaButton) {
 		verify2FaButton.addEventListener('click', (event) => {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -49,6 +49,12 @@ const setupDOMContentLoadedListener = () => {
     setupBodyClickListener();
 
     setOnlineStatus();  // WebSocket接続を再確立
+
+    // three-jsのEndGameボタン押下でSPA遷移するためのイベント
+    document.addEventListener('endGame', function() {
+      console.log('endGame event');
+      switchPage(routeTable['tournament'].path);
+    });
   });
 };
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
@@ -1,8 +1,13 @@
+import { setupLogoutEventListener } from "/static/accounts/js/logout.js"
+
 // headerを取得し差し替え
 export function updateHeader() {
     fetch('/spa/header/')
         .then(response => response.text())
         .then(headerHtml => {
             document.querySelector('header').innerHTML = headerHtml;
+
+            // logout buttonのイベントリスナーを設定
+            setupLogoutEventListener();
         });
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/updateHeader.js
@@ -1,0 +1,8 @@
+// headerを取得し差し替え
+export function updateHeader() {
+    fetch('/spa/header/')
+        .then(response => response.text())
+        .then(headerHtml => {
+            document.querySelector('header').innerHTML = headerHtml;
+        });
+}

--- a/docker/srcs/uwsgi-django/trans_pj/urls.py
+++ b/docker/srcs/uwsgi-django/trans_pj/urls.py
@@ -58,6 +58,7 @@ urlpatterns += _set_i18n_url(
 		path('view/lang/', main_views.lang, name='lang'),
 		path('view/script1/', main_views.script1, name='script1'),
 		path('view/script2/', main_views.script2, name='script2'),
+		path('spa/header/', main_views.header, name='header'),
 
 		# SPA
 		path('', main_views.spa, name='index'),

--- a/docker/srcs/uwsgi-django/trans_pj/views/main_views.py
+++ b/docker/srcs/uwsgi-django/trans_pj/views/main_views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.conf import settings
 from django.http import HttpResponse
 from django.http import JsonResponse
+from django.template.loader import render_to_string
 
 # def index(request):
 #     return HttpResponse("<h1>[Django]</h1> <p>index pageです</p>")
@@ -92,3 +93,8 @@ def home(request):
 		"content": "Welcome to the home page!"
 	}
 	return JsonResponse(data)
+
+
+def header(request):
+	url_config = settings.URL_CONFIG
+	return render(request, 'header.html', {'url_config': url_config})

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -144,12 +144,19 @@ class PongEngineMatch
 		const button = document.createElement('button');
 		button.textContent = 'End Game';
 		button.className = 'game-button';
-		button.setAttribute('data-link', '');
-		button.onclick = function() {
-			window.location.href = '/app/';
-		};
+
+		// SPAとして'/app/'に遷移するため、endGameイベントをdjango側で補足する
+		const endGameEvent = new CustomEvent('endGame');
+
 		// ボタンをページに追加
 		document.body.appendChild(button);
+
+		button.onclick = function() {
+			// endGameEventをdjangoで補足し、SPA遷移する
+			document.dispatchEvent(endGameEvent);
+			// ボタンをページから削除
+			document.body.removeChild(button);
+		};
 	}
 
 	sendMatchResult() 


### PR DESCRIPTION
#180 

#182 のベースから開始
コミット可視化のため merge先を`fix-#182`で進めていますが、`dev`へmerge予定です

<br>

## 要件
* Your website must be a [single-page application](https://en.wikipedia.org/wiki/Single-page_application).
* The user should be able to use the Back and Forward buttons of the browser.

<br>

## SPA定義(wikipedia)
* 単一のWebページのみから構成する
* 必要なコード（HTML、JavaScript、CSS）は最初にまとめて読み込むか、ユーザの操作などに応じて動的にサーバと通信し、必要なものだけ読み込みを行う

<br>

## todo
- [x] Auth操作
  - [x] basic login
  - [ ] ~login with 42~
  - [x] login with 2FA
  - [x] sign up
  - [x] logout
- [x] 3D Pong
  - [x] End Gameボタン

<br>

## memo
- Auth
  - ページ遷移のSPA化だけでは、naviがGuest/User向けに更新されない。naviの部分的な更新を追加 a6ca5c0
  - 42authは認証フロー上、一時的にSPA外れる
    - 42認証サーバーへのリダイレクト、パラメータ受け取り用の`/oauth-ft/callback/`へのリダイレクトが発生
    - OAuth部分をpopupなどで処理し、ブラウザでSPAを維持することも可能そうだが、以下理由により優先度低め（余裕があればやりたい... )
      - 現状でSPA要件は満足していると思われる（OAuthで外部サーバーにアクセスし、SPA外れるのはOAuthの仕様[1]であり、SPA要件を上書きするはず）
      - ポップアップでOAuthを走らせる場合、SPAを開いているブラウザ側との連携が発生し、考慮すべき問題が増える
- 3D Pong
  - EndGame押下時でendGameEventを発火、django側で補足し、SPAページ遷移にて対応 6cb069d
  - EndGame押下時にEndGameButtonも削除することでボタンの残留を防止

<br>

## Ref
- [1] [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1)