### PR TITLE
Fix #146 & onlineStatusリファクタリング

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/logout.js
@@ -21,7 +21,7 @@ function handleLogout() {
 	.then(data => {
 		if (data.message) {
 			alert(data.message);
-			console.log("redirect to " + data.redirect);
+			// console.log("redirect to " + data.redirect);
 			disconnectOnlineStatusWebSocket(data.user_id)
 
 			// alert(`Redirecting to ${data.redirect}. Check console logs before proceeding.`);  // debug

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -2,40 +2,40 @@
 
 import { deleteFriend, createActionButton } from "./friend.js"
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
-import { isUserLoggedIn } from "/static/spa/js/utility/isUser.js"
 
 
-let socket = null;
+let onlineStatusDebug = 1;
+let onlineStatusSocket = null;
 
 
 export function connectOnlineStatusWebSocket(userId) {
-    // console.log('Connecting WebSocket: userId: ' + userId);
+    if (onlineStatusDebug) { console.log('Connecting WebSocket: userId: ' + userId); }
 
-    if (socket && socket.readyState === WebSocket.OPEN) {
-        // console.log('WebSocket already connected');
+    if (onlineStatusSocket && onlineStatusSocket.readyState === WebSocket.OPEN) {
+        if (onlineStatusDebug) { console.log('WebSocket already connected'); }
         return;
     }
 
     const websocketUrl = 'wss://' + window.location.host + '/ws/online/';
-    // console.log(`connectOnlineStatusWebSocket websocketUrl:${websocketUrl}`);
+    if (onlineStatusDebug) { console.log(`connectOnlineStatusWebSocket websocketUrl:${websocketUrl}`); }
 
-    socket = new WebSocket(websocketUrl);
-    socket.onmessage = handleMessage;
-    socket.onopen = () => handleOpen(socket, userId);
-    socket.onclose = () => disconnectOnlineStatusWebSocket(userId);
-    socket.onerror = handleError;
+    onlineStatusSocket = new WebSocket(websocketUrl);
+    onlineStatusSocket.onmessage = handleMessage;
+    onlineStatusSocket.onopen = () => handleOpen(onlineStatusSocket, userId);
+    onlineStatusSocket.onclose = () => disconnectOnlineStatusWebSocket(userId);
+    onlineStatusSocket.onerror = handleError;
 
     // alert('connectOnlineStatusWebSocket completed')
 }
 
 
 export function disconnectOnlineStatusWebSocket(userId) {
-    // console.log('Disconnecting WebSocket: userId: ' + userId);
-    if (socket) {
-        // console.log(' socket exist -> disconnect');
-        sendStatusUpdate(socket, false, userId);
-        socket.close();
-        socket = null;
+    if (onlineStatusDebug) { console.log('Disconnecting WebSocket: userId: ' + userId); }
+    if (onlineStatusSocket) {
+        if (onlineStatusDebug) { console.log(' onlineStatusSocket exist -> disconnect'); }
+        sendStatusUpdate(onlineStatusSocket, false, userId);
+        onlineStatusSocket.close();
+        onlineStatusSocket = null;
     }
 }
 
@@ -45,29 +45,29 @@ function handleMessage(event) {
 }
 
 
-async function handleOpen(socket, userId) {
-    // console.log('WebSocket connection established');
-    socket.userId = userId;
-    await sendStatusUpdate(socket, true, userId);
+async function handleOpen(onlineStatusSocket, userId) {
+    if (onlineStatusDebug) { console.log('WebSocket connection established'); }
+    onlineStatusSocket.userId = userId;
+    await sendStatusUpdate(onlineStatusSocket, true, userId);
 }
 
 
-async function sendStatusUpdate(socket, status, userId) {
-    if (socket.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({ 'status': status, 'user_id': userId }));
-    } else if (socket.readyState === WebSocket.CONNECTING) {
-        await waitForWebSocketOpen(socket);
-        socket.send(JSON.stringify({ 'status': status, 'user_id': userId }));
+async function sendStatusUpdate(onlineStatusSocket, status, userId) {
+    if (onlineStatusSocket.readyState === WebSocket.OPEN) {
+        onlineStatusSocket.send(JSON.stringify({ 'status': status, 'user_id': userId }));
+    } else if (onlineStatusSocket.readyState === WebSocket.CONNECTING) {
+        await waitForWebSocketOpen(onlineStatusSocket);
+        onlineStatusSocket.send(JSON.stringify({ 'status': status, 'user_id': userId }));
     } else {
-        console.error('WebSocket is not open. readyState: ' + socket.readyState);
+        console.error('WebSocket is not open. readyState: ' + onlineStatusSocket.readyState);
     }
 }
 
 
-function waitForWebSocketOpen(socket) {
+function waitForWebSocketOpen(onlineStatusSocket) {
     return new Promise((resolve) => {
-        socket.addEventListener('open', function onOpen() {
-            socket.removeEventListener('open', onOpen);
+        onlineStatusSocket.addEventListener('open', function onOpen() {
+            onlineStatusSocket.removeEventListener('open', onOpen);
             resolve();
         });
     });
@@ -84,7 +84,7 @@ function updateFriendStatus(event) {
     const userId = data.user_id;
     const status = data.status;
 
-    // console.log(`Received status update: userId=${userId}, status=${status}`);
+    if (onlineStatusDebug) { console.log(`Received status update: userId=${userId}, status=${status}`); }
 
     // 変更があったフレンドのみ更新
     var statusElement = document.getElementById('friend-status-' + userId);
@@ -159,77 +159,4 @@ function updateOrCreateFriendListItem(friend) {
     listItem.appendChild(deleteButton);
 
     return listItem;
-}
-
-
-export function fetchUserId() {
-    return fetch("/accounts/api/user/profile/")
-        .then(response => {
-            if (!response.ok) {
-                // console.log('GuestUser? UserID not found');
-                return null;
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data.id) {
-                // console.log('GuestUser? UserID not found');
-                return null;
-            }
-            return data.id;
-        })
-        .catch(error => {
-            // console.log('Error:', error);
-            return null;
-        });
-}
-
-
-function onPageLoad(userId) {
-    connectOnlineStatusWebSocket(userId);
-}
-
-function isEventListenerRegistered(element, eventName, listener) {
-    const eventListeners = getEventListeners(element);
-    return eventListeners[eventName] && eventListeners[eventName].some(l => l.listener === listener);
-}
-
-function getEventListeners(element) {
-    return element.eventListenerList || {};
-}
-
-function setOnlineStatusHandler(userId) {
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
-        onPageLoad(userId);
-    } else {
-        if (!isEventListenerRegistered(window, 'load', onPageLoad)) {
-            window.addEventListener('load', onPageLoad, {
-                once: true,
-                passive: true
-            });
-        }
-    }
-
-    if (!isEventListenerRegistered(window, 'popstate', onPageLoad)) {
-        window.addEventListener('popstate', onPageLoad, {
-            passive: true
-        });
-    }
-}
-
-export async function setOnlineStatus() {
-    // console.log('setOnlineStatus called');
-    const isLoggedIn = await isUserLoggedIn();
-    if (!isLoggedIn) {
-        return;
-    }
-
-    // login userの場合に onlineStatusを評価
-    fetchUserId().then(userId => {
-        if (!userId) {
-            // console.log('GuestUser? UserID not found');
-            return;
-        }
-        setOnlineStatusHandler(userId);
-    });
 }

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -4,7 +4,7 @@ import { deleteFriend, createActionButton } from "./friend.js"
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 
 
-let onlineStatusDebug = 1;
+let onlineStatusDebug = 0;
 let onlineStatusSocket = null;
 
 

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -22,7 +22,7 @@ export function connectOnlineStatusWebSocket(userId) {
     socket = new WebSocket(websocketUrl);
     socket.onmessage = handleMessage;
     socket.onopen = () => handleOpen(socket, userId);
-    socket.onclose = () => handleClose(socket, userId);
+    socket.onclose = () => disconnectOnlineStatusWebSocket(userId);
     socket.onerror = handleError;
 
     // alert('connectOnlineStatusWebSocket completed')

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -2,6 +2,7 @@
 
 import { deleteFriend, createActionButton } from "./friend.js"
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { isUserLoggedIn } from "/static/spa/js/utility/isUser.js"
 
 
 let socket = null;
@@ -184,8 +185,12 @@ export function fetchUserId() {
 }
 
 
-export function setOnlineStatus() {
+export async function setOnlineStatus() {
     // console.log('setOnlineStatus called');
+    const isLoggedIn = await isUserLoggedIn();
+    if (!isLoggedIn) {
+        return;
+    }
 
     fetchUserId().then(userId => {
         if (!userId) {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/setOnlineStatus.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/setOnlineStatus.js
@@ -27,38 +27,6 @@ function fetchUserId() {
 }
 
 
-function onPageLoad(userId) {
-    connectOnlineStatusWebSocket(userId);
-}
-
-function isEventListenerRegistered(element, eventName, listener) {
-    const eventListeners = getEventListeners(element);
-    return eventListeners[eventName] && eventListeners[eventName].some(l => l.listener === listener);
-}
-
-function getEventListeners(element) {
-    return element.eventListenerList || {};
-}
-
-function setOnlineStatusHandler(userId) {
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
-        onPageLoad(userId);
-    } else {
-        if (!isEventListenerRegistered(window, 'load', onPageLoad)) {
-            window.addEventListener('load', onPageLoad, {
-                once: true,
-                passive: true
-            });
-        }
-    }
-
-    if (!isEventListenerRegistered(window, 'popstate', onPageLoad)) {
-        window.addEventListener('popstate', onPageLoad, {
-            passive: true
-        });
-    }
-}
-
 export async function setOnlineStatus() {
     // console.log('setOnlineStatus called');
     const isLoggedIn = await isUserLoggedIn();
@@ -74,6 +42,6 @@ export async function setOnlineStatus() {
             // console.log('GuestUser? UserID not found');
             return;
         }
-        setOnlineStatusHandler(userId);
+        connectOnlineStatusWebSocket(userId);
     });
 }

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/setOnlineStatus.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/setOnlineStatus.js
@@ -1,0 +1,79 @@
+// setOnlineStatusHandler.js
+
+import { connectOnlineStatusWebSocket } from "./online-status.js"
+import { isUserLoggedIn } from "/static/spa/js/utility/isUser.js"
+
+
+function fetchUserId() {
+    return fetch("/accounts/api/user/profile/")
+        .then(response => {
+            if (!response.ok) {
+                // console.log('GuestUser? UserID not found');
+                return null;
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (!data.id) {
+                // console.log('GuestUser? UserID not found');
+                return null;
+            }
+            return data.id;
+        })
+        .catch(error => {
+            // console.log('Error:', error);
+            return null;
+        });
+}
+
+
+function onPageLoad(userId) {
+    connectOnlineStatusWebSocket(userId);
+}
+
+function isEventListenerRegistered(element, eventName, listener) {
+    const eventListeners = getEventListeners(element);
+    return eventListeners[eventName] && eventListeners[eventName].some(l => l.listener === listener);
+}
+
+function getEventListeners(element) {
+    return element.eventListenerList || {};
+}
+
+function setOnlineStatusHandler(userId) {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+        onPageLoad(userId);
+    } else {
+        if (!isEventListenerRegistered(window, 'load', onPageLoad)) {
+            window.addEventListener('load', onPageLoad, {
+                once: true,
+                passive: true
+            });
+        }
+    }
+
+    if (!isEventListenerRegistered(window, 'popstate', onPageLoad)) {
+        window.addEventListener('popstate', onPageLoad, {
+            passive: true
+        });
+    }
+}
+
+export async function setOnlineStatus() {
+    // console.log('setOnlineStatus called');
+    const isLoggedIn = await isUserLoggedIn();
+    if (!isLoggedIn) {
+        // console.log('setOnlineStatus: isLogin: false');
+        return;
+    }
+    // console.log('setOnlineStatus: isLogin: true');
+
+    // login userの場合に onlineStatusを評価
+    fetchUserId().then(userId => {
+        if (!userId) {
+            // console.log('GuestUser? UserID not found');
+            return;
+        }
+        setOnlineStatusHandler(userId);
+    });
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -25,20 +25,20 @@ import { setupLoginEventListener } from "/static/accounts/js/login.js"
 const setupPopStateListener = () => {
   // console.log('popState: path: ' + window.location.pathname);
 
-  window.addEventListener("popstate", (event) => {
+  window.addEventListener("popstate", async (event) => {
     const path = window.location.pathname;
     refreshJWT()
     // stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
     renderView(path);
-    setOnlineStatus();  // WebSocket接続を再確立
+    await setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 
 
 // spa.htmlの読み込みと解析が完了した時点で発火
 const setupDOMContentLoadedListener = () => {
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", async () => {
     console.log('DOMContentLoaded: path: ' + window.location.pathname + window.location.search);
     // stopGamePageAnimation()
     refreshJWT()
@@ -52,7 +52,7 @@ const setupDOMContentLoadedListener = () => {
     // リンククリック時の遷移を設定
     setupBodyClickListener();
 
-    setOnlineStatus();  // WebSocket接続を再確立
+    await setOnlineStatus();  // WebSocket接続を再確立
 
     // three-jsのEndGameボタン押下でSPA遷移するためのイベント
     // document.addEventListener('endGame', function() {
@@ -118,20 +118,20 @@ const setupBodyClickListener = () => {
     //   const url = event.target.href;
     //   switchPage(url);
     // }
-    // setOnlineStatus();  // WebSocket接続を再確立
+    // await setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 
 
 // ページリロード時に発火
 const setupLoadListener = () => {
-  window.addEventListener("load", () => {
+  window.addEventListener("load", async () => {
     console.log('loadEvent: path: ' + window.location.pathname);
     refreshJWT()
 
     // stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
-    setOnlineStatus();  // WebSocket接続を再確立
+    await setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -4,7 +4,6 @@ import { routeTable } from "./routing/routeTable.js"
 import { switchPage, renderView } from "./routing/renderView.js";
 import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { refreshJWT } from "./utility/refreshJWT.js"
-import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
 
@@ -31,7 +30,7 @@ const setupPopStateListener = () => {
     // stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
     renderView(path);
-    await setOnlineStatus();  // WebSocket接続を再確立
+    setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 
@@ -51,8 +50,6 @@ const setupDOMContentLoadedListener = () => {
 
     // リンククリック時の遷移を設定
     setupBodyClickListener();
-
-    await setOnlineStatus();  // WebSocket接続を再確立
 
     // three-jsのEndGameボタン押下でSPA遷移するためのイベント
     // document.addEventListener('endGame', function() {
@@ -118,7 +115,6 @@ const setupBodyClickListener = () => {
     //   const url = event.target.href;
     //   switchPage(url);
     // }
-    // await setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 
@@ -131,7 +127,6 @@ const setupLoadListener = () => {
 
     // stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
-    await setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -30,7 +30,6 @@ const setupPopStateListener = () => {
     // stopGamePageAnimation()
     setupLoginEventListener()  // loginリダイレクト時にlogin buttonを設定
     renderView(path);
-    setOnlineStatus();  // WebSocket接続を再確立
   });
 };
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,6 +1,6 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
-import { setOnlineStatus } from "/static/accounts/js/online-status.js";
+import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
 
 const DEBUG_DETAIL = 0;
 
@@ -36,7 +36,7 @@ export const switchPage = (targePath) => {
   // }
   renderView(targetPathName).then(() => {
     window.dispatchEvent(new CustomEvent('switchPageResetState'));
-    setOnlineStatus();
+    // setOnlineStatus();
   });
 };
 
@@ -127,6 +127,8 @@ export const renderView = async (path) => {
   await view.executeScript();
         if (DEBUG_DETAIL) { console.log('renderView(): currentView', currentView); }
         if (DEBUG_DETAIL) { console.log('renderView(): selectedRoute.params', selectedRoute.params); }
+
+  setOnlineStatus();
 };
 
 // export const renderView = async (path) => {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,5 +1,6 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
+import { setOnlineStatus } from "/static/accounts/js/online-status.js";
 
 const DEBUG_DETAIL = 0;
 
@@ -35,6 +36,7 @@ export const switchPage = (targePath) => {
   // }
   renderView(targetPathName).then(() => {
     window.dispatchEvent(new CustomEvent('switchPageResetState'));
+    setOnlineStatus();
   });
 };
 


### PR DESCRIPTION
## #146 修正
- [x] Guest 401エラー抑制のため、`isLoggedIn` 評価後にwebsocket操作するよう変更  c498469

<br>

## その他修正・リファクタリング
- [x] `setOnlineStatus()` を `renderView()` に一元化  425fd9f -> 8413a88
- [x] logout時の`connectOnlineStatusWebSocket()` エラーハンドリング
  ```
  Uncaught ReferenceError: handleClose is not defined
      at socket.onclose (online-status.js:25:28)
  ```
- [x] Guest popState遷移 -> login -> onlineStatus反映なし・ページ遷移でも反映なし -> reloadで反映: eventListener経由せず、`connectOnlineStatusWebSocket()`の直接呼び出しで安定  35c5478