### PR TITLE
[fix] history, popstate

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
@@ -5,6 +5,7 @@ import { switchPage } from "/static/spa/js/routing/renderView.js"
 import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 const DEBUG = 0;
+const DEBUG_LOGIN = 0;
 
 export function loginUser() {
 	const email = document.getElementById('email').value;
@@ -24,17 +25,17 @@ export function loginUser() {
 				document.getElementById('message-area').textContent = data.error;
 				if (data.redirect) {
                     // alert('[tmp] login failure')
-					switchPage(data.redirect)
+					switchPage(data.redirect);
 				} else {
 					// alert('[tmp] error: ' + data.error)
 					console.error('Error:', data.error);
 				}
 			} else if (data.message) {
 				// Verified
-				if (DEBUG) { console.log(data.message); }
+				if (DEBUG_LOGIN) { console.log(data.message); }
 				const nextUrl = data.redirect;
-				if (DEBUG) { console.log('login: nextUrl:' + nextUrl); }
-				switchPage(nextUrl)  // Redirect on successful verification
+				if (DEBUG_LOGIN) { console.log('login: nextUrl:' + nextUrl); }
+				switchPage(nextUrl);  // Redirect on successful verification
                 updateHeader();
 			}
 		})

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
@@ -4,6 +4,7 @@ import { updateHeader } from "/static/spa/js/views/updateHeader.js"
 
 
 const DEBUG = 0;
+const DEBUG_LOG = 0;
 
 
 function signupUser() {
@@ -26,18 +27,20 @@ function signupUser() {
 			// Error
 			document.getElementById('message-area').textContent = data.error;
 			if (data.redirect) {
-				switchPage(data.redirect)
+				if (DEBUG_LOG) { console.log('signup error: next: ' + data.redirect); };
+				switchPage(data.redirect);
 			} else {
 				console.error('Error:', data.error);
 			}
 		} else if (data.message) {
 			// Verified
-			console.log(data.message);
-			switchPage(data.redirect)  // Redirect on successful verification
+			if (DEBUG_LOG) { console.log(data.message); };
+			switchPage(data.redirect);  // Redirect on successful verification
 			updateHeader();
 		}
 	})
 	.catch(error => console.error('Error:', error));
+	if (DEBUG_LOG) { console.log('signup 3'); };
 }
 
 
