### PR TITLE
[check] JWT再チェック

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: CREDENTIALS
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/block-user.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/block-user.js
@@ -8,8 +8,7 @@ function blockUser(nickname) {
     fetch(`/accounts/api/block/${nickname}/`, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/disable_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/disable_2fa.js
@@ -9,8 +9,7 @@ export function disable2FA() {
 		fetch('/accounts/api/disable_2fa/', {
 			method: 'POST',
 			headers: {
-				'Content-Type': 'application/json',
-				'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+				'Content-Type': 'application/json'
 			}
 		}).then(response => {
 			if (!response.ok) {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/edit_profile.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/edit_profile.js
@@ -11,8 +11,7 @@ export function updateNickname(event) {
 	fetch('/accounts/api/user/edit-profile/', {
 		method: 'POST',
 		headers: {
-			'Content-Type': 'application/json',
-			'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify({
 			nickname: nickname,
@@ -41,8 +40,7 @@ export function updatePassword(event) {
 	fetch('/accounts/api/user/edit-profile/', {
 		method: 'POST',
 		headers: {
-			'Content-Type': 'application/json',
-			'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify({
 			current_password: currentPassword,

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/enable_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/enable_2fa.js
@@ -8,7 +8,7 @@ export function fetchEnable2FA() {
 	fetch('/accounts/api/enable_2fa/', {
 		method: 'GET',
 		headers: {
-			'Content-Type': 'application/json',
+			'Content-Type': 'application/json'
 		}
 	})
 		.then(response => response.json())
@@ -42,7 +42,7 @@ function verifyToken() {
 	fetch('/accounts/api/enable_2fa/', {
 	method: 'POST',
 	headers: {
-		'Content-Type': 'application/json',
+		'Content-Type': 'application/json'
 	},
 	body: JSON.stringify({ token: token })
 	})

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -10,8 +10,7 @@ export function sendFriendRequest(userId) {
     fetch(`/accounts/api/friend/send-request/${userId}/`, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     }).then(response => {
         return response.json().then(data => {
@@ -36,8 +35,7 @@ export function cancelFriendRequest(userId) {
     fetch(`/accounts/api/friend/cancel-request/${userId}/`, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => {
@@ -64,8 +62,7 @@ export function acceptFriendRequest(userId) {
     fetch(`/accounts/api/friend/accept-request/${userId}/`, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     }).then(response => {
         return response.json().then(data => {
@@ -194,8 +191,7 @@ export function setupFriendRequestListEventListeners() {
 export function fetchFriendList() {
     fetch('/accounts/api/friend/list/', {
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => response.json())
@@ -290,8 +286,7 @@ export function fetchFriendRequestList() {
     // フレンド申請リストの一覧
     fetch("/accounts/api/friend/requests/", {
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => response.json())

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -88,8 +88,7 @@ export function rejectFriendRequest(userId) {
         fetch(`/accounts/api/friend/reject-request/${userId}/`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             }
         })
             .then(response => {
@@ -119,8 +118,7 @@ export function deleteFriend(userId) {
         fetch(`/accounts/api/friend/delete/${userId}/`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             }
         })
             .then(response => {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/unblock-user.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/unblock-user.js
@@ -8,8 +8,7 @@ function unblockUser(nickname) {
     fetch(`/accounts/api/unblock/${nickname}/`, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/upload-avatar.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/upload-avatar.js
@@ -20,9 +20,6 @@ function uploadAvatar() {
 
     fetch('/accounts/api/change-avatar/', {
         method: 'POST',
-        headers: {
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
-        },
         body: formData,
     }).then(handleResponse)
         .then(showSuccess)

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/userProfile.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/userProfile.js
@@ -65,8 +65,7 @@ function drawUserProfile(data) {
 export function fetchUserProfile() {
 	fetch("/accounts/api/user/profile/", {
 		headers: {
-			'Content-Type': 'application/json',
-			'Authorization': `Bearer ${localStorage.getItem('access')}`
+			'Content-Type': 'application/json'
 		}
 	})
 		.then(response => response.json())

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
@@ -18,7 +18,7 @@ function verify2FA() {
 	fetch('/accounts/api/verify_2fa/', {
 		method: 'POST',
 		headers: {
-			'Content-Type': 'application/json',
+			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify({ token: token , next: nextUrl})
 	})

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/edit_profile.html
@@ -42,8 +42,7 @@
         fetch('/accounts/api/user/edit-profile/', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             },
             body: JSON.stringify({
                 nickname: nickname,
@@ -69,8 +68,7 @@
         fetch('/accounts/api/user/edit-profile/', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             },
             body: JSON.stringify({
                 current_password: currentPassword,

--- a/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
@@ -51,14 +51,14 @@ class JWTTest(APITestCase):
 
     def test_refresh_token(self):
         response = self._basic_login()
-        refresh_token = response.cookies.get('Refresh-Token').value
-
-        response = self.client.post(self.token_refresh_api_url, {'refresh': refresh_token})
+        response = self.client.post(self.token_refresh_api_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self._assert_jwt_in_cookie(response)
+        self.assertEqual(response.json()['message'], 'Access token is still valid')
 
     def test_refresh_token_with_invalid_token(self):
-        response = self.client.post(self.token_refresh_api_url, {'refresh': 'invalidtoken1234567890'})
+        self.client.cookies['Refresh-Token'] = 'invalidtoken1234567890'
+
+        response = self.client.post(self.token_refresh_api_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn('error', response.json())
         self.assertEqual(response.json()['error'], 'Token is invalid or expired')

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -7,7 +7,7 @@ from accounts.views.basic_auth import LogoutTemplateView
 from accounts.views.basic_auth import LoginTemplateView
 from accounts.views.user import UserProfileView, get_user_info, ChangeAvatarView
 from accounts.views.user import EditUserProfileTemplateView
-from accounts.views.user import GetUserProfileTemplateView
+from accounts.views.user import GetUserHistoryTemplateView
 from accounts.views.friend import UserFriendsView
 from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Disable2FaView
@@ -30,7 +30,7 @@ urlpatterns = [
     path('edit/', EditUserProfileTemplateView.as_view(), name='edit'),
     path('change-avatar/', ChangeAvatarView.as_view(), name='change_avatar'),
 
-    path('history/', GetUserProfileTemplateView.as_view(), name='history'),
+    path('history/', GetUserHistoryTemplateView.as_view(), name='history'),
 
     path('friends/', UserFriendsView.as_view(), name='friends'),
 

--- a/docker/srcs/uwsgi-django/accounts/urls_api.py
+++ b/docker/srcs/uwsgi-django/accounts/urls_api.py
@@ -13,7 +13,7 @@ from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Enable2FaAPIView
 from accounts.views.two_factor_auth import Verify2FaAPIView
 from accounts.views.two_factor_auth import Disable2FaView
-from accounts.views.jwt import JWTRefreshView
+from accounts.views.jwt import JWTRefreshAPIView
 from accounts.views.block import BlockUserAPI, UnblockUserAPI
 from accounts.views.friend import SendFriendRequestAPI
 from accounts.views.friend import CancelFriendRequestAPI
@@ -37,7 +37,7 @@ urlpatterns = [
     path('api/verify_2fa/'          , Verify2FaAPIView.as_view()        , name='api_verify_2fa'),
     path('api/disable_2fa/'         , Disable2FaView.as_view()          , name='disable_2fa'),
 
-    path('api/token/refresh/'       , JWTRefreshView.as_view()          , name='api_token_refresh'),
+    path('api/token/refresh/'       , JWTRefreshAPIView.as_view()       , name='api_token_refresh'),
     path('oauth-ft/callback/'       , OAuthWith42.as_view()             , name='oauth_ft_callback'),
 
     path('api/block/<str:nickname>/'    , BlockUserAPI.as_view()        , name='api_block'),

--- a/docker/srcs/uwsgi-django/accounts/views/friend.py
+++ b/docker/srcs/uwsgi-django/accounts/views/friend.py
@@ -10,8 +10,6 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_simplejwt.authentication import JWTAuthentication
-from accounts.views.jwt import is_valid_jwt
 
 
 logging.basicConfig(
@@ -26,8 +24,6 @@ class UserFriendsView(LoginRequiredMixin, TemplateView):
     template_name = "accounts/friends.html"
 
     def get(self, request, *args, **kwargs):
-        if not is_valid_jwt(request):
-            return redirect('accounts:login')
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -26,8 +26,6 @@ from django.views.generic import TemplateView
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework_simplejwt.authentication import JWTAuthentication
-from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from accounts.forms import Enable2FAForm, Verify2FAForm

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -32,13 +32,10 @@ from accounts.views.jwt import is_valid_jwt
 logger = logging.getLogger(__name__)
 
 
-class UserProfileView(TemplateView):
+class UserProfileView(LoginRequiredMixin, TemplateView):
     template_name = "accounts/user.html"
 
     def get(self, request, *args, **kwargs):
-        if not is_valid_jwt(request):
-            return redirect('accounts:login')
-
         return super().get(request, *args, **kwargs)
 
 

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -59,13 +59,10 @@ class UserProfileAPIView(APIView):
         return JsonResponse(params)
 
 
-class EditUserProfileTemplateView(TemplateView):
+class EditUserProfileTemplateView(LoginRequiredMixin, TemplateView):
     template_name = "accounts/edit_profile.html"
 
     def get(self, request, *args, **kwargs):
-        if not is_valid_jwt(request):
-            return redirect('accounts:login')
-
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -109,7 +106,6 @@ class EditUserProfileAPIView(APIView):
         return Response(data, status=400)
 
     def _update_nickname(self, user, new_nickname):
-
         old_nickname = user.nickname
         if old_nickname == new_nickname:
             msg = "new nickname same as current"
@@ -119,11 +115,9 @@ class EditUserProfileAPIView(APIView):
         if is_ok is False:
             return False, err
 
-
         user.nickname = new_nickname
         user.save()
         return True, f"nickname updat successfully {old_nickname} -> {new_nickname}"
-
 
     def _update_password(self, request, input_current_password, new_password):
         user = request.user

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -26,7 +26,6 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from accounts.forms import UserEditForm, CustomPasswordChangeForm
 from accounts.models import CustomUser, UserManager, Friend
-from accounts.views.jwt import is_valid_jwt
 
 
 logger = logging.getLogger(__name__)
@@ -254,13 +253,10 @@ class UploadAvatarAPI(APIView):
                                   f' Allowed types are: jpg, jpeg, png, gif.')
 
 
-class GetUserProfileTemplateView(LoginRequiredMixin, TemplateView):
+class GetUserHistoryTemplateView(LoginRequiredMixin, TemplateView):
     template_name = "accounts/game_history.html"
 
     def get(self, request, *args, **kwargs):
-        if not is_valid_jwt(request):
-            return redirect('accounts:login')
-
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -50,8 +50,7 @@ export function startDMwithUser() {
         fetch(`/chat/api/validate-dm-target/${dmTargetNickname}/`, {
             method: 'GET',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             }
         })
             .then(response => {

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -9,8 +9,7 @@ export function fetchDMList() {
     fetch('/chat/api/dm-sessions/', {
         method: 'GET',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         }
     })
         .then(response => {

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/test-system-message.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/test-system-message.js
@@ -12,8 +12,7 @@ function sendSystemMessage(targetNickname) {
     fetch(url, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+            'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
     })

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -155,9 +155,7 @@ class TournamentCreator
 	// 進行中のトーナメントを確認する関数
 	async _isOngoingTournaments() {
 		try {
-			const response = await fetch(this.API_URLS.ongoingLatestTour, {
-				headers: {'Authorization': `Bearer ${localStorage.getItem('access_token')}`}
-			});
+			const response = await fetch(this.API_URLS.ongoingLatestTour);
 
 			// 見つからない場合でも、viewは204を返す。ここはそれ以外のエラーの場合の判定
 			// 見つからない場合のviewの戻り値: return JsonResponse({'status': 'success', 'message': 'No ongoing tournaments found'}, status=200)

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
@@ -23,7 +23,6 @@ class TournamentDeleter
 			{
 				method: 'POST',
 				headers: {
-					'Authorization': `Bearer ${localStorage.getItem('access_token')}`,
 					'X-CSRFToken': UIHelper.getCSRFToken(),
 					'Content-Type': 'application/json'
 				},

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
@@ -40,8 +40,7 @@ class TournamentOverview
 			const response = await fetch(url,
 			{
 				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+					'Content-Type': 'application/json'
 				}
 			});
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
@@ -90,9 +90,7 @@ class TournamentManager
 		try {
 					if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 
-			const response = await fetch(this.API_URLS.ongoingLatestTour, {
-				headers: {'Authorization': `Bearer ${localStorage.getItem('access_token')}`}
-			});
+			const response = await fetch(this.API_URLS.ongoingLatestTour);
 			// ongoingが見つからない場合は204が返ってくるので、ここではそれ以外のエラーを処理する。現状、APIにはそのような実装はないがハンドリングしておく
 			if (!response.ok) {
 				throw new Error(`Request failed with status ${response.status}`);

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/UserManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/UserManager.js
@@ -16,9 +16,7 @@ class UserManager
 		if (!this.userProfile) 
 		{
 			try {
-				let response = await fetch(config.API_URLS.userProfile, {
-					headers: {'Authorization': `Bearer ${localStorage.getItem('access_token')}`}
-				});
+				let response = await fetch(config.API_URLS.userProfile);
 
 						if (TEST_TRY1){	
 							response = {

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -103,8 +103,10 @@ AUTHENTICATION_BACKENDS = [
 
 
 SIMPLE_JWT = {
-	'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
-	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
+	'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
+	'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
+	# 'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
+	# 'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
 	'ROTATE_REFRESH_TOKENS': True,
 	'BLACKLIST_AFTER_ROTATION': True,
 	'UPDATE_LAST_LOGIN': False,

--- a/docker/srcs/uwsgi-django/trans_pj/settings.py
+++ b/docker/srcs/uwsgi-django/trans_pj/settings.py
@@ -103,10 +103,10 @@ AUTHENTICATION_BACKENDS = [
 
 
 SIMPLE_JWT = {
-	'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
-	'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
-	# 'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
-	# 'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
+	# 'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # テスト用
+	# 'REFRESH_TOKEN_LIFETIME': timedelta(seconds=60),  # テスト用
+	'ACCESS_TOKEN_LIFETIME': timedelta(hours=12),  # アクセストークンの有効期間
+	'REFRESH_TOKEN_LIFETIME': timedelta(days=1),  # リフレッシュトークンの有効期間
 	'ROTATE_REFRESH_TOKENS': True,
 	'BLACKLIST_AFTER_ROTATION': True,
 	'UPDATE_LAST_LOGIN': False,

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -3,6 +3,7 @@
 import { routeTable } from "./routing/routeTable.js"
 import { switchPage, renderView } from "./routing/renderView.js";
 import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
+import { refreshJWT } from "./utility/refreshJWT.js"
 import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
@@ -26,6 +27,7 @@ const setupPopStateListener = () => {
 
   window.addEventListener("popstate", (event) => {
     const path = window.location.pathname;
+    refreshJWT()
     stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
     renderView(path);
@@ -39,6 +41,7 @@ const setupDOMContentLoadedListener = () => {
   document.addEventListener("DOMContentLoaded", () => {
     console.log('DOMContentLoaded: path: ' + window.location.pathname + window.location.search);
     stopGamePageAnimation()
+    refreshJWT()
 
     // 初期ビューを表示
     const pathName = window.location.pathname;
@@ -95,6 +98,7 @@ const setupBodyClickListener = () => {
   document.body.addEventListener("click", async (event) => {
   console.log('clickEvent: path: ' + window.location.pathname);
   stopGamePageAnimation()
+  refreshJWT()
   setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
 
     const linkElement = event.target.closest("[data-link]");
@@ -123,6 +127,7 @@ const setupBodyClickListener = () => {
 const setupLoadListener = () => {
   window.addEventListener("load", () => {
     console.log('loadEvent: path: ' + window.location.pathname);
+    refreshJWT()
 
     stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
@@ -5,8 +5,7 @@ export async function isUserLoggedIn() {
         const response = await fetch('/accounts/api/is-user-logged-in/', {
             method: 'GET',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             },
         });
         const data = await response.json();
@@ -25,8 +24,7 @@ export async function isUserEnable2FA() {
         const response = await fetch('/accounts/api/is-user-enabled2fa/', {
             method: 'GET',
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${localStorage.getItem('access_token')}`
+                'Content-Type': 'application/json'
             },
         });
         const data = await response.json();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/refreshJWT.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/refreshJWT.js
@@ -1,0 +1,27 @@
+// spa/js/utility/refreshJWT.js
+
+// APIでaccess-tokenを再発行しcookieに設定するため、APIを呼ぶだけ
+export function refreshJWT() {
+    fetch('/accounts/api/token/refresh/', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+        .then(response => {
+            if (response.ok) {
+                return response.json();
+            } else {
+                console.log('[refreshJWT]Token refresh failed');
+                return null;
+            }
+        })
+        .then(data => {
+            if (data) {
+                console.log('[refreshJWT]Token refresh successful:', data.message);
+            }
+        })
+        .catch(error => {
+            console.log('[refreshJWT]Error refreshing token:', error);
+        });
+}


### PR DESCRIPTION
#177 

JWTの有効性、期限、client側の格納方法などを再確認 & リファクタリングなど


## 概要
- [x] Refresh-Token発行APIの呼び出しを追加
- [x] 有効期限の検証(`settings.SIMPLE_JWT`)
  - [x] Access-Token 30sec, Refresh-Token 30secに設定 -> login 30秒後に自動logoutを確認
  - [x] Access-Token 30sec, Refresh-Token 60secに設定 -> Access-Token期限後(31-60秒後)にAccessToken & Refresh-Token再発行を確認
- [x] client側のデータ保持方法を見直し
  - [x] https onlyのcookieで渡す(localStorageはXSS攻撃に対し脆弱, HTTP cookieは安全)
  - [x] cookieで判定 -> POST requestの際、headerの`'Authorization'`は不要のため削除


<br>

## JWT概要
- user情報を元に秘密鍵で署名されたJson形式のtoken(Acess-Token, Refresh-Token)を生成
https://github.com/42trans/ft_transcendence/blob/620abe595aa6947bfc7d22d75a096a164bd2cd30/docker/srcs/uwsgi-django/accounts/views/jwt.py#L19-L25
- Acess-Token, Refresh-Tokenをuserが保持し、serverはそのtokenを検証することでuserのlogin状態を評価することが可能。serverはuserのlogin状態を記録する必要がない、ステートレスな認証システムとなる
- Access-Tokenで認証を管理、Refresh-Tokenは有効期限延長用
- 有効期限
  - Access-Token < Refresh-Tokenであることが一般的
  - Access-Token期限切れでも、有効なRefresh-Tokenを保持しているclientに対し、serverは有効なAccess-Token( & Refresh-Token)を再発行する
  - Refresh-Token有効期限内にアクセスがなければ、認証は解除される

<br>

## memo
- セキュリティ面を考慮し、access token, refresh tokenの有効期間 -> [2-1 継続使用しない（無効化する）& 有効期間を引き継がない](https://www.authlete.com/ja/kb/oauth-and-openid-connect/refresh-tokens/refreshing-refresh-tokens/#2-1-%E7%B6%99%E7%B6%9A%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84--%E6%9C%89%E5%8A%B9%E6%9C%9F%E9%96%93%E3%82%92%E5%BC%95%E3%81%8D%E7%B6%99%E3%81%8C%E3%81%AA%E3%81%84%E5%A0%B4%E5%90%88)  
- `/spa/js/index.js`でページ切替ごとにJWTを更新する`refreshJWT()`を呼び出しています（AccessToken有効期限切れ && Refresh-Token有効期限内であれば、再度JWTを発行しLogin状態を維持するため）。`setupLoginEventListener`や`setOnlineStatus`とまとめた方が良さそう...