### PR TITLE
[add] API test: 非認証者によるAPI GET/POSTの結果が401(or 405)であることを評価するテストを追加

### DIFF
--- a/docker/srcs/uwsgi-django/pong/tournament/tests/test_tournament_data.py
+++ b/docker/srcs/uwsgi-django/pong/tournament/tests/test_tournament_data.py
@@ -86,11 +86,12 @@ class TestTournamentData(TestCase):
 		self.__logout()  # ユーザーをログアウト
 		response = self.client.get(reverse('get_tournament_data_by_id', kwargs={'tournament_id': self.tournament1.id}))
 		response_data = response.json()
-		self.assertEqual(response_data['id'], self.tournament1.id)
-		self.assertEqual(response_data['name'], self.t1_name)
-		self.assertEqual(response_data['player_nicknames'], self.t1_players)
-		self.assertEqual(response_data['organizer'], self.user1.id)
-		self.assertEqual(response.status_code, 200) 
+		# self.assertEqual(response_data['id'], self.tournament1.id)
+		# self.assertEqual(response_data['name'], self.t1_name)
+		# self.assertEqual(response_data['player_nicknames'], self.t1_players)
+		# self.assertEqual(response_data['organizer'], self.user1.id)
+		# self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.status_code, 401)
 
 	def test_access_by_other_user(self):
 		"""他のユーザーがトーナメントデータにアクセスした際に適切にアクセスを制限するか"""

--- a/docker/srcs/uwsgi-django/pong/urls_api.py
+++ b/docker/srcs/uwsgi-django/pong/urls_api.py
@@ -49,4 +49,3 @@ urlpatterns = [
 		# 「ユーザーが主催する && 未終了のトーナメント」 に関する「全7試合」のデータを全て取得する
 		path("tournament/user/ongoing/matches/all", get_matches_of_latest_tournament_user_ongoing, name="get_matches_of_latest_tournament_user_ongoing"),
 ]
-

--- a/docker/srcs/uwsgi-django/pong/urls_api.py
+++ b/docker/srcs/uwsgi-django/pong/urls_api.py
@@ -28,7 +28,7 @@ urlpatterns = [
 	# ----------------------------------------
 	# 「最新」のトーナメントの情報を取得: 「ログイン中のユーザーが主催する未終了トーナメント」の。
 	path("tournament/user/ongoing/latest/", get_latest_user_ongoing_tournament, name="get_latest_user_ongoing_tournament"),
-	#  ゲストも「ID」でトーナメント情報を取得: 指定されたトーナメントIDの。
+	#  「ID」でトーナメント情報を取得: 指定されたトーナメントIDの。
 	path("tournament/data/<int:tournament_id>/", get_tournament_data_by_id, name="get_tournament_data_by_id"),
 	# 「round_number」のデータを全て取得: 「ログイン中のユーザーが主催する未終了トーナメント」の。
 	path("tournament/user/ongoing/matches/<int:round_number>/", get_matches_by_round_latest_user_ongoing_tournament, name="get_matches_by_round_latest_user_ongoing_tournament"),

--- a/docker/srcs/uwsgi-django/pong/views/tournament_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament_views.py
@@ -76,8 +76,8 @@ def assign_winner_to_next_match(current_match: Match, winner_nickname: str):
 
 
 @csrf_exempt
-@login_required
-@require_http_methods(["POST"])
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def save_game_result(request):
 	try:
 		data = json.loads(request.body)

--- a/docker/srcs/uwsgi-django/pong/views/tournament_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament_views.py
@@ -133,13 +133,13 @@ def get_latest_user_ongoing_tournament(request) -> JsonResponse:
 
 
 @api_view(['GET'])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated])
 def get_tournament_data_by_id(request, tournament_id) -> JsonResponse:
-	""" 機能: ゲストも「ID」でトーナメント情報を取得: 指定されたトーナメントIDの。"""
-	print('fetchTournamentDetail: 1')
+	""" 機能: 「ID」でトーナメント情報を取得: 指定されたトーナメントIDの。"""
+	# print('fetchTournamentDetail: 1')
 	tournament = get_object_or_404(Tournament, pk=tournament_id)
 	# print("Tournament:", tournament)
-	print('fetchTournamentDetail: 2')
+	# print('fetchTournamentDetail: 2')
 	data = {
 		'id': tournament.id,
 		'name': tournament.name,
@@ -148,7 +148,7 @@ def get_tournament_data_by_id(request, tournament_id) -> JsonResponse:
 		'organizer': tournament.organizer_id,
 		'is_finished': tournament.is_finished
 	}