@@ -48,6 +51,7 @@ export function setupSignupEventListener() {
 	const form = document.getElementById('signup-form-container')
 	if (form && !signupFormSubmitHandler) {
 		signupFormSubmitHandler = (event) => {
+			if (DEBUG_LOG) { console.log("signup submit"); }
 			event.preventDefault();
 			signupUser();
 		};

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
@@ -22,7 +22,10 @@
 				form-floating">
 				<input class="form-control"
 				id="email"
-				type="text" placeholder="name@example.com" required>
+				type="text"
+				placeholder="name@example.com"
+				autocomplete="username"
+				required>
 				<label for="floatingInput">Email address</label>
 			</div>
 			<div class="
@@ -30,7 +33,10 @@
 				form-floating">
 				<input class="form-control"
 				id="password"
-				type="password" placeholder="password" required>
+				type="password"
+				placeholder="password"
+				autocomplete="current-password"
+				required>
 				<label for="floatingPassword">Password</label>
 			</div>
 			<input type="hidden" id="next" value="/accounts/user/">

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/signup.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/signup.html
@@ -23,7 +23,9 @@
 				<input class="form-control"
 				id="email"
 				type="text"
-				placeholder="name@example.com" required>
+				placeholder="name@example.com"
+				autocomplete="off"
+				required>
 				 {% comment %} labelはinputの下に記述する: bootstrap templateのアニメーションのため  {% endcomment %}
 				<label for="floatingInput">Email address</label>
 			</div>
@@ -33,7 +35,9 @@
 				<input class="form-control"
 				id="nickname"
 				type="text"
-				placeholder="nickname" required>
+				placeholder="nickname"
+				autocomplete="off"
+				required>
 				<label for="floatingInput">Nickname</label>
 			</div>
 			<div class="
@@ -42,7 +46,9 @@
 				<input class="form-control"
 				id="password1"
 				type="password"
-				placeholder="password" required>
+				placeholder="password"
+				autocomplete="off"
+				required>
 				<label for="floatingPassword">Password</label>
 			</div>
 			<div class="
@@ -51,7 +57,9 @@
 				<input class="form-control"
 				type="password"
 				id="password2"
-				placeholder="password confirmation" required>
+				placeholder="password confirmation"
+				autocomplete="off"
+				required>
 				<label for="floatingPassword">Password confirmation</label>
 			</div>
 			<button class="

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -17,12 +17,16 @@ from accounts.forms import SignupForm, LoginForm
 from accounts.models import CustomUser, UserManager
 from accounts.views.jwt import get_jwt_response
 
+import logging
+logger = logging.getLogger('accounts')
+
 
 class SignupTemplateView(View):
     template_name = "accounts/signup.html"
     authenticated_redirect_to = "/pong/"  # djangoで/pong/にrender -> SPA /app/
 
     def get(self, request, *args, **kwargs):
+        # logger.error("signup view called")
         if request.user.is_authenticated:
             return redirect(to=self.authenticated_redirect_to)
 
@@ -39,6 +43,7 @@ class SignupAPIView(APIView):
     # authenticated_redirect_to = url_config['kSpaPongTopUrl']  # SPA /app/にリダイレクト
 
     def post(self, request, *args, **kwargs):
+        # logger.error("signup api called")
         if request.user.is_authenticated:
             data = {
                 'message': "Already logged in",

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -11,11 +11,16 @@ const DEBUG_DETAIL = 0;
 
 // ブラウザの戻る/進むボタンで発火
 const setupPopStateListener = () => {
-  if (DEBUG_DETAIL) { console.log('popState: path: ' + window.location.pathname); }
   window.addEventListener("popstate", async (event) => {
-    const path = window.location.pathname;
     refreshJWT()
-    renderView(path);
+
+    const currentPath = window.location.href;
+    const renderPath = await getNextPath(currentPath)  // guest, userのredirectを加味したPathを取得
+
+    if (DEBUG_DETAIL) { console.log(`popState: currentPath: ${currentPath} -> renderPath: ${renderPath}`); }
+
+    history.replaceState(null, null, renderPath);  // historyは変更せず、guest, userに応じたURLに変更
+    renderView(renderPath);
   });
 };
 
@@ -23,7 +28,7 @@ const setupPopStateListener = () => {
 // spa.htmlの読み込みと解析が完了した時点で発火
 const setupDOMContentLoadedListener = () => {
   document.addEventListener("DOMContentLoaded", async () => {
-    // console.log('DOMContentLoaded: path: ' + window.location.pathname + window.location.search);
+    if (DEBUG_DETAIL) { console.log('DOMContentLoaded: path: ' + window.location.pathname); }
     refreshJWT()
 
     // 初期ビューを表示
@@ -41,10 +46,10 @@ const setupDOMContentLoadedListener = () => {
 const setupBodyClickListener = () => {
   document.body.addEventListener("click", async (event) => 
   {
-  // console.log('clickEvent: path: ' + window.location.pathname);
     const linkElement = event.target.closest("[data-link]");
-    if (linkElement) 
+    if (linkElement)
     {
+      if (DEBUG_DETAIL) { console.log('clickEvent: path: ' + window.location.pathname); }
       // console.log('clickEvent: taga-link');
       event.preventDefault();
       refreshJWT()
@@ -80,18 +85,18 @@ const toggleMenu = document.getElementById("hth-toggle-menu");
 
 
 // ページリロード時に発火
-const setupLoadListener = () => {
-  window.addEventListener("load", async () => {
-    // console.log('loadEvent: path: ' + window.location.pathname);
-    refreshJWT()
-  });
-};
+// const setupLoadListener = () => {
+//   window.addEventListener("load", async () => {
+//     if (DEBUG_DETAIL) { console.log('loadEvent: path: ' + window.location.pathname); }
+//     refreshJWT()
+//   });
+// };
 
 
 function initSpaEventListeners() {
   setupPopStateListener();
   setupDOMContentLoadedListener();
-  setupLoadListener()
+  // setupLoadListener()
 }
 
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -3,6 +3,7 @@ import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
 
 const DEBUG_DETAIL = 0;
+const DEBUG_LOG = 0;
 
 // touteTable.jsの記述について
 // game3d: { path: "/app/game/game-3d/", view: Game3D }は、/app/game/game-3d/というパスに対してGame3Dという「クラス」を対応
@@ -15,6 +16,8 @@ export const switchPage = (targetPath) => {
   const targetPathName = targetUrl.pathname;
 
   history.pushState(null, null, targetPathName );
+  if (DEBUG_LOG) { console.log(` history.push: ${targetPathName}`); }
+
   // currentViewにdisposeメソッドが存在するかどうかをチェック。オペランドの型がfunctionなら関数
   // if (currentView && typeof currentView.dispose === "function") {
   //         if (DEBUG_DETAIL) { console.log('switchPage(): dispose', currentView);  } 
@@ -106,11 +109,13 @@ async function getView(path) {
 
 // 現在表示しているviewを格納しておく変数: 次回の冒頭でdispose()が呼ばれる
 let currentView = null;
+
 // 全ての遷移で呼ばれるメソッド。とりあえずここに共通のものを設定
 export const renderView = async (path) => {
+  if (DEBUG_LOG) { console.log(` renderView: ${path}`); }
   // viewクラスのdespose()を呼び出す
   if (currentView && typeof currentView.dispose === "function") {
-        if (DEBUG_DETAIL) { console.log('renderView(): currentView.dispose(): currentView', currentView);  } 
+        if (DEBUG_DETAIL) { console.log('renderView(): currentView.dispose(): currentView', currentView);  }
     currentView.dispose();
   }
   // ここまで前回のviewに対する処理


### PR DESCRIPTION
- Guest
  - [ ] ~Login: `/app/` -> `/login/` -> `/app/` で戻るにloginが2つ並んでる~
  - [ ] ~Signup: `/app/` -> `/signup/` -> `/app/` で戻るにsignupが4つ並んでいる~
- User
  - [x] `/login-required/` -> logout -> `/app/` で戻ると画面はlogin, URLは`/login-required/`
    - b8e15b2
    - 戻る/進む表示ページをgetNextPath()で取得し、guestであればルーターでloginに遷移するよう変更

<br>

## memo
- 履歴増殖はchrome拡張機能のバグだった模様？firefoxでは再現せず
- 必要なさそうであればマージ不要です