### PR TITLE
[fix] login userのリダイレクトURL制御

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
@@ -1,0 +1,65 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class IsUserLoggedInAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    kIsUserLoggedInAPIName = "api_accounts:api_is_user_logged_in"
+    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.is_user_logged_in_api_path = reverse(self.kIsUserLoggedInAPIName)
+        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_logged_in'])
+
+    def test_user2(self):
+        self.client.force_authenticate(user=self.user2)
+
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_logged_in'])
+
+    def test_guest(self):
+        response = self.client.get(self.is_user_logged_in_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_logged_in'])

--- a/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_is_user.py
@@ -11,7 +11,6 @@ class IsUserLoggedInAPITests(TestCase):
     kLoginAPIName = "api_accounts:api_login"
     kLogoutAPIName = "api_accounts:api_logout"
     kIsUserLoggedInAPIName = "api_accounts:api_is_user_logged_in"
-    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
 
     kUser1Email = "test1@example.com"
     kUser1Nickname = "test1"
@@ -24,7 +23,6 @@ class IsUserLoggedInAPITests(TestCase):
     def setUp(self):
         self.login_api_path = reverse(self.kLoginAPIName)
         self.is_user_logged_in_api_path = reverse(self.kIsUserLoggedInAPIName)
-        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
         self.client = APIClient()
 
         User = get_user_model()
@@ -63,3 +61,59 @@ class IsUserLoggedInAPITests(TestCase):
         response = self.client.get(self.is_user_logged_in_api_path)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.json()['is_logged_in'])
+
+
+class IsUserEnabled2FaAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    kIsUserEnabled2FaAPIName = "api_accounts:api_is_user_enabled2fa"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.is_user_enabled2fa_api_path = reverse(self.kIsUserEnabled2FaAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_enable2fa'])
+
+    def test_user2(self):
+        self.client.force_authenticate(user=self.user2)
+
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()['is_enable2fa'])
+
+    def test_guest(self):
+        response = self.client.get(self.is_user_enabled2fa_api_path)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()['is_enable2fa'])

--- a/docker/srcs/uwsgi-django/accounts/urls_api.py
+++ b/docker/srcs/uwsgi-django/accounts/urls_api.py
@@ -5,6 +5,7 @@ from django.urls import include, path
 from accounts.views.basic_auth import SignupAPIView
 from accounts.views.basic_auth import LogoutAPIView
 from accounts.views.basic_auth import LoginAPIView
+from accounts.views.is_user import IsUserLoggedInAPIView, IsUserEnabled2FaAPIView
 from accounts.views.user import UserProfileAPIView
 from accounts.views.user import EditUserProfileAPIView
 from accounts.views.user import UploadAvatarAPI
@@ -27,6 +28,8 @@ urlpatterns = [
     path('api/signup/'              , SignupAPIView.as_view()           , name='api_signup'),
     path('api/login/'               , LoginAPIView.as_view()            , name='api_login'),
     path('api/logout/'              , LogoutAPIView.as_view()           , name='api_logout'),
+    path('api/is-user-logged-in/'   , IsUserLoggedInAPIView.as_view()   , name='api_is_user_logged_in'),
+    path('api/is-user-enabled2fa/'  , IsUserEnabled2FaAPIView.as_view() , name='api_is_user_enabled2fa'),
     path('api/user/profile/'        , UserProfileAPIView.as_view()      , name='api_user_profile'),
     path('api/user/edit-profile/'   , EditUserProfileAPIView.as_view()  , name='api_edit_profile'),
     path('api/change-avatar/'       , UploadAvatarAPI.as_view()         , name='change_avatar'),

--- a/docker/srcs/uwsgi-django/accounts/views/is_user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/is_user.py
@@ -1,0 +1,37 @@
+# accounts/views/is_user.py
+
+from django.conf import settings
+from django.http import JsonResponse
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+
+class IsUserLoggedInAPIView(APIView):
+    """
+    APIを叩いたuserのlogin状態を返す
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        data = {
+            'is_logged_in': request.user.is_authenticated
+        }
+        return JsonResponse(data, status=200)
+
+
+class IsUserEnabled2FaAPIView(APIView):
+    """
+    APIを叩いたuserのenable2faを返す
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs) -> JsonResponse:
+        if not request.user.is_authenticated:
+            # 401回避のため Faleを返す
+            enable2fa = False
+        else:
+            enable2fa = request.user.enable_2fa
+        data = {
+            'is_enable2fa': enable2fa
+        }
+        return JsonResponse(data, status=200)

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -2,6 +2,7 @@
 
 import { routeTable } from "./routing/routeTable.js"
 import { switchPage, renderView } from "./routing/renderView.js";
+import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
@@ -59,9 +60,39 @@ const setupDOMContentLoadedListener = () => {
 };
 
 
