### PR TITLE
2D戻る・進むのバグ、EventListenerの廃棄

### DIFF
--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
@@ -2,6 +2,7 @@
 class PongEngineKey 
 {
 	static keys = {/** empty */};
+	static isListenerRegistered = false;
 
 	static listenForEvents() 
 	{
@@ -20,6 +21,29 @@ class PongEngineKey
 		});
 	}
 
+	static listenForEvents() 
+	{
+		if (!PongEngineKey.isListenerRegistered) {
+			window.addEventListener('keydown', PongEngineKey.handleKeyDown);
+			window.addEventListener('keyup', PongEngineKey.handleKeyUp);
+			PongEngineKey.isListenerRegistered = true;
+		}
+	}
+
+	static removeListeners() 
+	{
+		if (PongEngineKey.isListenerRegistered) {
+			window.removeEventListener('keydown', PongEngineKey.handleKeyDown);
+			window.removeEventListener('keyup', PongEngineKey.handleKeyUp);
+			PongEngineKey.isListenerRegistered = false;
+		}
+	}
+	
+	static handleKeyDown(event) 
+	{
+		const key = event.key.toUpperCase();
+		PongEngineKey.keys[key] = true;
+	}
 	static isDown(key) 
 	{
 		return PongEngineKey.keys[key.toUpperCase()];

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameLoopManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameLoopManager.js
@@ -144,6 +144,26 @@ class PongOnlineGameLoopManager
 			console.error('hth: updateEndGameBtn() failed: ', error);
 		}
 	}
+
+	dispose() {
+		// アニメーションループの停止
+		if (this.animationFrameId) {
+			cancelAnimationFrame(this.animationFrameId);
+			this.animationFrameId = null;
+		}
+	
+		const endGameButton = document.getElementById('hth-pong-online-back-to-home-btn');
+		if (endGameButton) {
+			endGameButton.removeEventListener('click', this.endGameButtonClickHandler);
+		}
+
+		this.renderer = null;
+		this.clientApp = null;
+		this.gameStateManager = null;
+		this.field = null;
+		this.ctx = null;
+		this.canvas = null;
+	}
 }
 
 export default PongOnlineGameLoopManager;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -160,6 +160,31 @@ class PongOnlineGameStateManager
 		return this.gameState;
 	}
 
+	dispose() {
+		window.removeEventListener('resize', this.resizeHandler);
+
+		if (this.renderer) {
+			this.renderer.dispose();
+			this.renderer = null;
+		}
+		if (this.loopManager) {
+			this.loopManager.dispose();
+			this.loopManager = null;
+		}
+	
+		this.clientApp = null;
+		this.ctx = null;
+		this.canvas = null;
+		this.field = null;
+		this.socket = null;
+		this.finalGameState = null;
+		this.gameState = {
+			game_settings: {},
+			objects: {},
+			state: {},
+			is_running: false
+		};
+	}
 }
 
 export default PongOnlineGameStateManager;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -5,4 +5,45 @@ import PongOnlineClientApp from './PongOnlineClientApp.js';
  * 2D-Pong entry point
  */
 
-PongOnlineClientApp.main();
+// PongOnlineClientApp.main();
+
+let pongOnlineClientApp = null;
+let isEventListenerRegistered = false;
+
+async function initPongOnlineClientApp() 
+{
+	if (pongOnlineClientApp) {
+		pongOnlineClientApp.dispose();
+		pongOnlineClientApp = null;
+	}
+	pongOnlineClientApp = new PongOnlineClientApp();
+}
+
+async function disposePongOnlineClientApp() 
+{
+	if (pongOnlineClientApp) 
+	{
+		pongOnlineClientApp.dispose();
+		pongOnlineClientApp = null;
+	}
+}
+
+async function handleSwitchPageResetState() {
+	await initPongOnlineClientApp();
+}
+
+function registerEventListenerSwitchPageResetState() {
+	if (isEventListenerRegistered) {
+		return;
+	}
+	window.addEventListener('switchPageResetState', handleSwitchPageResetState);
+	isEventListenerRegistered = true;
+}
+
+registerEventListenerSwitchPageResetState();
+
+initPongOnlineClientApp();
+
+if (!window.disposePongOnlineClientApp) {
+	window.disposePongOnlineClientApp = disposePongOnlineClientApp;
+}

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
@@ -201,6 +201,14 @@ class PongOnlineRenderer
 		}
 	}
 
+	dispose() {
+		this.gameStateManager = null;
+		this.field = null;
+		this.ctx = null;
+		this.canvas = null;
+		this.gameState = null;
+	}
+	
 }
 
 export default PongOnlineRenderer;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
@@ -177,25 +177,6 @@ class PongOnlineSyncWS
 		console.error("hth: WebSocket error:", event);
 		alert('WebSocketの接続でエラーが起きました');
 	}
-
-
-
-	// createButton(text, id, onClickHandler) 
-	// {
-	// 	try {
-	// 				if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
-
-	// 		const button		= document.createElement('button');
-	// 		button.textContent	= text;
-	// 		button.id			= id;
-	// 		button.classList.add('hth-btn');
-	// 		document.getElementById('hth-main').appendChild(button);
-	// 		button.addEventListener('click', onClickHandler);
-	// 	} catch (error) {
-	// 		console.error('hth:: createButton() failed: ', error);
-	// 	}
-	// }
-
 	
 	/** dev用 再接続チェック用 */
 	// devTestCloseButton()
@@ -204,6 +185,15 @@ class PongOnlineSyncWS
 	// 		this.socket.close();
 	// 	});
 	// }
+
+	dispose() {
+		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+			this.socket.close();
+			this.socket = null;
+		}
+		this.clientApp = null;
+		this.gameStateManager = null;
+	}
 }
 
 export default PongOnlineSyncWS;

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
@@ -1,10 +1,11 @@
-// Game1vs1.js
+// docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
 
 import AbstractView from "../AbstractView.js";
 import fetchData from "../../utility/fetch.js";
 import { getUrl } from "../../utility/url.js";
 import { loadAndExecuteScript } from "../../utility/script.js";
 
+const DEBUG_FLOW = 1;
 
 export default class extends AbstractView {
   constructor(params) {
@@ -21,6 +22,14 @@ export default class extends AbstractView {
 
   async executeScript() {
     loadAndExecuteScript("/static/pong/js/online/PongOnlineIndex.js", true);
+  }
+
+  async dispose() {
+          if (DEBUG_FLOW) {  console.log('FreePlay: disopose(): start'); }
+    // disposePongOnlineClientApp()の定義: static/pong/js/online/PongOnlineIndex.js
+    if (typeof window.disposePongOnlineClientApp === 'function') {
+      window.disposePongOnlineClientApp();
+    }
   }
 
 }

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -38,7 +38,6 @@ async function initPongApp(env)
 {
 				if (DEBUG_FLOW) {	console.log('initPongApp(): start');	}
 	if (window.pongApp){
-		// return;
 		await window.pongApp.destroy();
 		window.pongApp = null;
 	}


### PR DESCRIPTION
#223 
#227 
## BUG
- 2Dの戻る、進むのバグ修正
- 戻る、進むの回数だけインスタンスが増えていく？。サーバーには複数のクライアントから同時にリクエスト => ボールが増える
## 修正
- viewクラスでdispose()
- それをトリガーに、念の為、インスタンスとプロパティのnull埋めを全クラスで。
- eventListenerの廃棄
- 3Dと同様のロジックにOnlineIndex.jsを変更