### PR TITLE
Fix spa append script

### DIFF
--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -121,8 +121,12 @@ export const renderView = async (path) => {
   const view = new selectedRoute.view(selectedRoute.params);
   currentView = view;
   const htmlSrc = await view.getHtml();
-  document.querySelector("#spa").innerHTML = htmlSrc;
-  await view.executeScript();
+
+  let spaElement = document.querySelector("#spa");
+  spaElement.innerHTML = htmlSrc;
+
+  // document.querySelector("#spa").innerHTML = htmlSrc;
+  await view.executeScript(spaElement);
         // DEBUG
         if (DEBUG_DETAIL) { console.log('renderView():htmlSrc', htmlSrc); }
         if (DEBUG_DETAIL) { console.log('renderView(): currentView', currentView); }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/script.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/script.js
@@ -30,12 +30,12 @@ function loadScript(scriptElement) {
  * @param {string} path - スクリプトファイルのパス
  * @param {boolean} [isModule=false] - スクリプトをモジュールとして読み込むかどうか
  */
-export async function loadAndExecuteScript(path, isModule = false) {
+export async function loadAndExecuteScript(spaElement, path, isModule = false) {
   // console.log("loadAndExecuteScript: path: " + path);
 
   // <script src="path"></script>
   const scriptElement = getScriptElement(path, isModule)
-  document.body.appendChild(scriptElement);
+  spaElement.appendChild(scriptElement);
   await loadScript(scriptElement)
 }
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/script.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/script.js
@@ -12,6 +12,8 @@ function getScriptElement(path, isModule) {
 
 function loadScript(scriptElement) {
   return new Promise((resolve, reject) => {
+
+    // DOM要素のscriptElementに対し、ブラウザが読み込んでonload, onerrorイベントを発生
     scriptElement.onload = () => {
       // console.log(`Script loaded successfully: ${scriptElement.src}`);
       resolve();
@@ -35,30 +37,8 @@ export async function loadAndExecuteScript(spaElement, path, isModule = false) {
 
   // <script src="path"></script>
   const scriptElement = getScriptElement(path, isModule)
+
+  // DOMツリーに追加
   spaElement.appendChild(scriptElement);
   await loadScript(scriptElement)
-}
-
-
-// todo: setupEventListeners 使えないかも
-/**
- * モジュールを非同期にインポートし、指定されたセットアップ関数を呼び出す
- *
- * @param {string} modulePath - モジュールのパス
- * @param {string} setupFunctionName - セットアップ関数の名前
- */
-export async function setupEventListeners(modulePath, setupFunctionName) {
-  // console.log("setupEventListeners: modulePath: " + modulePath);
-  try {
-    const module = await import(modulePath);
-    // console.log(`setupEventListeners: Module loaded: ${module}`);
-    if (setupFunctionName in module) {
-      // console.log(`setupEventListeners: Calling setup function: ${setupFunctionName}`);
-      module[setupFunctionName]();
-    } else {
-      console.error(`setupEventListeners: Setup function ${setupFunctionName} not found in module ${modulePath}`);
-    }
-  } catch (error) {
-    console.error(`setupEventListeners: Failed to import module: ${modulePath}`, error);
-  }
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/AbstractView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/AbstractView.js
@@ -11,7 +11,7 @@ export default class {
     return "";
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     return "";
   }
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/Home.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/Home.js
@@ -14,7 +14,7 @@ export default class extends AbstractView {
     const data = await fetchData(uri);
     return data;
   }
-  async executeScript() {
+  async executeScript(spaElement) {
     //executeScriptTab("");
   }
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Enable2FA.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Enable2FA.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const enable2FaModule = await import("/static/accounts/js/enable_2fa.js");
     enable2FaModule.fetchEnable2FA();
     enable2FaModule.setupVerifyTokenEventListener();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Login.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Login.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const loginModule = await import("/static/accounts/js/login.js");
     loginModule.setupLoginEventListener();
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Logout.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Logout.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const logoutModule = await import("/static/accounts/js/logout.js");
     logoutModule.setupLogoutEventListener();
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Signup.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Signup.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const signupModule = await import("/static/accounts/js/signup.js");
     signupModule.setupSignupEventListener();
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Verify2FA.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/auth/Verify2FA.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const verify2FaModule = await import("/static/accounts/js/verify_2fa.js");
     verify2FaModule.setupVerify2FaEventListener();
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMSessions.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMSessions.js
@@ -19,7 +19,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const dmSessionModule = await import("/static/chat/js/dm-sessions.js");
     dmSessionModule.fetchDMList();
     dmSessionModule.startDMwithUser();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
@@ -21,7 +21,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     // loadAndExecuteScript("/static/chat/js/dm-with-user.js", true);
     const dmWithUserModule = await import("/static/chat/js/dm-with-user.js");
     dmWithUserModule.initDM();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/FreePlay.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/FreePlay.js
@@ -17,8 +17,8 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
-    loadAndExecuteScript("/static/pong/three/assets/index.js", true);
+  async executeScript(spaElement) {
+    loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
   }
 
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
@@ -20,8 +20,8 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
-    loadAndExecuteScript("/static/pong/js/online/PongOnlineIndex.js", true);
+  async executeScript(spaElement) {
+    loadAndExecuteScript(spaElement, "/static/pong/js/online/PongOnlineIndex.js", true);
   }
 
   async dispose() {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game3D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game3D.js
@@ -20,8 +20,8 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
-    loadAndExecuteScript("/static/pong/three/assets/index.js", true);
+  async executeScript(spaElement) {
+    loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
   }
 
   // dispose() {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
@@ -34,8 +34,8 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
-    loadAndExecuteScript("/static/pong/three/assets/index.js", true);
+  async executeScript(spaElement) {
+    loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
   }
 
   async dispose() {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/PongTop.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/PongTop.js
@@ -17,6 +17,6 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
   }
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Tournament.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Tournament.js
@@ -19,7 +19,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     // await loadAndExecuteScript("/static/pong/js/tournament/TournamentMain.js", true);
 
     const tournamentModule = await import("/static/pong/js/tournament/TournamentMain.js");

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/ChangeAvatar.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/ChangeAvatar.js
@@ -19,7 +19,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     const uploadAvatarModule = await import("/static/accounts/js/upload-avatar.js");
     uploadAvatarModule.setupUploadAvatarEventListener();
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/EditProfile.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/EditProfile.js
@@ -19,7 +19,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     // loadAndExecuteScript("/static/accounts/js/edit_profile.js", true);
 
     const loginModule = await import("/static/accounts/js/edit_profile.js");

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/Friends.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/Friends.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     // loadAndExecuteScript("/static/accounts/js/friend.js", true);
     const friendModule = await import("/static/accounts/js/friend.js");
     friendModule.fetchFriendList();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/GameHistory.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/GameHistory.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
     return data;
   }
 
-  async executeScript() {
+  async executeScript(spaElement) {
     // loadAndExecuteScript("/static/accounts/js/history.js");
   }
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
@@ -21,7 +21,7 @@ export default class extends AbstractView {
         return data;
     }
 
-    async executeScript() {
+    async executeScript(spaElement) {
       const blockUserModule = await import("/static/accounts/js/block-user.js");
       blockUserModule.setupBlockUserEventListener();
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserProfile.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserProfile.js
@@ -18,7 +18,7 @@ export default class extends AbstractView {
         return data;
     }
 
-    async executeScript() {
+    async executeScript(spaElement) {
         const userProfileModule = await import("/static/accounts/js/userProfile.js");
         userProfileModule.fetchUserProfile();
     }


### PR DESCRIPTION
- `loadAndExecuteScript()`でDOMに追加した`<script>`を破棄できていなかった問題を解消
- 追加先を`document.body` -> `spaElement`に変更
```js
document.body.appendChild(scriptElement);
```
  ↓
```js
let spaElement = document.querySelector("#spa");
spaElement.innerHTML = htmlSrc;
spaElement.appendChild(scriptElement);
```