### PR TITLE
[check] input周りのコーナーケース再確認

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -4,6 +4,7 @@ import logging
 from typing import List, Dict, Any
 
 from django.db import models
+from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.password_validation import validate_password
@@ -32,6 +33,10 @@ class UserManager(BaseUserManager):
         """
         Create and save a user with the given email, password, and nickname.
         """
+        # ユーザー数の上限チェック
+        if settings.MAX_USER_COUNT <= CustomUser.objects.count():
+            raise ValueError("User registration limit exceeded.")
+
         email = self.normalize_email(email)
         nickname = extra_fields.get("nickname")
         ok, err = self._is_valid_user_field(email, nickname, password)

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -117,6 +117,8 @@ class UserManager(BaseUserManager):
         if CustomUser.kPASSWORD_MAX_LENGTH < len(password):
             err = f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less"
             return False, err
+        if not password.isascii():
+            return False, "The password can only contain ASCII characters"
         try:
             validate_password(password, user=tmp_user)
             return True, None

--- a/docker/srcs/uwsgi-django/accounts/models.py
+++ b/docker/srcs/uwsgi-django/accounts/models.py
@@ -88,7 +88,7 @@ class UserManager(BaseUserManager):
 
 
     @classmethod
-    def _is_valid_nickname(self, nickname):
+    def _is_valid_nickname(self, nickname, is_check_exists=True):
         if not nickname:
             return False, "The given nickname must be set"
         if len(nickname) < CustomUser.kNICKNAME_MIN_LENGTH:
@@ -102,7 +102,7 @@ class UserManager(BaseUserManager):
         if not nickname.isalnum():
             return False, "Invalid nickname format"
 
-        if CustomUser.objects.filter(nickname=nickname).exists():
+        if is_check_exists and CustomUser.objects.filter(nickname=nickname).exists():
             return False, "This nickname is already in use"
 
         return True, None

--- a/docker/srcs/uwsgi-django/pong/models.py
+++ b/docker/srcs/uwsgi-django/pong/models.py
@@ -11,6 +11,7 @@ from accounts.models import CustomUser, UserManager
 class Tournament(models.Model):
 	kTORNAMENT_NAME_MIN_LEN = 3
 	kTORNAMENT_NAME_MAX_LEN = 30
+	kMAX_TORNAMENT_COUNT = 10000
 
 	name = models.CharField(max_length=kTORNAMENT_NAME_MAX_LEN)
 	# settings.py で USE_TZ=True が設定されている。保存はUTC
@@ -25,6 +26,9 @@ class Tournament(models.Model):
 		return self.name
 
 	def clean(self):
+		if self.kMAX_TORNAMENT_COUNT <= Tournament.objects.count():
+			raise ValueError("Tournament registration limit exceeded.")
+
 		# トーナメント名が空でないことを確認
 		if not self.__is_valid_tournament_name():
 			raise ValidationError({'tournament_name': 'non-empty alnum 3-30 length name required.'})

--- a/docker/srcs/uwsgi-django/pong/models.py
+++ b/docker/srcs/uwsgi-django/pong/models.py
@@ -9,6 +9,7 @@ from accounts.models import CustomUser
 
 
 class Tournament(models.Model):
+	kTORNAMENT_NAME_MIN_LEN = 3
 	kTORNAMENT_NAME_MAX_LEN = 30
 
 	name = models.CharField(max_length=kTORNAMENT_NAME_MAX_LEN)
@@ -36,7 +37,7 @@ class Tournament(models.Model):
 
 	def __is_valid_tournament_name(self) -> bool:
 		return (self.name is not None
-				and 0 < len(self.name)
+				and self.kTORNAMENT_NAME_MIN_LEN < len(self.name)
 				and self.__is_valid_name(self.name))
 
 	def __is_valid_date(self) -> bool:

--- a/docker/srcs/uwsgi-django/pong/models.py
+++ b/docker/srcs/uwsgi-django/pong/models.py
@@ -26,14 +26,13 @@ class Tournament(models.Model):
 	def clean(self):
 		# トーナメント名が空でないことを確認
 		if not self.__is_valid_tournament_name():
