### PR TITLE
DM Socketのdispose 

### DIFF
--- a/docker/srcs/uwsgi-django/chat/dm_consumers.py
+++ b/docker/srcs/uwsgi-django/chat/dm_consumers.py
@@ -175,5 +175,5 @@ class DMConsumer(Consumer):
             message_instance.save()
             return message_instance
         except Exception as e:
-            logger.debug(f'[DMConsumer]: Error: storing message: {str(e)}')
+            logger.debug(f'[DMConsumer]: Error: store message: {str(e)}')
             raise e

--- a/docker/srcs/uwsgi-django/chat/models.py
+++ b/docker/srcs/uwsgi-django/chat/models.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from django.core.exceptions import ValidationError
 from django.core.validators import MaxLengthValidator
 from django.db import models
 from shortuuidfield import ShortUUIDField

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
@@ -1,6 +1,6 @@
 // chat/js/dm-with-user.js
 import { applyStylesToInitialLoadMessages } from './module/apply-message-style.js';
-import { setupDmWebsocket } from './module/setup-dm-websocket.js';
+import { setupDmWebsocket, closeDmSocket } from './module/setup-dm-websocket.js';
 import { setupSendKeyEventListener, scrollToBottom } from './module/ui-util.js';
 
 
@@ -26,5 +26,6 @@ export function initDM() {
 }
 
 
-// ページが完全に読み込まれた後にDM画面を初期化し、初期スクロール位置を設定
-// document.addEventListener('DOMContentLoaded', initDM);
+export function disposeDM() {
+    closeDmSocket();
+}

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -54,7 +54,6 @@ function handleSendMessage(dmSocket) {
     }
     // メッセージの長さが128文字を超える場合は送信せず、エラーメッセージを表示（Message modelsでMax128に制限）
     if (128 < message.length) {
-
         const over = message.length - 128;
         const overCharaMessage = `${over === 1 ? `${over} character over` :  `${over} characters over`}`
         errorMessageDom.textContent = `Message must be less than 128 characters, ${overCharaMessage}`;

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -7,10 +7,12 @@ import { scrollToBottom } from './ui-util.js';
 export { setupDmWebsocket };
 
 
+let dmSocket = null;
+
 // WebSocketの接続確立とメッセージの送受信ロジック
 function setupDmWebsocket(dmTargetNickname) {
     const websocketUrl = 'wss://' + window.location.host + '/ws/dm-with/' + dmTargetNickname + '/';
-    const dmSocket = new WebSocket(websocketUrl);
+    dmSocket = new WebSocket(websocketUrl);
 
     dmSocket.onmessage = (event) => handleReceiveMessage(event, dmTargetNickname);
     dmSocket.onopen = () => handleOpen(dmSocket, dmTargetNickname);
@@ -27,7 +29,7 @@ function handleOpen(dmTargetNickname) {
 
 
 function handleClose(event) {
-    console.error('Chat socket closed unexpectedly:', event);
+    console.log('Chat socket closed:', event);
 }
 
 function handleError(event) {
@@ -51,4 +53,12 @@ function handleSendMessage(dmSocket) {
     }));
     messageInputDom.value = '';
     scrollToBottom();  // dm-logのスクロール位置を調整
+}
+
+
+export function closeDmSocket() {
+    if (dmSocket && dmSocket.readyState === WebSocket.OPEN) {
+        dmSocket.close();
+        dmSocket = null;
+    }
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -54,7 +54,10 @@ function handleSendMessage(dmSocket) {
     }
     // メッセージの長さが128文字を超える場合は送信せず、エラーメッセージを表示（Message modelsでMax128に制限）
     if (128 < message.length) {
-        errorMessageDom.textContent = 'Message must be less than 128 characters';
+
+        const over = message.length - 128;
+        const overCharaMessage = `${over === 1 ? `${over} character over` :  `${over} characters over`}`
+        errorMessageDom.textContent = `Message must be less than 128 characters, ${overCharaMessage}`;
         return;
     }
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -44,18 +44,26 @@ function handleError(event) {
 function handleSendMessage(dmSocket) {
     const messageInputDom = document.querySelector('#message-input');
     const message = messageInputDom.value;
+    const errorMessageDom = document.querySelector('#error-message');
 
     // console.log('message: ' + message)
     // 空文字列、空白のみのメッセージの送信はしない
     if (message.trim() === '') {
-        // console.log(' smessage is empty')
+        errorMessageDom.textContent = 'Message can not be empty';
+        return;
+    }
+    // メッセージの長さが128文字を超える場合は送信せず、エラーメッセージを表示（Message modelsでMax128に制限）
+    if (128 < message.length) {
+        errorMessageDom.textContent = 'Message must be less than 128 characters';
         return;
     }
 
     dmSocket.send(JSON.stringify({
         'message': message
     }));
+
     messageInputDom.value = '';
+    errorMessageDom.textContent = '';
     scrollToBottom();  // dm-logのスクロール位置を調整
 }
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -11,6 +11,10 @@ let dmSocket = null;
 
 // WebSocketの接続確立とメッセージの送受信ロジック
 function setupDmWebsocket(dmTargetNickname) {
+    if (dmSocket) {
+        closeDmSocket();
+    }
+
     const websocketUrl = 'wss://' + window.location.host + '/ws/dm-with/' + dmTargetNickname + '/';
     dmSocket = new WebSocket(websocketUrl);
 
@@ -57,8 +61,14 @@ function handleSendMessage(dmSocket) {
 
 
 export function closeDmSocket() {
-    if (dmSocket && dmSocket.readyState === WebSocket.OPEN) {
-        dmSocket.close();
+    if (dmSocket) {
+        if (dmSocket.readyState === WebSocket.CONNECTING) {
+            dmSocket.onopen = () => {
+                dmSocket.close();
+            };
+        } else if (dmSocket.readyState === WebSocket.OPEN) {
+            dmSocket.close();
+        }
         dmSocket = null;
     }
 }

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -10,6 +10,8 @@
 
 
 {% if not isBlockingUser %}
+    <p id="error-message"></p>
+
     <div id="dm-container">
     
         {% comment %} DM logを表示  {% endcomment %}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
@@ -22,8 +22,12 @@ export default class extends AbstractView {
   }
 
   async executeScript() {
-    // loadAndExecuteScript("/static/chat/js/dm-with-user.js", true);
     const dmWithUserModule = await import("/static/chat/js/dm-with-user.js");
     dmWithUserModule.initDM();
+  }
+
+  async dispose() {
+    const dmWithUserModule = await import("/static/chat/js/dm-with-user.js");
+    dmWithUserModule.disposeDM();
   }
 }


### PR DESCRIPTION
#232 

- DM pageを複数回開くとsocketが重複し、メッセージの送信がバグる -> ページ離脱時にdisposeを追加
- 129文字以上のメッセージ送信でsocket closeされる対策  79855c9
  - Message modelで129文字以上をNG判定 -> DM socket closeでDM継続不可になっていた
  - 送信前のmessage長さチェックを追加しDM継続可能に
  - 文字列長判定がオーバーフローしバグり、巨大文字列がDBに書き込まれることはなさそう

<br>

## memo
- JSのstring.lengthは`MAX_SAFE_INTEGER = 9007199254740991` までは精度を保証
-浮動小数点ラッパーの型のため、それ以上は正確に表現できなくなるが、オーバーフローはしない

<br>

## Ref
- [MAX_SAFE_INTEGER](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)