-	print('fetchTournamentDetail: 3')
+	# print('fetchTournamentDetail: 3')
 	return JsonResponse(data, safe=False)
 
 

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
@@ -102,7 +102,6 @@ class PongAPITestCase(TestCase):
         exclude_urls = {
             "save_testnet/<str:testnet_name>/",
             "fetch_testnet/<str:testnet_name>/",
-            "tournament/data/<int:tournament_id>/",  # guestも取得可能
         }
         api_urls = []
         for url in pong_api_urls:

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
@@ -1,0 +1,141 @@
+# trans_pj/tests/test_api_security.py
+
+import requests
+import urllib3
+from django.test import TestCase
+from django.urls import reverse
+from django.urls.resolvers import URLPattern
+
+from accounts.urls_api import urlpatterns as accounts_api_urls
+from chat.urls_api import urlpatterns as chat_api_urls
+from pong.urls_api import urlpatterns as pong_api_urls
+
+# 自己署名証明書の警告を非表示にする
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+kURL_PREFIX = "https://nginx"
+
+
+class AccountsAPITestCase(TestCase):
+    def setUp(self):
+        exclude_urls = {
+            "api/signup/",
+            "api/login/",
+            "api/is-user-logged-in/",
+            "api/is-user-enabled2fa/",
+            "oauth-ft/callback/",
+        }
+        api_urls = []
+        for url in accounts_api_urls:
+            if isinstance(url, URLPattern):
+                if str(url.pattern) in exclude_urls:
+                    continue
+
+                if '<str:nickname>' in str(url.pattern):
+                    api_url = str(url.pattern).replace('<str:nickname>', 'user1')
+                elif '<int:user_id>' in str(url.pattern):
+                    api_url = str(url.pattern).replace('<int:user_id>', '1')
+                else:
+                    api_url = str(url.pattern)
+            api_url = f"{kURL_PREFIX}/accounts/{api_url}"
+            api_urls.append(api_url)
+
+        self.api_urls = api_urls
+
+    def test_api_unauthorized(self):
+        print("[AccountsAPI Test]")
+        print(f"api_urls: {self.api_urls}")
+
+        for url in self.api_urls:
+            print(f" [Testing: {url}]")
+
+            response = requests.get(url, verify=False)
+            print(f"  -> GET : {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")
+
+            response = requests.post(url, verify=False)
+            print(f"  -> POST: {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")
+
+
+class ChatAPITestCase(TestCase):
+    def setUp(self):
+        api_urls = []
+        for url in chat_api_urls:
+            if isinstance(url, URLPattern):
+                if '<str:target_nickname>' in str(url.pattern):
+                    api_url = str(url.pattern).replace('<str:target_nickname>', 'user1')
+                else:
+                    api_url = str(url.pattern)
+            api_url = f"{kURL_PREFIX}/chat/{api_url}"
+            api_urls.append(api_url)
+
+        self.api_urls = api_urls
+
+    def test_api_unauthorized(self):
+        print("[ChatAPI Test]")
+        print(f"api_urls: {self.api_urls}")
+
+        for url in self.api_urls:
+            print(f" [Testing: {url}]")
+
+            response = requests.get(url, verify=False)
+            print(f"  -> GET : {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")
+
+            response = requests.post(url, verify=False)
+            print(f"  -> POST: {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")
+
+
+class PongAPITestCase(TestCase):
+    def setUp(self):
+        exclude_urls = {
+            "save_testnet/<str:testnet_name>/",
+            "fetch_testnet/<str:testnet_name>/",
+            "tournament/data/<int:tournament_id>/",  # guestも取得可能
+        }
+        api_urls = []
+        for url in pong_api_urls:
+            if isinstance(url, URLPattern):
+                if str(url.pattern) in exclude_urls:
+                    continue
+
+                if '<int:tournament_id>' in str(url.pattern):
+                    api_url = str(url.pattern).replace('<int:tournament_id>', '1')
+                elif '<int:round_number>' in str(url.pattern):
+                    api_url = str(url.pattern).replace('<int:round_number>', '1')
+                else:
+                    api_url = str(url.pattern)
+            api_url = f"{kURL_PREFIX}/pong/api/{api_url}"
+            api_urls.append(api_url)
+
+        self.api_urls = api_urls
+
+    def test_api_unauthorized(self):
+        print("[PongAPI Test]")
+        print(f"api_urls: {self.api_urls}")
+
+        for url in self.api_urls:
+            print(f" [Testing: {url}]")
+
+            response = requests.get(url, verify=False)
+            print(f"  -> GET : {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")
+
+            response = requests.post(url, verify=False)
+            print(f"  -> POST: {response.status_code}")
+            self.assertIn(response.status_code,
+                          [401, 405],
+                          f"Expected 401 status code for {url}, but got {response.status_code}")


### PR DESCRIPTION
#248 

- Review用にAPIテストを集約（minimal security要件 第5項目の確認用）
- 実行：`docker exec uwsgi-django python manage.py test trans_pj.tests.test_api_scurity`
- `urls_api`に対するGET, POSTのresponseを確認。401（methodにより405も）が期待値
- `tournament/data/<int:tournament_id>/`はGuestも取得可能ですが、`IsAuthenticated`でも良さそうでしょうか？ -> `IsAuthenticated`に変更する場合は本ブランチで変更 & テスト変更後、マージします