-			raise ValidationError('Invalid tournament name: non-empty alnum name required.')
+			raise ValidationError({'tournament_name': 'non-empty alnum name required.'})
 
 		if not self.__is_valid_date():
-			raise ValidationError('Invalid data: ISO 8601 format required.')
+			raise ValidationError({'date': 'ISO 8601 format required.'})
 
 		if not self.__is_valid_player_nicknames():
-			raise ValidationError('Invalid player nicknames: '
-								  '8 unique, non-empty alnum nicknames required.')
+			raise ValidationError({'player_nicknames': '8 unique, non-empty alnum nicknames required.'})
 
 	def __is_valid_tournament_name(self) -> bool:
 		return (self.name is not None

--- a/docker/srcs/uwsgi-django/pong/models.py
+++ b/docker/srcs/uwsgi-django/pong/models.py
@@ -41,7 +41,7 @@ class Tournament(models.Model):
 
 	def __is_valid_tournament_name(self) -> bool:
 		return (self.name is not None
-				and self.kTORNAMENT_NAME_MIN_LEN < len(self.name)
+				and self.kTORNAMENT_NAME_MIN_LEN <= len(self.name)
 				and self.__is_valid_name(self.name))
 
 	def __is_valid_date(self) -> bool:

--- a/docker/srcs/uwsgi-django/pong/views/tournament_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament_views.py
@@ -215,8 +215,14 @@ def create_new_tournament_and_matches(request) -> JsonResponse:
 		return JsonResponse({'status': 'success', 'tournament_id': tournament.id, 'matches': match_data})
 
 	except ValidationError as e:
-		logger.error(f'create_new_tournament: ValidationError: {str(e)}')
-		return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
+		logger.error(f'create_new_tournament: ValidationError: {e.message_dict}')
+		if e.message_dict:
+			field = list(e.message_dict.keys())[0]
+			error = e.message_dict[field][0]
+			error_message = f'Invalid {field}: {error}'
+		else:
+			error_message = 'An error occurred'
+		return JsonResponse({'status': 'error', 'message': error_message}, status=400)
 	except Exception as e:
 		logger.error(f'create_new_tournament: Exception: {str(e)}')
 		return JsonResponse({'status': 'error', 'message': str(e)}, status=500)

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -162,6 +162,10 @@ DATABASES = {
 }
 
 
+# ユーザー登録数の上限
+MAX_USER_COUNT = 10000
+
+
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators
 

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -176,9 +176,9 @@ class TestConfig(LiveServerTestCase):
         elem = self._element(by, value)
         self.assertTrue(elem.is_displayed())
 
-    def _assert_message(self, expected_message):
-        message_area = self._element(By.ID, "message-area")
-        self._wait_display_message(expected_message)
+    def _assert_message(self, expected_message, value="message-area"):
+        message_area = self._element(By.ID, value)
+        self._wait_display_message(expected_message, value)
         self.assertEqual(message_area.text, expected_message)
 
     def _assert_is_2fa_enabled(self, expected_2fa_enabled: bool):
@@ -212,10 +212,10 @@ class TestConfig(LiveServerTestCase):
             EC.url_to_be(url)
         )
 
-    def _wait_display_message(self, expected_message):
+    def _wait_display_message(self, expected_message, value):
         WebDriverWait(driver=self.driver, timeout=10).until(
             EC.text_to_be_present_in_element(
-                locator=(By.ID, "message-area"),
+                locator=(By.ID, value),
                 text_=expected_message
             )
         )
@@ -320,6 +320,12 @@ class TestConfig(LiveServerTestCase):
         self._click_link(friend_page_link, wait_for_link_invisible=False)
         self._assert_page_url_and_title(expecter_url=self.dm_url,
                                         expected_title='DMSessions')
