### PR TITLE
[fix] User Info: friend Deleteが機能しない

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -144,7 +144,7 @@ export function deleteFriend(userId) {
 }
 
 
-function setupFriendListEventListener() {
+export function setupDeleteFriendEventListener() {
     console.log("Setup friend event listeners");
     document.querySelectorAll('.deleteFriendButton').forEach(button => {
         button.addEventListener('click', () => {
@@ -195,7 +195,7 @@ export function fetchFriendList() {
         .then(response => response.json())
         .then(data => {
             createFriendsList(data);
-            setupFriendListEventListener()
+            setupDeleteFriendEventListener()
         })
         .catch(error => console.error('Error:', error));
 }

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
@@ -9,19 +9,13 @@
 	<li>xxx: xxx</li>
 	<li>xxx: xxx</li>
 	<li><a href="{{ url_config.kSpaDmWithUrlBase }}{{ user_data.info_user_nickname }}" data-link>DM with {{ user_data.info_user_nickname }}</a></li>
-	<br>
-	{% if not user_data.isBlockingUser %}
-		<button class="hth-btn blockUserButton" data-nickname="{{ user_data.info_user_nickname }}">block</button>
-	{% else %}
-		<button class="hth-btn unBlockUserButton" data-nickname="{{ user_data.info_user_nickname }}">unblock</button>
-	{% endif %}
 	{% comment %} <li><a href="#" onclick="sendSystemMessage('{{ user_data.info_user_nickname }}');">[test] send system message to {{ user_data.info_user_nickname }}</a></li> {% endcomment %}
 	{% comment %} <li><a href="#" onclick="sendSystemMessage('user1');">[test] send system message to user1</a></li> {% endcomment %}
 </ul>
 
 <hr>
 
-{% comment %} フレンド関係の表示  {% endcomment %}
+{% comment %} フレンド関係の表示 {% endcomment %}
 <ul>
 	<h4>friendship</h4>
 	{% if user_data.is_friend %}
@@ -37,6 +31,21 @@
 		<button class="hth-btn sendFriendRequestButton" data-userid="{{ user_data.info_user_id }}">Send Friend Reques</button>
 	{% endif %}
 </ul>
+
+<hr>
+
+{% comment %} Block {% endcomment %}
+<ul>
+	<h4>blocking</h4>
+	{% if not user_data.isBlockingUser %}
+		Unblocking
+		<button class="hth-btn blockUserButton" data-nickname="{{ user_data.info_user_nickname }}">block user</button>
+	{% else %}
+		Blocking
+		<button class="hth-btn unBlockUserButton" data-nickname="{{ user_data.info_user_nickname }}">unblock user</button>
+	{% endif %}
+</ul>
+
 
 {% comment %} <script src="{% static 'accounts/js/block-user.js' %}"></script> {% endcomment %}
 {% comment %} <script src="{% static 'accounts/js/unblock-user.js' %}"></script> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
@@ -25,13 +25,16 @@
 <ul>
 	<h4>friendship</h4>
 	{% if user_data.is_friend %}
-		<li>Friend -> <a href="#" class="deleteFriendButton" data-userid="{{ user_data.info_user_id }}">Delete</a></li>
+		Friend with You
+		<button class="hth-btn deleteFriendButton" data-userid="{{ user_data.info_user_id }}">Delete friendship</button>
 	{% elif user_data.friend_request_sent_status == "pending" %}
-		<li>Request sent (pending) -> <a href="#" class="cancelFriendRequestButton" data-userid="{{ user_data.info_user_id }}">Cancel</a></li>
+		Request sent (pending)
+		<button class="hth-btn cancelFriendRequestButton" data-userid="{{ user_data.info_user_id }}">Cancel</button>
 	{% elif user_data.friend_request_received_status == "pending" %}
-		<li>Request received (pending)</li>
+		Request received (pending)
 	{% else %}
-		<li><a href="#" class="sendFriendRequestButton" data-userid="{{ user_data.info_user_id }}">Send Friend Reques</a></li>
+		Not Friend Yet
+		<button class="hth-btn sendFriendRequestButton" data-userid="{{ user_data.info_user_id }}">Send Friend Reques</button>
 	{% endif %}
 </ul>
 

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
@@ -9,8 +9,6 @@
 	<li>xxx: xxx</li>
 	<li>xxx: xxx</li>
 	<li><a href="{{ url_config.kSpaDmWithUrlBase }}{{ user_data.info_user_nickname }}" data-link>DM with {{ user_data.info_user_nickname }}</a></li>
-	{% comment %} <li><a href="#" onclick="sendSystemMessage('{{ user_data.info_user_nickname }}');">[test] send system message to {{ user_data.info_user_nickname }}</a></li> {% endcomment %}
-	{% comment %} <li><a href="#" onclick="sendSystemMessage('user1');">[test] send system message to user1</a></li> {% endcomment %}
 </ul>
 
 <hr>
@@ -45,9 +43,3 @@
 		<button class="hth-btn unBlockUserButton" data-nickname="{{ user_data.info_user_nickname }}">unblock user</button>
 	{% endif %}
 </ul>
-
-
-{% comment %} <script src="{% static 'accounts/js/block-user.js' %}"></script> {% endcomment %}
-{% comment %} <script src="{% static 'accounts/js/unblock-user.js' %}"></script> {% endcomment %}
-{% comment %} <script type="module" src="{% static 'accounts/js/friend.js' %}"></script> {% endcomment %}
-{% comment %} <script src="{% static 'chat/js/test-system-message.js' %}"></script> {% endcomment %}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
@@ -30,5 +30,6 @@ export default class extends AbstractView {
 
       const friendModule = await import("/static/accounts/js/friend.js");
       friendModule.setupFriendRequestListEventListeners();
+      friendModule.setupDeleteFriendEventListener();
     }
 }

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
@@ -45,8 +45,8 @@ class FriendTest(TestConfig):
         self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
         # self._screenshot("friend2")
 
-        request_link = self._text_link("Send Friend Reques")
-        self._click_link(request_link, wait_for_link_invisible=True)
+        request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
+        self._click_button(request_button, wait_for_button_invisible=True)
 
         # test_user2のinfoでcancelFriendRequestButtonの存在を確認
         self._assert_element_exists(By.CSS_SELECTOR, ".cancelFriendRequestButton")
@@ -126,8 +126,8 @@ class FriendTest(TestConfig):
         self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
 
         # requestを送信
-        request_link = self._text_link("Send Friend Reques")
-        self._click_link(request_link, wait_for_link_invisible=True)
+        request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
+        self._click_button(request_button, wait_for_button_invisible=True)
 
         self.driver.refresh()
         time.sleep(0.5)
@@ -141,8 +141,8 @@ class FriendTest(TestConfig):
         time.sleep(0.5)
 
         # requestを再送信
-        request_link = self._text_link("Send Friend Reques")
-        self._click_link(request_link, wait_for_link_invisible=True)
+        request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
+        self._click_button(request_button, wait_for_button_invisible=True)
 
         # test_user1 friend page ###############################################
         self._move_top_to_friend()
@@ -169,8 +169,8 @@ class FriendTest(TestConfig):
         self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
         # self._screenshot("friend2")
 
-        request_link = self._text_link("Send Friend Reques")
-        self._click_link(request_link, wait_for_link_invisible=True)
+        request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
+        self._click_button(request_button, wait_for_button_invisible=True)
 
         # test_user1のSent Friend Requestsに追加されていることを確認
         self._move_top_to_friend()


### PR DESCRIPTION
#212 

- User Info pageのfriend deleteリンクが機能していなかった点を修正
- friend関係の操作をhth-button化

![Screenshot 2024-06-14 at 12 20 53](https://github.com/42trans/ft_transcendence/assets/51146172/4211d073-e715-460d-86f6-fe7a77feac6a)
