### PR TITLE
[check] JWT

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
@@ -51,14 +51,14 @@ class JWTTest(APITestCase):
 
     def test_refresh_token(self):
         response = self._basic_login()
-        refresh_token = response.cookies.get('Refresh-Token').value
-
-        response = self.client.post(self.token_refresh_api_url, {'refresh': refresh_token})
+        response = self.client.post(self.token_refresh_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self._assert_jwt_in_cookie(response)
+        self.assertEqual(response.json()['message'], 'Access token is still valid')
 
     def test_refresh_token_with_invalid_token(self):
-        response = self.client.post(self.token_refresh_api_url, {'refresh': 'invalidtoken1234567890'})
+        self.client.cookies['Refresh-Token'] = 'invalidtoken1234567890'
+
+        response = self.client.post(self.token_refresh_api_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn('error', response.json())
         self.assertEqual(response.json()['error'], 'Token is invalid or expired')

--- a/docker/srcs/uwsgi-django/accounts/urls_api.py
+++ b/docker/srcs/uwsgi-django/accounts/urls_api.py
@@ -13,7 +13,7 @@ from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Enable2FaAPIView
 from accounts.views.two_factor_auth import Verify2FaAPIView
 from accounts.views.two_factor_auth import Disable2FaView
-from accounts.views.jwt import JWTRefreshView
+from accounts.views.jwt import JWTRefreshAPIView
 from accounts.views.block import BlockUserAPI, UnblockUserAPI
 from accounts.views.friend import SendFriendRequestAPI
 from accounts.views.friend import CancelFriendRequestAPI
@@ -37,7 +37,7 @@ urlpatterns = [
     path('api/verify_2fa/'          , Verify2FaAPIView.as_view()        , name='api_verify_2fa'),
     path('api/disable_2fa/'         , Disable2FaView.as_view()          , name='disable_2fa'),
 
-    path('api/token/refresh/'       , JWTRefreshView.as_view()          , name='api_token_refresh'),
+    path('api/token/refresh/'       , JWTRefreshAPIView.as_view()       , name='api_token_refresh'),
     path('oauth-ft/callback/'       , OAuthWith42.as_view()             , name='oauth_ft_callback'),
 
     path('api/block/<str:nickname>/'    , BlockUserAPI.as_view()        , name='api_block'),

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -103,8 +103,10 @@ AUTHENTICATION_BACKENDS = [
 
 
 SIMPLE_JWT = {
-	'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
-	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
+	'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
+	'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
+	# 'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
+	# 'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
 	'ROTATE_REFRESH_TOKENS': True,
 	'BLACKLIST_AFTER_ROTATION': True,
 	'UPDATE_LAST_LOGIN': False,

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -103,10 +103,10 @@ AUTHENTICATION_BACKENDS = [
 
 
 SIMPLE_JWT = {
-	'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
-	'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
-	# 'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
-	# 'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
+	# 'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
+	# 'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
+	'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
+	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
 	'ROTATE_REFRESH_TOKENS': True,
 	'BLACKLIST_AFTER_ROTATION': True,
 	'UPDATE_LAST_LOGIN': False,

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -3,6 +3,7 @@
 import { routeTable } from "./routing/routeTable.js"
 import { switchPage, renderView } from "./routing/renderView.js";
 import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
+import { refreshJWT } from "./utility/refreshJWT.js"
 import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
@@ -26,6 +27,7 @@ const setupPopStateListener = () => {
 
   window.addEventListener("popstate", (event) => {
     const path = window.location.pathname;
+    refreshJWT()
     stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
     renderView(path);
@@ -39,6 +41,7 @@ const setupDOMContentLoadedListener = () => {
   document.addEventListener("DOMContentLoaded", () => {
     console.log('DOMContentLoaded: path: ' + window.location.pathname + window.location.search);
     stopGamePageAnimation()
+    refreshJWT()
 
     // 初期ビューを表示
     const pathName = window.location.pathname;
@@ -95,12 +98,13 @@ const setupBodyClickListener = () => {
   document.body.addEventListener("click", async (event) => {
   console.log('clickEvent: path: ' + window.location.pathname);
   stopGamePageAnimation()
-  setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
+  refreshJWT()
 
     const linkElement = event.target.closest("[data-link]");
     if (linkElement) {
       console.log('clickEvent: taga-link');
       event.preventDefault();
+      setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
 
       const linkUrl = linkElement.href;
       const url = await getLoggedInUserRedirectUrl(linkUrl)
@@ -123,6 +127,7 @@ const setupBodyClickListener = () => {
 const setupLoadListener = () => {
   window.addEventListener("load", () => {
     console.log('loadEvent: path: ' + window.location.pathname);
+    refreshJWT()
 
     stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/refreshJWT.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/refreshJWT.js
@@ -1,0 +1,23 @@
+// spa/js/utility/refreshJWT.js
+
+// APIでaccess-tokenを再発行しcookieに設定するため、APIを呼ぶだけ
+export async function refreshJWT() {
+    try {
+        const response = await fetch('/accounts/api/token/refresh/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            console.log('[refreshJWT]Token refresh successful:', data.message);
+        } else {
+            console.log('[refreshJWT]Token refresh failed:', data.error);
+        }
+    } catch (error) {
+        console.log('[refreshJWT]Error refreshing token:', error);
+    }
+}


### PR DESCRIPTION
#177 

JWTの有効性、期限、client側の格納方法などを再確認 & リファクタリングなど

- [x] Refresh-Token発行APIの呼び出しを追加
- [x] 有効期限の検証
  - [x] Access-Token 30secに設定 -> login 30秒後に自動logoutを確認
  - [x] Refresh-Token 60secに設定 -> Access-Token期限後でも再度有効かを確認
- [ ] client側のデータ保持方法を見直し

<br>

## memo
- セキュリティ面を考慮し、access token, refresh tokenの有効期間 -> [2-1 継続使用しない（無効化する）& 有効期間を引き継がない](https://www.authlete.com/ja/kb/oauth-and-openid-connect/refresh-tokens/refreshing-refresh-tokens/#2-1-%E7%B6%99%E7%B6%9A%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84--%E6%9C%89%E5%8A%B9%E6%9C%9F%E9%96%93%E3%82%92%E5%BC%95%E3%81%8D%E7%B6%99%E3%81%8C%E3%81%AA%E3%81%84%E5%A0%B4%E5%90%88)  