+
+    def _move_top_to_tournament(self):
+        tournament_page_link = self._text_link("Tournament")
+        self._click_link(tournament_page_link, wait_for_link_invisible=False)
+        self._assert_page_url_and_title(expecter_url=self.tournament_url,
+                                        expected_title='Tournament')
 
     def _login(self, email, password, wait_for_button_invisible=True):
         self._move_top_to_login()

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
@@ -65,41 +65,48 @@ class ProfileTest(TestConfig):
          - 不正な文字列
         """
         self._move_to_edit_page()
-
-        # user1 -> user1
         current_nickname = self.nickname
-        self._edit_nickname(current_nickname, wait_for_button_invisible=False)
-        self._assert_message("new nickname same as current")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_nickname_1")
 
-        # user1 -> user2
-        already_use_nickname = "user2"
-        self._edit_nickname(already_use_nickname, wait_for_button_invisible=False)
-        self._assert_message("This nickname is already in use")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_nickname_2")
+        invalid_nicknames_and_expected_messages = [
+            # current nickname
+            {"nickname": current_nickname,  "message": "new nickname same as current"},
 
-        # user1 -> too long nickname
-        too_long_nickname = "a" * (self.nickname_max_len + 1)
-        self._edit_nickname(too_long_nickname, wait_for_button_invisible=False)
-        self._assert_message(f"The nickname must be {self.nickname_max_len} characters or less")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_nickname_3")
+            # すでに使用されているnickname
+            {"nickname": "user2",           "message": "This nickname is already in use"},
 
-        # user1 -> invalid nickname format
-        invalid_nickname = "SP in nickname"
-        self._edit_nickname(invalid_nickname, wait_for_button_invisible=False)
-        self._assert_message("Invalid nickname format")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_nickname_4")
 
-        # user1 -> invalid nickname format
-        multi_byte_nickname = "ニックネーム"
-        self._edit_nickname(multi_byte_nickname, wait_for_button_invisible=False)
-        self._assert_message("The nickname can only contain ASCII characters")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_nickname_5")
+            # 不正なnickname
+            {"nickname": "nick_name",       "message": "Invalid nickname format"},
+            {"nickname": "nick name",       "message": "Invalid nickname format"},
+            {"nickname": "***",             "message": "Invalid nickname format"},
+            {"nickname": "   aaa",          "message": "Invalid nickname format"},
+            {"nickname": "<script>alert('x')</script>",  "message": f"Invalid nickname format"},
+
+            # multi-byte
+            {"nickname": "ニックネーム",      "message": "The nickname can only contain ASCII characters"},
+
+            # too short
+            {"nickname": "n",               "message": f"The nickname must be at least {CustomUser.kNICKNAME_MIN_LENGTH} characters"},
+            {"nickname": "ng",              "message": f"The nickname must be at least {CustomUser.kNICKNAME_MIN_LENGTH} characters"},
+            {"nickname": " ",               "message": f"The nickname must be at least {CustomUser.kNICKNAME_MIN_LENGTH} characters"},
+
+            # too long
+            {"nickname": "<script>alert('hello')</script>",  "message": f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"},
+            {"nickname": f"{'a' * 31}",     "message": f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"},
+            {"nickname": f"{' ' * 31}",     "message": f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"},
+            {"nickname": f"{'a' * 1024}",   "message": f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"},
+            {"nickname": f"{'a' * 8096}",   "message": f"The nickname must be {CustomUser.kNICKNAME_MAX_LENGTH} characters or less"},
+        ]
+
+        print(f"[Testing] invalid nickname")
+        for invalid_data in invalid_nicknames_and_expected_messages:
+            invalid_nickname = invalid_data["nickname"]
+            expected_message = invalid_data["message"]
+            print(f" nickname: [{invalid_nickname}]")
+
+            self._edit_nickname(invalid_nickname, wait_for_button_invisible=False)
+            self._assert_message(expected_message)
+            self._assert_current_url(self.edit_profile_url)
 
         # nicknameはuser1から不変のはず
         self._move_top_to_profile()

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_profile.py
@@ -154,36 +154,44 @@ class ProfileTest(TestConfig):
         """
         self._move_to_edit_page()
 