+// login userであれば/auth/への遷移を/app/に切り返る
+async function getLoggedInUserRedirectUrl(url) {
+  const isLoggedIn = await isUserLoggedIn();
+  if (!isLoggedIn) {
+    return url;
+  }
+  // 2FA有効user && enable2faへの遷移 は/app/に切り替える
+  const isEnable2FA = await isUserEnable2FA();
+
+  const urlObject = new URL(url);
+  const pathName = urlObject.pathname;
+  let nextUrl;
+  if (pathName === routeTable['signup'].path
+      || pathName === routeTable['login'].path
+      || pathName === routeTable['veryfy2fa'].path
+      || (pathName === routeTable['enable2fa'].path && isEnable2FA)) {
+    nextUrl = new URL(routeTable['top'].path, window.location.origin);
+  } else {
+    nextUrl = url;
+  }
+
+  // console.log(`DEBUG getLoggedInUserRedirectUrl`)
+  // console.log(` url      :${url}`)
+  // console.log(` pathName :${pathName}`)
+  // console.log(` nextUrl  :${nextUrl}`)
+  // alert(`[check console log]getLoggedInUserRedirectUrl`)
+  return nextUrl;
+}
+
+
 // リンクのクリックイベントで発火
 const setupBodyClickListener = () => {
-  document.body.addEventListener("click", (event) => {
+  document.body.addEventListener("click", async (event) => {
   console.log('clickEvent: path: ' + window.location.pathname);
   stopGamePageAnimation()
   setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
@@ -70,7 +101,9 @@ const setupBodyClickListener = () => {
     if (linkElement) {
       console.log('clickEvent: taga-link');
       event.preventDefault();
-      const url = linkElement.href;
+
+      const linkUrl = linkElement.href;
+      const url = await getLoggedInUserRedirectUrl(linkUrl)
       switchPage(url);
     }
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,6 +1,5 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
-import { isLogined } from "../utility/user.js";
 
 
 const getPathAndQueryString = (targetPath) => {
@@ -43,7 +42,7 @@ export const switchPage = (targePath) => {
 };
 
 
-const getSelectedRoute = (currentPath, routeTable, isLogined) => {
+const getSelectedRoute = (currentPath, routeTable) => {
   let params = {};  // URLパラメータを格納するオブジェクト
 
   // パスパラメータを含む可能性があるルートを評価
@@ -71,17 +70,17 @@ const getSelectedRoute = (currentPath, routeTable, isLogined) => {
     matchedRoute.params = params;
     matchedRoute.queryParams = new URLSearchParams(window.location.search);
     return matchedRoute;
-  } else if (isLogined) {
-    return routeTable['home'];
   } else {
-    return routeTable['login']
+    // routeTableに存在しないpathの場合、Guest, Userともにtopを表示
+    // todo: URLとinnerHTMLが乖離 -> URLも/app/に切り替えるべきか？
+    return routeTable['top'];
   }
 };
 
 
-function getView(path) {
+async function getView(path) {
   // 選択されたルートを取得
-  const selectedRoute = getSelectedRoute(path, routeTable, isLogined());
+  const selectedRoute = getSelectedRoute(path, routeTable);
   // console.log("renderView: selectedRoute.path: " + selectedRoute.path)
 
   // 選択されたルートに対応するビューをインスタンス化して、paramsを渡す
@@ -94,7 +93,7 @@ function getView(path) {
 
 export const renderView = async (path) => {
   // console.log("    renderView 1: path: " + path)
-  const view = getView(path)
+  const view = await getView(path)
 
   // HTMLの描画 <div id="app">
   const htmlSrc = await view.getHtml();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
@@ -1,0 +1,40 @@
+// spa/js/utility/isUser.js
+
+export async function isUserLoggedIn() {
+    try {
+        const response = await fetch('/accounts/api/is-user-logged-in/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+        });
+        const data = await response.json();
+        // alert(`isUserLoggedIn: ${data.is_logged_in}`)
+        return data.is_logged_in;
+    } catch (error) {
+        console.error('Error:', error);
+        // alert(`isUserLoggedIn: error: ${error}`)
+        return false;
+    }
+}
+
+
+export async function isUserEnable2FA() {
+    try {
+        const response = await fetch('/accounts/api/is-user-enabled2fa/', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            },
+        });
+        const data = await response.json();
+        // alert(`isUserEnable2FA: ${data.is_enable2fa}`)
+        return data.is_enable2fa;
+    } catch (error) {
+        console.error('Error:', error);
+        // alert(`isUserEnable2FA: error: ${error}`)
+        return false;
+    }
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/user.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/user.js
@@ -1,7 +1,0 @@
-export function isLogined() {
-  //todo
-  // ログインしていればtrue
-  // ログインしていなければfalseを返す
-
-  return true;
-}


### PR DESCRIPTION
## 概要
- login済みuserが`/auth/*/`へアクセスすると、画面表示は`/app/`へ更新されるが、URLは`/auth/*/`のまま（URLと表示内容の不整合）
- これは、django view関数でリダイレクト & レンダリングしており画面は更新されるが、JSの`switchPage()`を呼んでいないためURLを制御できていないことが原因 -> JSでのURL制御を追加

<br>

## 挙動 before/after
- before: login後`/auth/*/`へアクセス -> URL`/auth/*/`のままTOP画面に遷移
- after: login後`/auth/*/`へアクセス -> URL`/app/`でTOP画面に遷移

<br>

## 変更点
- リンククリックイベントの際、`/spa/js/index.js`内でlogin userが`/app/`リダイレクトされるページであればurlを`/app/`に差し替えることで対応  bc159a3

<br>

## memo
- まだツメ甘いところがありますが、dev集約に回します
- login後、ブラウザバックで`/auth/*/`に戻ると、URLは`/auth/*/`で表示はTOP #191 