### PR TITLE
[fix] DM: nickname変更の挙動

### DIFF
--- a/docker/srcs/uwsgi-django/chat/consumers.py
+++ b/docker/srcs/uwsgi-django/chat/consumers.py
@@ -66,8 +66,8 @@ class Consumer(AsyncWebsocketConsumer):
 
 
     @database_sync_to_async
-    def _get_user_by_nickname(self, nickname: str):
-        return CustomUser.objects.get(nickname=nickname)
+    def _get_user_by_id(self, id: int):
+        return CustomUser.objects.get(id=id)
 
 
     @database_sync_to_async

--- a/docker/srcs/uwsgi-django/chat/dm_consumers.py
+++ b/docker/srcs/uwsgi-django/chat/dm_consumers.py
@@ -86,7 +86,7 @@ class DMConsumer(Consumer):
         timestamp = message_instance.timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
         send_data = {
-            'sender'            : self.user.nickname,
+            'sender_id'         : self.user.id,
             'message'           : message,
             'timestamp'         : timestamp,
             'is_system_message' : False,
@@ -114,7 +114,7 @@ class DMConsumer(Consumer):
                 f'room_{dm_session.id}',
                 {
                     'type'              : 'send_message',
-                    'sender'            : system_user.nickname,
+                    'sender_id'         : system_user.id,
                     'message'           : message,
                     'timestamp'         : timestamp,
                     'is_system_message' : True
@@ -138,13 +138,13 @@ class DMConsumer(Consumer):
         return None
 
     async def _get_users(self):
-        # DM送受信者のuser objectをnickanmeから取得
+        # DM送受信者のuser objectをidから取得
         try:
-            user_nickname = self.scope['user'].nickname
-            other_user_nickname = self.scope['url_route']['kwargs']['nickname']
+            user_id = self.scope['user'].id
+            other_user_id = self.scope['url_route']['kwargs']['id']
 
-            user = await self._get_user_by_nickname(nickname=user_nickname)
-            other_user = await self._get_user_by_nickname(nickname=other_user_nickname)
+            user = await self._get_user_by_id(id=user_id)
+            other_user = await self._get_user_by_id(id=other_user_id)
 
             if user == other_user:
                 raise ValueError('user and other_user must be a different user')

--- a/docker/srcs/uwsgi-django/chat/routing.py
+++ b/docker/srcs/uwsgi-django/chat/routing.py
@@ -4,5 +4,5 @@ from chat.dm_consumers import DMConsumer
 
 
 websocket_urlpatterns = [
-    re_path(r'ws/dm-with/(?P<nickname>\w+)/$', DMConsumer.as_asgi()),
+    re_path(r'ws/dm-with/(?P<id>\w+)/$', DMConsumer.as_asgi()),
 ]

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -59,13 +59,14 @@ export function startDMwithUser() {
                         throw new Error(data.error);
                     } else {
                         // 検証が成功した場合にdiWithUserに遷移
-                        const routePath = routeTable['dmWithUserBase'].path + dmTargetNickname + '/'
+                        const targetId = data.target_id;
+                        console.log("target_id: " + targetId)
+                        const routePath = routeTable['dmWithUserBase'].path + targetId + '/'
                         switchPage(routePath);
                     }
                 });
             })
             .catch(error => {
-                console.log('startDMwithUser 6');
                 if (error.message.includes('<!doctype')) {
                     // <script></script>入力された場合。APIにたどり着く前にエラー判定されている
                     messageArea.textContent = "The specified user does not exist";
@@ -87,7 +88,7 @@ function createDMSessionLinks(data) {
         const link = document.createElement('a');
 
         // リンクの設定
-        link.href = `${routeTable['dmSessions'].path}${dmSession.target_nickname}/`;
+        link.href = `${routeTable['dmSessions'].path}${dmSession.target_id}/`;
         link.setAttribute('data-link', '');
 
         // システムメッセージの場合は表示を変更

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -60,7 +60,7 @@ export function startDMwithUser() {
                     } else {
                         // 検証が成功した場合にdiWithUserに遷移
                         const targetId = data.target_id;
-                        console.log("target_id: " + targetId)
+                        // console.log("target_id: " + targetId)
                         const routePath = routeTable['dmWithUserBase'].path + targetId + '/'
                         switchPage(routePath);
                     }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
@@ -14,14 +14,13 @@ export function initDM() {
         return
     }
 
-    const dmTargetNickname = JSON.parse(
-        document.getElementById('target_nickname').textContent
-    );
+    const userInfo = JSON.parse(document.getElementById('user_info').textContent);
+    const targetInfo = JSON.parse(document.getElementById('target_info').textContent);
 
-    applyStylesToInitialLoadMessages(dmTargetNickname);
+    applyStylesToInitialLoadMessages(userInfo, targetInfo);
     scrollToBottom();  // 受信時にスクロール位置を調整
 
-    setupDmWebsocket(dmTargetNickname);
+    setupDmWebsocket(userInfo, targetInfo);
     setupSendKeyEventListener();
 }
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-with-user.js
@@ -17,7 +17,7 @@ export function initDM() {
     const userInfo = JSON.parse(document.getElementById('user_info').textContent);
     const targetInfo = JSON.parse(document.getElementById('target_info').textContent);
 
-    applyStylesToInitialLoadMessages(userInfo, targetInfo);
+    applyStylesToInitialLoadMessages(targetInfo);
     scrollToBottom();  // 受信時にスクロール位置を調整
 
     setupDmWebsocket(userInfo, targetInfo);

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
@@ -1,10 +1,8 @@
 // chat/js/apple-message-stype.js
-export { applyStylesToInitialLoadMessages, classifyMessageSender };
-
 const DEBUG_LOG = 0;
 
 // WebSocketで受信したメッセージのクラス[dm-to / dm-from]を分類
-function classifyMessageSender(messageElement, senderId, targetId) {
+export function classifyMessageSender(messageElement, senderId, targetId) {
     if (senderId === targetId) {
         if (DEBUG_LOG) { console.log('     [target]'); }
         messageElement.classList.add('dm-to');  // 他のユーザーからのメッセージ
@@ -15,7 +13,7 @@ function classifyMessageSender(messageElement, senderId, targetId) {
 }
 
 // DBから取得したメッセージのクラス[dm-to / dm-from]を分類
-function applyStylesToInitialLoadMessages(targetInfo) {
+export function applyStylesToInitialLoadMessages(targetInfo) {
     if (DEBUG_LOG) { console.log('[applyStylesToInitialLoadMessages]'); }
     if (DEBUG_LOG) { console.log('  target_id: ' + targetInfo.id); }
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
@@ -1,21 +1,29 @@
 // chat/js/apple-message-stype.js
 export { applyStylesToInitialLoadMessages, classifyMessageSender };
 
+const DEBUG_LOG = 0;
+
 // WebSocketで受信したメッセージのクラス[dm-to / dm-from]を分類
-function classifyMessageSender(messageElement, senderId, userId, targetId) {
+function classifyMessageSender(messageElement, senderId, targetId) {
     if (senderId === targetId) {
+        if (DEBUG_LOG) { console.log('     [target]'); }
         messageElement.classList.add('dm-to');  // 他のユーザーからのメッセージ
-    } else if (senderId === userId) {
+    } else {
+        if (DEBUG_LOG) { console.log('     [user]'); }
         messageElement.classList.add('dm-from');  // 自分が送信したメッセージ
     }
 }
 
 // DBから取得したメッセージのクラス[dm-to / dm-from]を分類
-function applyStylesToInitialLoadMessages(userInfo, targetInfo) {
-    const messageElements = document.querySelectorAll('#dm-log li');
+function applyStylesToInitialLoadMessages(targetInfo) {
+    if (DEBUG_LOG) { console.log('[applyStylesToInitialLoadMessages]'); }
+    if (DEBUG_LOG) { console.log('  target_id: ' + targetInfo.id); }
 
+    const messageElements = document.querySelectorAll('#dm-log li');
     messageElements.forEach(function(messageElement) {
-        let senderId = messageElement.getAttribute('data-sender-id');
-        classifyMessageSender(messageElement, senderId, userInfo.id, targetInfo.id);
+        let senderId = parseInt(messageElement.getAttribute('data-sender-id'));
+        if (DEBUG_LOG) { console.log('     message        : ' + messageElement.textContent); }
+        if (DEBUG_LOG) { console.log('     data-sender-id: ' + senderId); }
+        classifyMessageSender(messageElement, senderId, targetInfo.id);
     });
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/apply-message-style.js
@@ -2,21 +2,20 @@
 export { applyStylesToInitialLoadMessages, classifyMessageSender };
 
 // WebSocketで受信したメッセージのクラス[dm-to / dm-from]を分類
-function classifyMessageSender(messageElement, senderName, dmTargetNickname) {
-    if (senderName === dmTargetNickname) {
+function classifyMessageSender(messageElement, senderId, userId, targetId) {
+    if (senderId === targetId) {
         messageElement.classList.add('dm-to');  // 他のユーザーからのメッセージ
-    } else {
+    } else if (senderId === userId) {
         messageElement.classList.add('dm-from');  // 自分が送信したメッセージ
     }
 }
 
-
 // DBから取得したメッセージのクラス[dm-to / dm-from]を分類
-function applyStylesToInitialLoadMessages(dmTargetNickname) {
+function applyStylesToInitialLoadMessages(userInfo, targetInfo) {
     const messageElements = document.querySelectorAll('#dm-log li');
 
     messageElements.forEach(function(messageElement) {
-        let senderName = messageElement.getAttribute('data-sender-name');
-        classifyMessageSender(messageElement, senderName, dmTargetNickname);
+        let senderId = messageElement.getAttribute('data-sender-id');
+        classifyMessageSender(messageElement, senderId, userInfo.id, targetInfo.id);
     });
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
@@ -59,12 +59,12 @@ function createMessageElement(senderName, message, timestamp, avatarUrl) {
 }
 
 
-function classifyMessage(messageElement, isSystemMessage, senderId, userId, targetId) {
+function classifyMessage(messageElement, isSystemMessage, senderId, targetId) {
     // todo: isSystemMessageは未使用, system message実装で使う可能性あり
     if (isSystemMessage) {
         messageElement.classList.add('system-message');
     } else {
-        classifyMessageSender(messageElement, senderId, userId, targetId);
+        classifyMessageSender(messageElement, senderId, targetId);
     }
 }
 
@@ -87,7 +87,7 @@ function handleReceiveMessage(event, userInfo, targetInfo) {
     const isSystemMessage = message_data.is_system_message;
 
     // メッセージに適切なクラスを適用
-    classifyMessage(messageElement, isSystemMessage, message_data.sender_id, userInfo.id, targetInfo.id);
+    classifyMessage(messageElement, isSystemMessage, message_data.sender_id, targetInfo.id);
 
     document.querySelector('#dm-log').appendChild(messageElement);
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
@@ -59,34 +59,46 @@ function createMessageElement(senderName, message, timestamp, avatarUrl) {
 }
 
 
-function classifyMessage(messageElement, isSystemMessage, senderName, dmTargetNickname) {
+function classifyMessage(messageElement, isSystemMessage, senderId, userId, targetId) {
     // todo: isSystemMessageは未使用, system message実装で使う可能性あり
     if (isSystemMessage) {
         messageElement.classList.add('system-message');
     } else {
-        classifyMessageSender(messageElement, senderName, dmTargetNickname);
+        classifyMessageSender(messageElement, senderId, userId, targetId);
     }
 }
 
 
-function handleReceiveMessage(event, dmTargetNickname) {
+function handleReceiveMessage(event, userInfo, targetInfo) {
     const data = JSON.parse(event.data);
     const message_data = JSON.parse(data.data);
+
     console.log('Received WebSocket data:', data);
     console.log('Received WebSocket message_data:', message_data);
 
+    const senderInfo = getSenderInfo(message_data.sender_id, userInfo, targetInfo);
+
     let messageElement = createMessageElement(
-        message_data.sender,
+        senderInfo.nickname,
         message_data.message,
         message_data.timestamp,
-        message_data.avatar_url
+        senderInfo.avatar_url
     );
     const isSystemMessage = message_data.is_system_message;
 
     // メッセージに適切なクラスを適用
-    classifyMessage(messageElement, isSystemMessage, message_data.sender, dmTargetNickname);
+    classifyMessage(messageElement, isSystemMessage, message_data.sender_id, userInfo.id, targetInfo.id);
 
     document.querySelector('#dm-log').appendChild(messageElement);
 
     scrollToBottom();  // dm-logのスクロール位置を調整
+}
+
+
+function getSenderInfo(senderId, userInfo, targetInfo) {
+    if (senderId === userInfo.id) {
+        return userInfo;
+    } else {
+        return targetInfo;
+    }
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/handle-receive-message.js
@@ -3,8 +3,7 @@
 import {classifyMessageSender} from "./apply-message-style.js";
 import {scrollToBottom} from "./ui-util.js";
 
-export { handleReceiveMessage };
-
+const DEBUG_LOG = 0;
 
 export function escapeHtml(unsafe) {
     return unsafe
@@ -69,12 +68,12 @@ function classifyMessage(messageElement, isSystemMessage, senderId, targetId) {
 }
 
 
-function handleReceiveMessage(event, userInfo, targetInfo) {
+export function handleReceiveMessage(event, userInfo, targetInfo) {
     const data = JSON.parse(event.data);
     const message_data = JSON.parse(data.data);
 
-    console.log('Received WebSocket data:', data);
-    console.log('Received WebSocket message_data:', message_data);
+    if (DEBUG_LOG) { console.log('Received WebSocket data        :', data); }
+    if (DEBUG_LOG) { console.log('Received WebSocket message_data:', message_data); }
 
     const senderInfo = getSenderInfo(message_data.sender_id, userInfo, targetInfo);
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -1,43 +1,90 @@
 // chat/js/setup-dm-websocket.js
 
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { switchPage } from "/static/spa/js/routing/renderView.js"
 import { classifyMessageSender } from './apply-message-style.js';
 import { handleReceiveMessage } from './handle-receive-message.js';
 import { scrollToBottom } from './ui-util.js';
 
-export { setupDmWebsocket };
 
+const DEBUG_LOG = false;
+const TEST_RECCONNECTION = false;
+
+const RECONNECT_DELAY_MS = 5000;
+const MAX_RECONNECT_ATTEMPTS = 3;  // 接続最大再接続試行回数
 
 let dmSocket = null;
+let reconnectAttempts = 0;
 
 // WebSocketの接続確立とメッセージの送受信ロジック
-function setupDmWebsocket(userInfo, targetInfo) {
+export function setupDmWebsocket(userInfo, targetInfo) {
+
+    if (DEBUG_LOG) { console.log('setupDmWebsocket 1'); }
     if (dmSocket) {
+        if (DEBUG_LOG) { console.log('setupDmWebsocket 2'); }
         closeDmSocket();
     }
+    if (DEBUG_LOG) { console.log('setupDmWebsocket 3'); }
 
     const websocketUrl = 'wss://' + window.location.host + '/ws/dm-with/' + targetInfo.id + '/';
     dmSocket = new WebSocket(websocketUrl);
 
     dmSocket.onmessage = (event) => handleReceiveMessage(event, userInfo, targetInfo);
     dmSocket.onopen = () => handleOpen(dmSocket, targetInfo.nickname);
-    dmSocket.onclose = handleClose;
-    dmSocket.onerror = handleError;
+    dmSocket.onclose = (event) => handleClose(event, userInfo, targetInfo);
+    dmSocket.onerror = (event) => handleError(event, userInfo, targetInfo);
 
     document.querySelector('#message-submit').onclick = () => handleSendMessage(dmSocket);
+
+    if (TEST_RECCONNECTION) { handleClose({ wasClean: false }, userInfo, targetInfo); }
 }
 
 
 function handleOpen(dmTargetNickname) {
-    console.log('WebSocket connection established with', dmTargetNickname);
+    if (DEBUG_LOG) { console.log('WebSocket connection established with', dmTargetNickname); }
+
+    const errorMessageDom = document.querySelector('#error-message');
+    errorMessageDom.textContent = '';
 }
 
 
-function handleClose(event) {
-    console.log('Chat socket closed:', event);
+function tryReconnection(userInfo, targetInfo) {
+    reconnectAttempts++;
+    if (DEBUG_LOG) { console.log(`reconnectAttempts: ${reconnectAttempts}`); }
+
+    const errorMessageDom = document.querySelector('#error-message');
+    if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+        errorMessageDom.textContent = `DM connection closed. Trying to reconnect... (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS} times)`;
+    } else {
+        // 一定回数接続でなかった場合には、DM Topに戻す
+        let reconnectAttempts = 0;
+        errorMessageDom.textContent = 'DM connection closed. Return to DM TOP Page';
+    }
+
+    setTimeout(() => {
+        if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+            setupDmWebsocket(userInfo, targetInfo)
+        } else {
+            // 一定回数接続でなかった場合には、DM Topに戻す
+            const routePath = routeTable['dmSessions'].path
+            switchPage(routePath);
+        }
+    }, RECONNECT_DELAY_MS);
 }
 
-function handleError(event) {
-    console.error('WebSocket error observed:', event);
+function handleClose(event, userInfo, targetInfo) {
+    if (DEBUG_LOG) { console.log('WebSocket closed'); }
+
+    closeDmSocket();
+    if (!event.wasClean) {
+        tryReconnection(userInfo, targetInfo);
+    }
+}
+
+function handleError(event, userInfo, targetInfo) {
+    if (DEBUG_LOG) { console.log('WebSocket encountered an error', event); }
+    closeDmSocket();
+    tryReconnection(userInfo, targetInfo);
 }
 
 
@@ -71,14 +118,23 @@ function handleSendMessage(dmSocket) {
 
 
 export function closeDmSocket() {
-    if (dmSocket) {
-        if (dmSocket.readyState === WebSocket.CONNECTING) {
-            dmSocket.onopen = () => {
-                dmSocket.close();
-            };
-        } else if (dmSocket.readyState === WebSocket.OPEN) {
-            dmSocket.close();
-        }
-        dmSocket = null;
+    if (DEBUG_LOG) { console.log('closeDmSocket 1'); }
+
+    if (!dmSocket) {
+        return;
     }
+
+    if (DEBUG_LOG) { console.log('closeDmSocket 2'); }
+    if (dmSocket.readyState === WebSocket.CONNECTING) {
+        if (DEBUG_LOG) { console.log('closeDmSocket 3'); }
+        dmSocket.onopen = () => {
+            if (DEBUG_LOG) { console.log('closeDmSocket 4'); }
+            dmSocket.close();
+        };
+    } else if (dmSocket.readyState === WebSocket.OPEN) {
+        if (DEBUG_LOG) { console.log('closeDmSocket 5'); }
+        dmSocket.close();
+    }
+    if (DEBUG_LOG) { console.log('closeDmSocket 6'); }
+    dmSocket = null;
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/setup-dm-websocket.js
@@ -10,16 +10,16 @@ export { setupDmWebsocket };
 let dmSocket = null;
 
 // WebSocketの接続確立とメッセージの送受信ロジック
-function setupDmWebsocket(dmTargetNickname) {
+function setupDmWebsocket(userInfo, targetInfo) {
     if (dmSocket) {
         closeDmSocket();
     }
 
-    const websocketUrl = 'wss://' + window.location.host + '/ws/dm-with/' + dmTargetNickname + '/';
+    const websocketUrl = 'wss://' + window.location.host + '/ws/dm-with/' + targetInfo.id + '/';
     dmSocket = new WebSocket(websocketUrl);
 
-    dmSocket.onmessage = (event) => handleReceiveMessage(event, dmTargetNickname);
-    dmSocket.onopen = () => handleOpen(dmSocket, dmTargetNickname);
+    dmSocket.onmessage = (event) => handleReceiveMessage(event, userInfo, targetInfo);
+    dmSocket.onopen = () => handleOpen(dmSocket, targetInfo.nickname);
     dmSocket.onclose = handleClose;
     dmSocket.onerror = handleError;
 

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/module/ui-util.js
@@ -1,10 +1,7 @@
 // chat/js/ui-util.js
 
-export { setupSendKeyEventListener, scrollToBottom };
-
-
 // メッセージ送信のイベントを制御
-function setupSendKeyEventListener() {
+export function setupSendKeyEventListener() {
     const input = document.getElementById('message-input');
     const submitButton = document.getElementById('message-submit');
 
@@ -18,7 +15,7 @@ function setupSendKeyEventListener() {
 
 
 // dm-logのスクロール位置を調整
-function scrollToBottom() {
+export function scrollToBottom() {
     const dmLog = document.getElementById('dm-log');
     dmLog.scrollTop = dmLog.scrollHeight;
 }

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -14,16 +14,16 @@
 
     <div id="dm-container">
     
-        {% comment %} DM logを表示  {% endcomment %}
+        {% comment %} DBから読み込んだmessage_logを表示  {% endcomment %}
         <ul id="dm-log" style="list-style: none;">
-            {% for message in messages %}
+            {% for message in message_log %}
             <li class="{{ message.sender.id|slugify }}" data-sender-id="{{ message.sender.id }}">
                 <div class="avatar-and-sender">
                     {% if message.sender.id == target_info.id %}
-                        <img src="{{ target_avatar_url }}" alt="Avatar" class="avatar">
+                        <img src="{{ target_info.avatar_url }}" alt="Avatar" class="avatar">
                         <span class="sender-name">{{ target_info.nickname }}</span>
                     {% else %}
-                        <img src="{{ user_avatar_url }}" alt="Avatar" class="avatar">
+                        <img src="{{ user_info.avatar_url }}" alt="Avatar" class="avatar">
                         <span class="sender-name">{{ user_info.nickname }}</span>
                     {% endif %}
                 </div>

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -3,13 +3,13 @@
 {% load static %}
 
 {% if not isSystemUser %}
-    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/" data-link>{{ target_nickname }}</a></h2>
+    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/" data-link>{{ target_info.nickname }}</a></h2>
 {% else %}
     <h2>System Message</h2>
 {% endif %}
 
 
-{% if not isBlockingUser %}
+{% if not target_info.isBlockingUser %}
     <p id="error-message"></p>
 
     <div id="dm-container">
@@ -17,14 +17,15 @@
         {% comment %} DM logを表示  {% endcomment %}
         <ul id="dm-log" style="list-style: none;">
             {% for message in messages %}
-            <li class="{{ message.sender.nickname|slugify }}" data-sender-name="{{ message.sender.nickname }}">
+            <li class="{{ message.sender.id|slugify }}" data-sender-id="{{ message.sender.id }}">
                 <div class="avatar-and-sender">
-                    {% if message.sender.nickname == target_nickname %}
-                        <img src="{{ other_avatar_url }}" alt="Avatar" class="avatar">
+                    {% if message.sender.id == target_info.id %}
+                        <img src="{{ target_avatar_url }}" alt="Avatar" class="avatar">
+                        <span class="sender-name">{{ target_info.nickname }}</span>
                     {% else %}
                         <img src="{{ user_avatar_url }}" alt="Avatar" class="avatar">
+                        <span class="sender-name">{{ user_info.nickname }}</span>
                     {% endif %}
-                    <span class="sender-name">{{ message.sender.nickname }}</span>
                 </div>
                 <div class="message-content">
                     <span>{{ message.message|escape }}</span>
@@ -35,7 +36,7 @@
         </ul>
 
 
-        {% if not isSystemUser %}
+        {% if not target_info.isSystemUser %}
         <div class="message-container">
             <input id="message-input" type="text">
             <input id="message-submit" type="button" value="Send">
@@ -48,4 +49,5 @@
 {% endif %}
 
 
-{{ target_nickname|json_script:"target_nickname" }}
+{{ user_info|json_script:"user_info" }}
+{{ target_info|json_script:"target_info" }}

--- a/docker/srcs/uwsgi-django/chat/tests/test_dm_consumer.py
+++ b/docker/srcs/uwsgi-django/chat/tests/test_dm_consumer.py
@@ -61,7 +61,7 @@ class DMConsumerTestCase(TransactionTestCase):
         token_header = f'Bearer {user1_jwt}'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/{self.user2.nickname}/",
+                                             f"ws/dm-with/{self.user2.id}/",
                                              headers)
         return communicator
 
@@ -106,7 +106,7 @@ class DMConsumerTestCase(TransactionTestCase):
             response_data = json.loads(response['data'])
 
             # messageの各要素を評価
-            self.assertEqual(response_data['sender'], self.user1.nickname)
+            self.assertEqual(response_data['sender_id'], self.user1.id)
             self.assertEqual(response_data['message'], 'Hello, user2!')
             self.assertIsInstance(response_data['timestamp'], str)
             self.assertFalse(response_data['is_system_message'])
@@ -145,7 +145,7 @@ class DMConsumerTestCase(TransactionTestCase):
             response_data = json.loads(response['data'])
 
             # messageの各要素を評価
-            self.assertEqual(response_data['sender'], self.user1.nickname)
+            self.assertEqual(response_data['sender_id'], self.user1.id)
             self.assertEqual(response_data['message'], '')
             self.assertIsInstance(response_data['timestamp'], str)
             self.assertFalse(response_data['is_system_message'])
@@ -185,7 +185,7 @@ class DMConsumerTestCase(TransactionTestCase):
             response_data = json.loads(response['data'])
 
             # messageの各要素を評価
-            self.assertEqual(response_data['sender'], self.user1.nickname)
+            self.assertEqual(response_data['sender_id'], self.user1.id)
             self.assertEqual(response_data['message'], message_text)
             self.assertIsInstance(response_data['timestamp'], str)
             self.assertFalse(response_data['is_system_message'])
@@ -253,7 +253,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
         token_header = f'Bearer {self.user1_jwt}'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/nothing/",
+                                             f"ws/dm-with/9999/",
                                              headers)
         connected, subprotocol = await communicator.connect()
         self.assertFalse(connected)
@@ -267,7 +267,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
         token_header = f'Bearer invalid'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/{self.user2.nickname}/",
+                                             f"ws/dm-with/{self.user2.id}/",
                                              headers)
         connected, subprotocol = await communicator.connect()
         self.assertFalse(connected)
@@ -281,7 +281,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
         token_header = f'Bearer {self.user1_jwt}'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/{self.user1.nickname}/",
+                                             f"ws/dm-with/{self.user1.id}/",
                                              headers)
         connected, subprotocol = await communicator.connect()
 
@@ -294,7 +294,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
             token_header = f'Bearer {self.user1_jwt}'.encode()
             headers = [(b'authorization', token_header)]
             communicator = WebsocketCommunicator(application,
-                                                 f"ws/dm-with/{self.user2.nickname}/",
+                                                 f"ws/dm-with/{self.user2.id}/",
                                                  headers)
             connected, subprotocol = await communicator.connect()
             self.assertTrue(connected, f"WebSocket connection failed, code: {subprotocol}")
@@ -319,7 +319,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
         token_header = f'Bearer {self.user1_jwt}'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/{self.user2.nickname}/",
+                                             f"ws/dm-with/{self.user2.id}/",
                                              headers)
         connected, subprotocol = await communicator.connect()
 
@@ -349,7 +349,7 @@ class DMConsumerInvalidTestCase(TransactionTestCase):
         token_header = f'Bearer {self.user1_jwt}'.encode()
         headers = [(b'authorization', token_header)]
         communicator = WebsocketCommunicator(application,
-                                             f"ws/dm-with/{self.user2.nickname}/",
+                                             f"ws/dm-with/{self.user2.id}/",
                                              headers)
         connected, subprotocol = await communicator.connect()
 

--- a/docker/srcs/uwsgi-django/chat/urls.py
+++ b/docker/srcs/uwsgi-django/chat/urls.py
@@ -8,5 +8,6 @@ app_name = 'chat'
 
 urlpatterns = [
     path('dm-sessions/', DMSessionsView.as_view(), name='dm_sessions'),
-    path('dm-with/<str:target_nickname>/', DMView.as_view(), name='dm'),
+    # path('dm-with/<str:target_nickname>/', DMView.as_view(), name='dm'),
+    path('dm-with/<int:target_id>/', DMView.as_view(), name='dm'),
 ]

--- a/docker/srcs/uwsgi-django/chat/views/get_dm_sessions.py
+++ b/docker/srcs/uwsgi-django/chat/views/get_dm_sessions.py
@@ -29,15 +29,16 @@ class GetDMSessionsAPI(APIView):
         for session in sessions:
             other_user = session.member.exclude(id=user.id).first()
             if other_user:
-                dm_set.add((other_user.nickname, session.is_system_message))
+                dm_set.add((other_user.nickname, other_user.id, session.is_system_message))
         return dm_set
 
 
     def _get_dm_session_list(self, dm_set):
         dm_session_list = []
-        for target_nickname, is_system_message in dm_set:
+        for target_nickname, target_id, is_system_message in dm_set:
             data = {
                 'target_nickname'   : target_nickname,
+                'target_id'         : target_id,
                 'is_system_message' : is_system_message  # Maybe unused
             }
             dm_session_list.append(data)

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -25,19 +25,29 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def _get_dm_users(request, target_nickname):
+def _get_dm_users(request, target):
     try:
-        if not target_nickname:
+        if not target:
             err = "Nickname cannot be empty"
             return None, None, err
 
         user = request.user
-        other_user = CustomUser.objects.get(nickname=target_nickname)
+        dm_target = None
         err = None
 
-        if target_nickname == user.nickname:
+        if isinstance(target, int):
+            # targetがintの場合は、idとみなして検索
+            dm_target = CustomUser.objects.get(id=target)
+        elif isinstance(target, str):
+            # targetがstrの場合は、nicknameとみなして検索
+            dm_target = CustomUser.objects.get(nickname=target)
+        else:
+            err = "Invalid target type"
+            return None, None, err
+
+        if dm_target == user:
             err = "You cannot send a message to yourself"
-        return user, other_user, err
+        return user, dm_target, err
 
     except CustomUser.DoesNotExist:
         err = "The specified user does not exist"
@@ -49,13 +59,13 @@ def _get_dm_users(request, target_nickname):
 class ValidateDmTargetAPI(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request, target_nickname) -> Response:
-        user, other_user, err = _get_dm_users(request, target_nickname)
+    def get(self, request, target_nickname: str) -> Response:
+        user, dm_target, err = _get_dm_users(request, target_nickname)
         logger.error(f"ValidateDmTargetAPI target: {target_nickname}")
         if err is not None:
             logger.error(f"ValidateDmTargetAPI error: {err}")
             return Response({'error': err}, status=400)
-        return Response({'status': 'ok'}, status=200)
+        return Response({'status': 'ok', 'target_id': dm_target.id}, status=200)
 
 
 class DMView(LoginRequiredMixin, TemplateView):
@@ -67,31 +77,40 @@ class DMView(LoginRequiredMixin, TemplateView):
     template_name = "chat/dm_with.html"
     error_occurred_redirect_to = "chat:dm_sessions"
 
-    def get(self, request, target_nickname):
+    def get(self, request, target_id: str):
         # user, other_userを取得
         # dm targetのnicknameがuser.nicknameである場合はerr
-        user, other_user, err = _get_dm_users(request, target_nickname)
+        user, dm_target, err = _get_dm_users(request, target_id)
         if err is not None:
             # messages.error(request, err)
             return redirect(self.error_occurred_redirect_to)  # ValidateDmTargetAPIで判定済み
 
         # DBから user, other_userのメッセージを取得。検索パターンは
-        #  1) sender=user,       receiver=other_user
-        #  2) sender=other_user, receiver=user
+        #  1) sender=user,       receiver=dm_target
+        #  2) sender=dm_target,  receiver=user
         message_log = Message.objects.filter(
-            (models.Q(sender=user) & models.Q(receiver=other_user)) |
-            (models.Q(sender=other_user) & models.Q(receiver=user))
+            (models.Q(sender=user) & models.Q(receiver=dm_target)) |
+            (models.Q(sender=dm_target) & models.Q(receiver=user))
         ).order_by('timestamp')
-        is_blocking_user = user.blocking_users.filter(id=other_user.id).exists()
+        is_blocking_user = user.blocking_users.filter(id=dm_target.id).exists()
 
+        user_info = {
+            'id'        : user.id,
+            'nickname'  : user.nickname,
+            'avatar_url': user.avatar.url,
+        }
+        target_info = {
+            'id'                : dm_target.id,
+            'nickname'          : dm_target.nickname,
+            'avatar_url'        : dm_target.avatar.url,
+            'isBlockingUser'    : is_blocking_user,
+            'isSystemUser'      : dm_target.is_system,
+        }
         # dm.htmlのレンダリングに必要な情報を格納
         data = {
-            'target_nickname'   : other_user.nickname,
+            'user_info'         : user_info,
+            'target_info'       : target_info,
             'messages'          : message_log,
-            'isBlockingUser'    : is_blocking_user,
-            'isSystemUser'      : other_user.is_system,
-            'user_avatar_url'   : user.avatar.url,
-            'other_avatar_url'  : other_user.avatar.url,
             'url_config'        : settings.URL_CONFIG,
         }
         # logging.error(f'dm_room: user: {user.nickname}, dm_to: {nickname}, blocking: {is_blocking_user}')

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -92,6 +92,7 @@ class DMView(LoginRequiredMixin, TemplateView):
             (models.Q(sender=user) & models.Q(receiver=dm_target)) |
             (models.Q(sender=dm_target) & models.Q(receiver=user))
         ).order_by('timestamp')
+
         is_blocking_user = user.blocking_users.filter(id=dm_target.id).exists()
 
         user_info = {
@@ -110,7 +111,7 @@ class DMView(LoginRequiredMixin, TemplateView):
         data = {
             'user_info'         : user_info,
             'target_info'       : target_info,
-            'messages'          : message_log,
+            'message_log'       : message_log,
             'url_config'        : settings.URL_CONFIG,
         }
         # logging.error(f'dm_room: user: {user.nickname}, dm_to: {nickname}, blocking: {is_blocking_user}')

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-dm.css
@@ -83,7 +83,7 @@
 }
 
 .timestamp {
-	font-size: 0.8em;               /* 小さめのフォントサイズ */
+	font-size: 0.6em;               /* 小さめのフォントサイズ */
 	/* color: #666;                    色は暗めに設定 */
 	/* color: #131313; */
 	align-self: flex-end;     /* タイムスタンプを右揃え */

--- a/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
@@ -19,7 +19,7 @@
 	<li><a href="https://localhost/app/user/profile/change-avatar/" class="nav__link" data-link>kSpaChangeAvatarUrl</a></li>
 	<hr>
 	<li><a href="https://localhost/app/dm/" class="nav__link" data-link>kSpaDmUrl</a></li>
-	<li><a href="https://localhost/app/dm/user2" class="nav__link" data-link>kSpaDmWithUrl->user2</a></li>
+	<li><a href="https://localhost/app/dm/4/" class="nav__link" data-link>kSpaDmWithUrl->user2</a></li>
 <!--	<li><a href="https://localhost/app/dm/" class="nav__link" data-link>kSpaDmWithUrlBase</a></li>-->
 	<hr>
 	<li><a href="https://localhost/app/auth/enable-2fa/" class="nav__link" data-link>kSpaAuthEnable2FaUrl</a></li>

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -56,7 +56,7 @@ export const routeTable = {
 
   friends       : { path: "/app/user/friends/",               view: Friends },
   dmSessions    : { path: "/app/dm/",                         view: DMSessions },
-  dmWithUser    : { path: "/app/dm/:nickname/",               view: DMwithUser },
+  dmWithUser    : { path: "/app/dm/:userId/",                 view: DMwithUser },
   dmWithUserBase: { path: "/app/dm/",                         view: DMwithUser },
 
   editProfile   : { path: "/app/user/profile/edit/",          view: EditProfile },

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
@@ -14,15 +14,14 @@ export default class extends AbstractView {
   }
 
   async getHtml() {
-    const nickname = this.params.nickname;
-    const uri = `/chat/dm-with/${nickname}/`;
+    const userId = this.params.userId;
+    const uri = `/chat/dm-with/${userId}/`;
     const data = await fetchData(uri);
     //console.log("Pong:" + data);
     return data;
   }
 
   async executeScript(spaElement) {
-    // loadAndExecuteScript("/static/chat/js/dm-with-user.js", true);
     const dmWithUserModule = await import("/static/chat/js/dm-with-user.js");
     dmWithUserModule.initDM();
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
@@ -17,7 +17,7 @@
   "kSpaChangeAvatarUrl" : "/app/user/profile/change-avatar/",
 
   "kSpaDmUrl"           : "/app/dm/",
-  "kSpaDmWithUrl"       : "/app/dm/:nickname",
+  "kSpaDmWithUrl"       : "/app/dm/:userId/",
   "kSpaDmWithUrlBase"   : "/app/dm/",
 
   "kSpaAuthEnable2FaUrl": "/app/auth/enable-2fa/",

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -424,4 +424,3 @@ class TestConfig(LiveServerTestCase):
         self._send_to_elem(By.ID, "nickname-input", target_nickname)
         signup_button = self._element(By.ID, "nickname-submit")
         self._click_button(signup_button, wait_for_button_invisible=True)
-        self._assert_current_url(f"{self.dm_with_base_url}{target_nickname}/")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_block.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_block.py
@@ -45,7 +45,8 @@ class DMTest(TestConfig):
         # self._screenshot("block 3")
 
         # DMへ遷移し、dm-log要素が非表示であることを確認
-        self._access_to(f"{self.dm_with_base_url}{self.test_user2_nickname}/")
+        self._move_top_to_dm()
+        self._send_dm_with_form(self.test_user2_nickname)
         self.assertFalse(self._is_unblocking_dm())
 
         # self._screenshot("block 4")
@@ -54,7 +55,8 @@ class DMTest(TestConfig):
         self._unblock_user(self.test_user2_nickname)
 
         # DMへ遷移し、dm-log要素が非表示であることを確認
-        self._access_to(f"{self.dm_with_base_url}{self.test_user2_nickname}/")
+        self._move_top_to_dm()
+        self._send_dm_with_form(self.test_user2_nickname)
         self.assertTrue(self._is_unblocking_dm())
 
         # self._screenshot("block 5")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_dm.py
@@ -54,7 +54,8 @@ class DMTest(TestConfig):
 
         # test_user2が受信したDM #################################################
         self._login(email=self.test_user2_email, password=self.password)
-        self._access_to(f"{self.dm_with_base_url}{self.test_user1_nickname}/")
+        self._move_top_to_dm()
+        self._send_dm_with_form(self.test_user1_nickname)
         received_message = self._element(By.CSS_SELECTOR, "#dm-log li.dm-to .message-content span:first-child")
         self.assertEqual(received_message.text, message)
         # self._screenshot("dm3")
@@ -89,11 +90,6 @@ class DMTest(TestConfig):
         self._assert_message("The specified user does not exist")
         self._assert_current_url(self.dm_url)
         # self._screenshot("dm4")
-
-        valid_nickname = "user2"
-        self._send_nickname(valid_nickname, wait_for_button_invisible=True)
-        self._assert_current_url(f"{self.dm_with_base_url}{valid_nickname}/")
-        # self._screenshot("dm5")
 
     def _send_message(self, message):
         self._send_to_elem(By.ID, "message-input", message)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -229,7 +229,7 @@ class UrlAccessTest(TestConfig):
         """
         url_with_param_pages = {
             UserInfoUrlBase,
-            DmWithUrlBase,
+            # DmWithUrlBase,  # /url/<user_id>/ に変更, id取得必要のためテストNG
         }
         return page_name in url_with_param_pages
 


### PR DESCRIPTION
#245 

- [x] DM sessionをnicknameベース -> idベースに変更し、nickname変更耐性を強化
- [x] test 修正


<br>

## memo
- dm pageのURLは`nickname` -> `user_id`に変更
  - nickname変更の影響を受けない状態になった
  - URLが`/dm-with/<nickname>/`の場合、nicknameが変更されると画面更新後にDM維持できない
- DMwith画面表示の間、DM相手のnicknameは初期のまま固定（変更されても元のnicknameを使い続ける。updateしない）
  - メッセージもuser_idベースとし、初期に読み込んだNicknameを送信者名として表示
- DMwith画面を更新すると、相手のnickname変更が反映される