+        current_password = self.password
+        invalid_new_passwords_and_expected_messages = [
+            # current passwordと同一
+            {"new_password": current_password,  "message": "new password same as current"},
+
+            # 不正なpassword
+            {"new_password": "パスワード123",    "message": "The password can only contain ASCII characters"},
+            {"new_password": "パスワード",       "message": "The password can only contain ASCII characters"},
+
+            # too common
+            {"new_password": "password",        "message": "このパスワードは一般的すぎます。"},
+            {"new_password": "********",        "message": "このパスワードは一般的すぎます。"},
+
+            # too short
+            {"new_password": "***4567",         "message": "このパスワードは短すぎます。最低 8 文字以上必要です。"},
+            {"new_password": "a1",              "message": "このパスワードは短すぎます。最低 8 文字以上必要です。"},
+
+            # too long
+            {"new_password": f"{"pass0" + "0123456789" * 6}",   "message": f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less"},
+            {"new_password": f"{"pass0" + "0123456789" * 128}", "message": f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less"},
+        ]
+        print(f"[Testing] invalid password")
+        for invalid_data in invalid_new_passwords_and_expected_messages:
+            invalid_new_password = invalid_data["new_password"]
+            expected_message = invalid_data["message"]
+            print(f" new_password: [{invalid_new_password}]")
+
+            self._edit_password(current_password, invalid_new_password, wait_for_button_invisible=False)
+            self._assert_message(expected_message)
+            self._assert_current_url(self.edit_profile_url)
+
         # current passwordが不正
-        wrong_current_pass = "pass01234"
+        wrong_current_pass = current_password + 'a'
         new_pass = "0123pass"
         self._edit_password(wrong_current_pass, new_pass, wait_for_button_invisible=False)
         self._assert_message("Current password is incorrect")
         self._assert_current_url(self.edit_profile_url)
         # self._screenshot("edit_pass_1")
-
-        # new passwordがcurrent passwordと同一
-        current_pass = "pass0123"
-        self._edit_password(current_pass, current_pass, wait_for_button_invisible=False)
-        self._assert_message("new password same as current")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_pass_2")
-
-        # new passwordが不正
-        current_pass = "pass0123"
-        new_pass = "pass012"
-        self._edit_password(current_pass, new_pass, wait_for_button_invisible=False)
-        self._assert_message("このパスワードは短すぎます。最低 8 文字以上必要です。")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_pass_3")
-
-        # new passwordが不正(too long)
-        current_pass = "pass0123"
-        new_pass = "pass0" + "0123456789" * 6
-        self._edit_password(current_pass, new_pass, wait_for_button_invisible=False)
-        self._assert_message(f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less")
-        self._assert_current_url(self.edit_profile_url)
-        # self._screenshot("edit_pass_3")
 
     ############################################################################
 

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
@@ -28,6 +28,31 @@ class TournamentTest(TestConfig):
         # self._screenshot("tournament4")
         self._is_tournament_top()
 
+    def test_valid_tournament_name(self):
+        self._is_tournament_top()
+
+        valid_tournament_names = [
+            "aaa",
+            "a a",
+            "1 a",
+            "abc",
+            f"{'a' * 29}",
+            f"{'a' * 30}",
+        ]
+
+        print(f"[Testing] valid tournament name")
+        for tournament_name in valid_tournament_names:
+            print(f" tournament name: [{tournament_name}]")
+
+            self._send_to_elem(By.CSS_SELECTOR, 'input[name="name"]', tournament_name)
+            # self._screenshot(f"valid_tournament-{tournament_name}-1")
+            self._submit_tournament()
+            # self._screenshot(f"valid_tournament-{tournament_name}-2")
+            self._is_progress()
+            # self._screenshot(f"valid_tournament-{tournament_name}-3")
+            self._delete_tournament()
+            self._is_tournament_top()
+
     def test_invalid_tournament_name(self):
         self._is_tournament_top()
 
@@ -41,7 +66,8 @@ class TournamentTest(TestConfig):
             {"name": ".",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "abc*012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "abc_012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "abc\t012",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "  abc",           "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "abc  ",           "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "<script>alert('a')</script>",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
 
             # too short

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
@@ -1,0 +1,142 @@
+import time
+
+from . import *
+
+
+class TournamentTest(TestConfig):
+    def setUp(self):
+        super().setUp()
+
+        self.nickname = self._generate_random_string(20)
+        self.email = f"{self.nickname}@example.com"
+        self.password = "pass0123"
+
+        self._create_new_user(email=self.email,
+                              nickname=self.nickname,
+                              password=self.password)
+        self._login(self.email, self.password)
+        self._move_top_to_tournament()
+
+    def test_create_and_delete_tournament(self):
+        self._is_tournament_top()
+        # self._screenshot("tournament1")
+        self._submit_tournament()
+        # self._screenshot("tournament2")
+        self._is_progress()
+        # self._screenshot("tournament3")
+        self._delete_tournament()
+        # self._screenshot("tournament4")
+        self._is_tournament_top()
+
+    def test_invalid_tournament_name(self):
+        self._is_tournament_top()
+
+        invalid_tournament_name_and_expected_messages = [
+            # empty
+            {"name": "",                "message": "Tournament name is required."},
+
+            # invalid character
+            {"name": "トーナメント",      "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": " ",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": ".",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "abc*012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "abc_012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "abc\t012",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "<script>alert('a')</script>",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+
+            # too short
+            {"name": "a",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "aa",              "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "  aa  ",          "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+
+            # too long
+            {"name": f"{'a' * 31}",     "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+            {"name": f"{'a' * 8192}",   "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 8192 文字になっています)。"},
+            {"name": "<script>alert('hello')</script>",   "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+        ]
+
+        print(f"[Testing] invalid tournament name")
+        for invalid_data in invalid_tournament_name_and_expected_messages:
+            invalid_tournament_name = invalid_data["name"]
+            expected_message = invalid_data["message"]
+            print(f" tournament name: [{invalid_tournament_name}]")
+
+            self._send_to_elem(By.CSS_SELECTOR, 'input[name="name"]', invalid_tournament_name)
+            # self._screenshot("invalid1")
+            self._submit_tournament(wait_invisible=False)
+            # self._screenshot("invalid2")
+            self._assert_message(expected_message, value="error-message")
+            self._is_tournament_top()
+
+    def test_invalid_player_name(self):
+        self._is_tournament_top()
+
+        invalid_player_name_and_expected_messages = [
+            # empty
+            {"name": "",                "message": "All 8 nicknames are required."},
+            {"name": " ",               "message": "All 8 nicknames are required."},
+
+            # same as user
+            {"name": self.nickname,    "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+
+            # invalid character
+            {"name": "ニックネーム",      "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": ".",               "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "abc*012",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "abc_012",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "<script>alert('a')</script>",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+
+            # too short
+            {"name": "a",               "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "aa",              "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "  aa  ",          "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+
+            # too long
+            {"name": f"{'a' * 31}",     "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+            {"name": f"{'a' * 8192}",   "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 8192 文字になっています)。"},
+            {"name": "<script>alert('hello')</script>",     "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+        ]
+
+        print(f"[Testing] invalid player name")
+        for invalid_data in invalid_player_name_and_expected_messages:
+            invalid_player_name = invalid_data["name"]
+            expected_message = invalid_data["message"]
+            print(f" player name: [{invalid_player_name}]")
+
+            self._send_to_elem(By.CSS_SELECTOR,  '.slideup-text.form-floating:nth-of-type(3) input[name="nickname"]', invalid_player_name)
+            # self._screenshot("invalid_nickname_1")
+            self._submit_tournament(wait_invisible=False)
+            # self._screenshot("invalid_nickname_2")
+            self._assert_message(expected_message, value="error-message")
+            self._is_tournament_top()
+
+    def _submit_tournament(self, wait_invisible=True):
+        submit_button = self._button(By.CSS_SELECTOR, ".hth-btn.my-4")
+        self.driver.execute_script("arguments[0].click();", submit_button)
+        if wait_invisible:
+            self._wait_invisible(submit_button)
+
+    def _delete_tournament(self):
+        delete_button = self._button(By.ID, "delete-button")
+        self.driver.execute_script("arguments[0].click();", delete_button)
+        self._close_alert("Delete this tournament?")
+
+    def _is_tournament_top(self):
+        """
+        'Create Tournament'が表示されている場合はsign up pageとみなす
+        """
+        h1_element = self._element(
+            by=By.CSS_SELECTOR,
+            value="h2.slideup-text",
+        )
+        self.assertIn("Create Tournament", h1_element.text)
+
+    def _is_progress(self):
+        """
+        'Tournament is in progress.'が表示されている場合はsign up pageとみなす
+        """
+        h1_element = self._element(
+            by=By.CSS_SELECTOR,
+            value="h2#overview-header",
+        )
+        self.assertIn("Tournament is in progress.", h1_element.text)


### PR DESCRIPTION
#183 

## 概要
input周りの仕様、コーナーケースを再確認し、不足があれば変更＆テスト追加

<br>

## 主な変更内容
- E2Eテスト追加
  - 文字数、文字種、XSSの不足分を追加
  - Tournament name, player namesのテストを追加
- 登録上限数を仮決め（雑に決めただけ、少なくても良い気がしています）
  - user 10000
  - tournament 10000
- tournament
  - tournament name, player nameの文字数、文字種見直し
  - tournament create エラーメッセージ整形

<br>

## check
- [x] user
  - [x] 登録数
    - [x] max: 10000(暫定)
  - [x] nickname 登録: 05a3643, 変更: 413422e
    - [x] 重複: NG 
    - [x] min length: 3
      - [x] 登録
      - [x] 変更
    - [x] max length: 30
      - [x] 登録
      - [x] 変更
    - [x] 文字種: alnum
      - [x] 登録
      - [x] 変更
  - [x] email f94fd9a
    - [x] 重複: NG 
    - [x] min length: 5
      - [x] 登録
    - [x] max length: 64
      - [x] 登録
    - [x] 文字種: [validate_email()](https://docs.djangoproject.com/en/5.0/ref/validators/#emailvalidator)
      - [x] 登録
  - [x] password 登録: 217aa32, 変更: b180544
    - [x] min length: 8
      - [x] 登録
      - [x] 変更
    - [x] max length: 64
      - [x] 登録
      - [x] 変更
    - [x] 文字種: ascii
      - [x] 登録
      - [x] 変更
  - [x] avatar
    - [x] 拡張子 jpg, jpeg, png, gif
      - [x] 変更
    - [x] max size: 500kb
      - [x] 変更
    - [x] upload file name
      - [x] 変更
    - [x] avatars/ の保存imageが削除された場合にクラッシュしないか
      - [x] 変更
- [x] Friend
  - [x] 登録数
    - [x] max: 10000(暫定, user数以上にはならないため、設定なし)
- [x] Tournament
  - [x] 登録数
    - [x] max: 10000(暫定)
  - [x] Tournament name 52a24d1
    - [x] 重複: OK
    - [x] min length: 3
    - [x] max length: 30
    - [x] 文字種: `^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$` (中間のSP許容)
  - [x] Player nicknames 52a24d1
    - [x] 重複: NG 
    - [x] min length: 3(user nickname共通)
    - [x] max length: 30(user nickname共通)
    - [x] 文字種: alnum(user nickname共通)

<br>

## memo
- avatar画像のfilenameに全角や特殊記号が含まれている場合、`_`に置換され`media`に格納される
- user登録上限を超過（設定数6でテスト）
  <img src="https://github.com/42trans/ft_transcendence/assets/51146172/dd0dfd23-799e-4842-bfa3-1fc5a0393a9c" width="300">
- tournament登録数超過した場合（設定数2でテスト）
  <img src="https://github.com/42trans/ft_transcendence/assets/51146172/f8fc27ec-31a3-4f68-811e-c8adec08b14e" width="600">
- tournament nameの重複排除すると、APIのテストが落ちたため重複OKのまま。開催中のtournament名との重複排除は必要？とも思ったが、Offline Tournamentなので気にする必要はなさそう