### PR TITLE
[fix] login userのリダイレクトURL制御

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           total_result=0
           
-          docker exec uwsgi-django python manage.py test trans_pj.tests > /dev/null
+          docker exec uwsgi-django python manage.py test trans_pj.tests.test_top > /dev/null
           unit_result=$?
           total_result=$((total_result | unit_result))
           if [ $unit_result -eq 0 ]; then

--- a/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
@@ -1,0 +1,65 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class IsUserLoggedInAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    kIsUserLoggedInAPIName = "api_accounts:api_is_user_logged_in"
+    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.is_user_logged_in_api_path = reverse(self.kIsUserLoggedInAPIName)
+        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_logged_in'])
+
+    def test_user2(self):
+        self.client.force_authenticate(user=self.user2)
+
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_logged_in'])
+
+    def test_guest(self):
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_logged_in'])

--- a/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
@@ -11,7 +11,6 @@ class IsUserLoggedInAPITests(TestCase):
     kLoginAPIName = "api_accounts:api_login"
     kLogoutAPIName = "api_accounts:api_logout"
     kIsUserLoggedInAPIName = "api_accounts:api_is_user_logged_in"
-    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
 
     kUser1Email = "test1@example.com"
     kUser1Nickname = "test1"
@@ -24,7 +23,6 @@ class IsUserLoggedInAPITests(TestCase):
     def setUp(self):
         self.login_api_path = reverse(self.kLoginAPIName)
         self.is_user_logged_in_api_path = reverse(self.kIsUserLoggedInAPIName)
-        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
         self.client = APIClient()
 
         User = get_user_model()
@@ -63,3 +61,59 @@ class IsUserLoggedInAPITests(TestCase):
         response = self.client.get(self.is_user_logged_in_api_path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.json()['is_logged_in'])
+
+
+class IsUserEnabled2FaAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_enable2fa'])
+
+    def test_user2(self):
+        self.client.force_authenticate(user=self.user2)
+
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_enable2fa'])
+
+    def test_guest(self):
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_enable2fa'])

--- a/docker/srcs/uwsgi-django/accounts/urls_api.py
+++ b/docker/srcs/uwsgi-django/accounts/urls_api.py
@@ -5,6 +5,7 @@ from django.urls import include, path
 from accounts.views.basic_auth import SignupAPIView
 from accounts.views.basic_auth import LogoutAPIView
 from accounts.views.basic_auth import LoginAPIView
+from accounts.views.is_user import IsUserLoggedInAPIView, IsUserEnabled2FaAPIView
 from accounts.views.user import UserProfileAPIView
 from accounts.views.user import EditUserProfileAPIView
 from accounts.views.user import UploadAvatarAPI
@@ -27,6 +28,8 @@ urlpatterns = [
     path('api/signup/'              , SignupAPIView.as_view()           , name='api_signup'),
     path('api/login/'               , LoginAPIView.as_view()            , name='api_login'),
     path('api/logout/'              , LogoutAPIView.as_view()           , name='api_logout'),
+    path('api/is-user-logged-in/'   , IsUserLoggedInAPIView.as_view()   , name='api_is_user_logged_in'),
+    path('api/is-user-enabled2fa/'  , IsUserEnabled2FaAPIView.as_view() , name='api_is_user_enabled2fa'),
     path('api/user/profile/'        , UserProfileAPIView.as_view()      , name='api_user_profile'),
     path('api/user/edit-profile/'   , EditUserProfileAPIView.as_view()  , name='api_edit_profile'),
     path('api/change-avatar/'       , UploadAvatarAPI.as_view()         , name='change_avatar'),

--- a/docker/srcs/uwsgi-django/accounts/views/is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/is_user.py
@@ -1,0 +1,37 @@
+# accounts/views/is_user.py
+
+from django.conf import settings
+from django.http import JsonResponse
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+
+class IsUserLoggedInAPIView(APIView):
+    """
+    APIを叩いたuserのlogin状態を返す
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        data = {
+            'is_logged_in': request.user.is_authenticated
+        }
+        return JsonResponse(data, status=200)
+
+
+class IsUserEnabled2FaAPIView(APIView):
+    """
+    APIを叩いたuserのenable2faを返す
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        if not request.user.is_authenticated:
+            # 401回避のため Faleを返す
+            enable2fa = False
+        else:
+            enable2fa = request.user.enable_2fa
+        data = {
+            'is_enable2fa': enable2fa
+        }
+        return JsonResponse(data, status=200)

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -103,8 +103,9 @@ const setupBodyClickListener = () => {
       event.preventDefault();
 
       const linkUrl = linkElement.href;
-      const url = await getLoggedInUserRedirectUrl(linkUrl)
-      switchPage(url);
+      // const url = await getLoggedInUserRedirectUrl(linkUrl)
+      // switchPage(url);
+      switchPage(linkUrl);
     }
 
     // if (event.target.matches("[data-link]")) {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -2,6 +2,7 @@
 
 import { routeTable } from "./routing/routeTable.js"
 import { switchPage, renderView } from "./routing/renderView.js";
+import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
@@ -59,9 +60,39 @@ const setupDOMContentLoadedListener = () => {
 };
 
 
+// login userであれば/auth/への遷移を/app/に切り返る
+async function getLoggedInUserRedirectUrl(url) {
+  const isLoggedIn = await isUserLoggedIn();
+  if (!isLoggedIn) {
+    return url;
+  }
+  // 2FA有効user && enable2faへの遷移 は/app/に切り替える
+  const isEnable2FA = await isUserEnable2FA();
+
+  const urlObject = new URL(url);
+  const pathName = urlObject.pathname;
+  let nextUrl;
+  if (pathName === routeTable['signup'].path
+      || pathName === routeTable['login'].path
+      || pathName === routeTable['veryfy2fa'].path
+      || (pathName === routeTable['enable2fa'].path && isEnable2FA)) {
+    nextUrl = new URL(routeTable['top'].path, window.location.origin);
+  } else {
+    nextUrl = url;
+  }
+
+  // console.log(`DEBUG getLoggedInUserRedirectUrl`)
+  // console.log(` url      :${url}`)
+  // console.log(` pathName :${pathName}`)
+  // console.log(` nextUrl  :${nextUrl}`)
+  // alert(`[check console log]getLoggedInUserRedirectUrl`)
+  return nextUrl;
+}
+
+
 // リンクのクリックイベントで発火
 const setupBodyClickListener = () => {
-  document.body.addEventListener("click", (event) => {
+  document.body.addEventListener("click", async (event) => {
   console.log('clickEvent: path: ' + window.location.pathname);
   stopGamePageAnimation()
   setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
@@ -70,7 +101,9 @@ const setupBodyClickListener = () => {
     if (linkElement) {
       console.log('clickEvent: taga-link');
       event.preventDefault();
-      const url = linkElement.href;
+
+      const linkUrl = linkElement.href;
+      const url = await getLoggedInUserRedirectUrl(linkUrl)
       switchPage(url);
     }
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
@@ -1,0 +1,40 @@
+// spa/js/utility/isUser.js
+
+export async function isUserLoggedIn() {
+    try {
+        const response = await fetch('/accounts/api/is-user-logged-in/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+        });
+        const data = await response.json();
+        // alert(`isUserLoggedIn: ${data.is_logged_in}`)
+        return data.is_logged_in;
+    } catch (error) {
+        console.error('Error:', error);
+        // alert(`isUserLoggedIn: error: ${error}`)
+        return false;
+    }
+}
+
+
+export async function isUserEnable2FA() {
+    try {
+        const response = await fetch('/accounts/api/is-user-enabled2fa/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+        });
+        const data = await response.json();
+        // alert(`isUserEnable2FA: ${data.is_enable2fa}`)
+        return data.is_enable2fa;
+    } catch (error) {
+        console.error('Error:', error);
+        // alert(`isUserEnable2FA: error: ${error}`)
+        return false;
+    }
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/user.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/user.js
@@ -1,7 +1,0 @@
-export function isLogined() {
-  //todo
-  // ログインしていればtrue
-  // ログインしていなければfalseを返す
-
-  return true;
-}

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -167,6 +167,9 @@ class TestConfig(LiveServerTestCase):
         self.assertEqual(self.driver.current_url, expected_url)
 
     def _assert_page_url_and_title(self, expecter_url, expected_title):
+        WebDriverWait(self.driver, 10).until(
+            EC.title_contains(expected_title)
+        )
         # ページのURLを検証
         self._assert_current_url(expecter_url)
         # ページのタイトルを検証
@@ -300,7 +303,7 @@ class TestConfig(LiveServerTestCase):
     def _move_top_to_signup(self):
         signup_page_link = self._text_link("Sign-up")
         self._click_link(signup_page_link, wait_for_link_invisible=False)
-        time.sleep(0.2)
+        time.sleep(1)
         self.driver.refresh()
         self._assert_page_url_and_title(expecter_url=self.signup_url,
                                         expected_title='Signup')

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -300,6 +300,8 @@ class TestConfig(LiveServerTestCase):
     def _move_top_to_signup(self):
         signup_page_link = self._text_link("Sign-up")
         self._click_link(signup_page_link, wait_for_link_invisible=False)
+        time.sleep(0.2)
+        self.driver.refresh()
         self._assert_page_url_and_title(expecter_url=self.signup_url,
                                         expected_title='Signup')
 
@@ -345,7 +347,7 @@ class TestConfig(LiveServerTestCase):
         # self._screenshot("logout 2")
 
     def _create_new_user(self, email, nickname, password, is_enable_2fa=False):
-        self._move_top_to_signup()
+        self._move_top_to_signup(assert_page_and_title=False)
 
         self._send_to_elem(By.ID, "email", email)
         self._send_to_elem(By.ID, "nickname", nickname)
@@ -361,7 +363,7 @@ class TestConfig(LiveServerTestCase):
             self._move_top_to_profile()
             self.driver.refresh()
             set_up_key = self._setting_enable_2fa()
-            self._assert_is_2fa_enabled(expected_2fa_enabled=True)
+            self._assert_is_2fa_enabled()
 
         self._logout()
         return set_up_key

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -88,6 +88,8 @@ class TestConfig(LiveServerTestCase):
 
         # set up operation #####################################################
         self._access_to(self.top_url)
+        # ページの読み込みが完了するまでの待機時間を設定
+        self.driver.implicitly_wait(10)
 
     def tearDown(self):
         self.driver.quit()
@@ -350,7 +352,7 @@ class TestConfig(LiveServerTestCase):
         # self._screenshot("logout 2")
 
     def _create_new_user(self, email, nickname, password, is_enable_2fa=False):
-        self._move_top_to_signup(assert_page_and_title=False)
+        self._move_top_to_signup()
 
         self._send_to_elem(By.ID, "email", email)
         self._send_to_elem(By.ID, "nickname", nickname)


### PR DESCRIPTION
#186 

PR #187 でsign inが死んでおり動作検証不可 & ActionsでE2E通らず -> 動作確認済みの #182 のベースから開始

<hr>

## 概要
- login userがauth pageへアクセスする際、`/app/`へリダイレクトされるが、URLは`auth-page`のままである
- これは、django view関数でリダイレクト & レンダリングしており、JSの`switchPage()`を呼べずURLを制御できていないためで、JSでの制御を追加した

<br>

## 挙動 before/after
- before: login後`/auth/*/`へアクセス -> URL`/auth/*/`のままTOP画面に遷移
- after: login後`/auth/*/`へアクセス -> URL`/app/`でTOP画面に遷移

<br>

## 変更点
- リンククリックイベントの際、`/spa/js/index.js`内でlogin userが`/app/`リダイレクトされるページであればurlを`/app/`に差し替えることで対応  f3ee8fe