### PR TITLE
Todo ft #261

### DIFF
--- a/docker/srcs/compose-yaml/compose-monitor.yaml
+++ b/docker/srcs/compose-yaml/compose-monitor.yaml
@@ -54,10 +54,9 @@ services:
       - ${VOLUME_PATH:?}/grafana/:/var/lib/grafana
       # 上記/var/lib/grafanaの中でもdashboradの設定ファイルは、別枠でコンテナイメージに入れたい。方法がわからないのでマウントで対応
       - ./grafana/dashboards/1860-node-exporter-full.json:/var/lib/grafana/dashboards/ft_trans/1860-node-exporter-full.json
-      # TODO-ft: レビュー前に.gitignoreする
+      # TODO_ft_2: レビュー前に.gitignoreする
       - ./grafana/ssl/grafana.crt:/etc/grafana/grafana.crt
       - ./grafana/ssl/grafana.key:/etc/grafana/grafana.key
-      # TODO_ft:本番環境ではimageに埋め込む？開発スピードのために即時反映させたいのでマウント
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
     env_file:
       - .env
@@ -75,31 +74,3 @@ services:
       - monitor_transcendence
     profiles:
       - monitor
-
-  # grafana-dev:
-  #   container_name: grafana-dev
-  #   build: ./grafana-dev
-  #   image: grafana-dev
-  #   restart: unless-stopped
-  #   ports:
-  #     - "3309:3000"
-  #   volumes:
-  #     - ${VOLUME_PATH:?}/grafana-dev/:/var/lib/grafana
-  #     - ./grafana-dev/dashboards/1860-node-exporter-full.json:/var/lib/grafana/dashboards/ft_trans/1860-node-exporter-full.json
-  #     # TODO-ft: レビュー前に.gitignoreする
-  #     - ./grafana/ssl/grafana.crt:/etc/grafana/grafana.crt
-  #     - ./grafana/ssl/grafana.key:/etc/grafana/grafana.key
-  #     # TODO_ft:本番環境ではimageに埋め込む？開発スピードのために即時反映させたいのでマウント
-  #     - ./grafana/grafana.ini:/etc/grafana/grafana.ini
-  #   env_file:
-  #     - .env
-  #   environment:
-  #     - GF_INSTALL_PLUGINS=grafana-clock-panel
-  #     - GF_LOG_LEVEL=debug
-  #     - GF_PLUGIN_GRAFANA_IMAGE_RENDERER_RENDERING_IGNORE_HTTPS_ERRORS=true
-  #     - GF_SERVER_ROOT_URL=https://localhost:3309/
-  #   networks:
-  #     - web_transcendence
-  #     - monitor_transcendence
-  #   profiles:
-  #     - monitor

--- a/docker/srcs/grafana/doc_md/grafana_dev_memo.md
+++ b/docker/srcs/grafana/doc_md/grafana_dev_memo.md
@@ -10,7 +10,6 @@
   - 連携: github, discord, spotify
     - テスト時注意
       - 同一アドレスで登録できない(githubとdiscordで同じメアドの場合)。連続で挙動テストするときに発生するかも。adm:admで管理者でインして、emailが同一のuserを削除してテストしてください
-  - TODO_ft：Basic認証の下にAuthボタン > Basic認証機能を削除するか検討中
   <img src="img/スクリーンショット 2024-03-31 21.45.44.png" width="450" alt="alt">
   <img src="img/スクリーンショット 2024-04-01 8.51.45.png" width="450" alt="alt">
 
@@ -29,7 +28,7 @@
 
 ![alt text](<img/スクリーンショット 2024-03-30 8.03.02.png>)
 
-## TODO_ft
+## TODO_ft_2
 
 - 優先
 - Auth0

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
@@ -6,7 +6,7 @@
 	<div class="hth-accounts-container">
 
 		<h2>Edit user profile</h2>
-		{% comment %} TODO_ft:あらかじめスペースをとっているので、トーストに変更したい  {% endcomment %}
+		{% comment %} TODO_ft_2:あらかじめスペースをとっているので、トーストに変更したい  {% endcomment %}
 		<p id="message-area"></p>
 
 		{% comment %} ニックネーム更新用のフォーム  {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
@@ -12,7 +12,7 @@
 			slideup-text
 			">Please log in</h1>
 
-		 {% comment %} TODO_ft:あらかじめスペースを用意しているのでPOPUPに切り替えたい  {% endcomment %}
+		 {% comment %} TODO_ft_2:あらかじめスペースを用意しているのでPOPUPに切り替えたい  {% endcomment %}
 		<p id="message-area"></p>
 
 		 {% comment %} auth form  {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/edit_profile.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
@@ -93,4 +93,4 @@
 <hr>
 <a href="/pong">🏓 return to pong</a>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/login.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/login.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
@@ -61,4 +61,4 @@
 <hr>
 <a href="/pong/">🏓 return to pong</a>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/logout.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/logout.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
@@ -42,4 +42,4 @@
 <a href="/pong/">🏓 return to pong</a>
 
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/signup copy.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/signup copy.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% comment %} {% extends 'base.html' %}
 {% load static %}
 {% block title %}ユーザー登録 - hth Pong{% endblock title %}
 {% block head %}
@@ -194,4 +194,4 @@
 	</div>
 </div>
 
-{% endblock %}
+{% endblock %} {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/signup.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/signup.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
@@ -63,4 +63,4 @@
 <hr>
 <a href="/pong/">🏓 return to pong</a>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/user.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/user.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% comment %} {% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -40,4 +40,4 @@
 <br>
 <a href="/pong/">🏓 Pong Index Page</a>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/user_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/plane/user_profile.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% comment %} {% extends "base.html" %}
 
 {% block title %}
 {{ user.username }}'s Profile - user info
@@ -8,4 +8,4 @@
 <h1>user page</h1>
 <h2>email: {{ user.email }}</h2>
 <h2>nickname: {{ user.nickname }}</h2>
-{% endblock %}
+{% endblock %} {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/verify/plane/enable_2fa.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/verify/plane/enable_2fa.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
   <meta charset="utf-8">
@@ -126,4 +126,4 @@
 <!--<hr>-->
 <!--<a href="/pong">🏓 return to pong</a>-->
 <!--</body>-->
-<!--</html>-->
+<!--</html>--> {% endcomment %}

--- a/docker/srcs/uwsgi-django/accounts/templates/verify/plane/verify_2fa.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/verify/plane/verify_2fa.html
@@ -1,4 +1,4 @@
-<!doctype html>
+{% comment %} <!doctype html>
 <html lang="ja">
 <head>
     <meta charset="utf-8">
@@ -55,4 +55,4 @@
 <br>
 <a href="/pong/">🏓 Return to pong</a>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-accounts.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-accounts.css
@@ -1,10 +1,9 @@
 
-/* TODO_ft:tournament UIHelper SPA後削除予定*/
 #user-info {
 	list-style-type: none;
 }
 
-/* TODO_ft:UI変更予定 */
+
 #message-area {
 	color: #ffb320;
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
@@ -1,6 +1,6 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
 
-const DEBUG_FLOW 		= 1;
+const DEBUG_FLOW 		= 0;
 const DEBUG_DETAIL		= 0;
 const TEST_TRY1			= 0;
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
@@ -1,42 +1,32 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
+
+const DEBUG_FLOW 		= 1;
+const DEBUG_DETAIL		= 0;
+const TEST_TRY1			= 0;
+
 class PongEngineKey 
 {
 	static keys = {/** empty */};
 	static isListenerRegistered = false;
 
-	// static listenForEvents() 
-	// {
-	// 	window.addEventListener('keydown', (event) => 
-	// 	{
-	// 		const key = event.key.toUpperCase();
-	// 		PongEngineKey.keys[key] = true;
-	// 		// console.log(`Key down: ${key}`);
-	// 	});
-
-	// 	window.addEventListener('keyup', (event) => 
-	// 	{
-	// 		const key = event.key.toUpperCase();
-	// 		PongEngineKey.keys[key] = false;
-	// 		// console.log(`Key down: ${key}`);
-	// 	});
-	// }
-
-	static listenForEvents() 
+	static registerListenersKeyUpDown() 
 	{
 		if (!PongEngineKey.isListenerRegistered) {
 			window.addEventListener('keydown', PongEngineKey.handleKeyDown);
 			window.addEventListener('keyup', PongEngineKey.handleKeyUp);
 			PongEngineKey.isListenerRegistered = true;
+						if (DEBUG_FLOW) {	console.log('PongEngineKey: registerListenersKeyUpDown done');	};
 		}
 	}
 
-	static removeListeners() 
+	static unregistersListenersKyeUpDown() 
 	{
 		if (PongEngineKey.isListenerRegistered) {
 			window.removeEventListener('keydown', PongEngineKey.handleKeyDown);
 			window.removeEventListener('keyup', PongEngineKey.handleKeyUp);
 			PongEngineKey.isListenerRegistered = false;
 			PongEngineKey.keys = {/** empty */};
+						if (DEBUG_FLOW) {	console.log('PongEngineKey: unregisterListenersKyeUpDown done');	}
 		}
 	}
 	

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongEngineKey.js
@@ -4,22 +4,22 @@ class PongEngineKey
 	static keys = {/** empty */};
 	static isListenerRegistered = false;
 
-	static listenForEvents() 
-	{
-		window.addEventListener('keydown', (event) => 
-		{
-			const key = event.key.toUpperCase();
-			PongEngineKey.keys[key] = true;
-			// console.log(`Key down: ${key}`);
-		});
+	// static listenForEvents() 
+	// {
+	// 	window.addEventListener('keydown', (event) => 
+	// 	{
+	// 		const key = event.key.toUpperCase();
+	// 		PongEngineKey.keys[key] = true;
+	// 		// console.log(`Key down: ${key}`);
+	// 	});
 
-		window.addEventListener('keyup', (event) => 
-		{
-			const key = event.key.toUpperCase();
-			PongEngineKey.keys[key] = false;
-			// console.log(`Key down: ${key}`);
-		});
-	}
+	// 	window.addEventListener('keyup', (event) => 
+	// 	{
+	// 		const key = event.key.toUpperCase();
+	// 		PongEngineKey.keys[key] = false;
+	// 		// console.log(`Key down: ${key}`);
+	// 	});
+	// }
 
 	static listenForEvents() 
 	{
@@ -36,6 +36,7 @@ class PongEngineKey
 			window.removeEventListener('keydown', PongEngineKey.handleKeyDown);
 			window.removeEventListener('keyup', PongEngineKey.handleKeyUp);
 			PongEngineKey.isListenerRegistered = false;
+			PongEngineKey.keys = {/** empty */};
 		}
 	}
 	
@@ -44,6 +45,13 @@ class PongEngineKey
 		const key = event.key.toUpperCase();
 		PongEngineKey.keys[key] = true;
 	}
+
+	static handleKeyUp(event) 
+	{
+		const key = event.key.toUpperCase();
+		PongEngineKey.keys[key] = false;
+	}
+
 	static isDown(key) 
 	{
 		return PongEngineKey.keys[key.toUpperCase()];

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
@@ -4,7 +4,7 @@ import PongOnlineSyncWS from "./PongOnlineSyncWS.js";
 import PongOnlineGameStateManager from "./PongOnlineGameStateManager.js"
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-const DEBUG_FLOW		= 1;
+const DEBUG_FLOW		= 0;
 const DEBUG_DETAIL1		= 0;
 const DEBUG_DETAIL2		= 0;
 const TEST_TRY1			= 0;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
@@ -2,6 +2,8 @@
 import PongEngineKey from "./PongEngineKey.js";
 import PongOnlineSyncWS from "./PongOnlineSyncWS.js";
 import PongOnlineGameStateManager from "./PongOnlineGameStateManager.js"
+import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js"
+
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
 const DEBUG_FLOW		= 0;
@@ -30,7 +32,7 @@ class PongOnlineClientApp
 	{
 		try {
 			if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-				console.log('init(): this.socket.close()');
+							if (DEBUG_FLOW) {	console.log('init(): this.socket.close()');	}
 				this.socket.close();
 				this.socket = null;
 
@@ -38,8 +40,10 @@ class PongOnlineClientApp
 			this.initWebSocket();
 			this.initStartButton();
 			this.initEndButton();
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 		} catch(error) {
-			console.error('hth: init() failed: ', error);
+			console.error('hth: PongOnlineClientApp init() failed: ', error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -60,7 +64,7 @@ class PongOnlineClientApp
 	initStartButton() 
 	{
 		try {
-					if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
+						if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 
 			this.startGameButton = document.getElementById('hth-pong-online-start-game-btn');
 			if (!this.startGameButton) {
@@ -70,6 +74,7 @@ class PongOnlineClientApp
 			this.registerStartButtonEventListener();
 		} catch (error) {
 			console.error('hth: initStartButton() failed: ', error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 	
@@ -109,7 +114,7 @@ class PongOnlineClientApp
 	setupWebSocketConnection()
 	{
 		try {
-					if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
+						if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 
 			if (this.socket && this.socket.readyState === WebSocket.OPEN) {
 				this.socket.close();
@@ -130,6 +135,7 @@ class PongOnlineClientApp
 			this.socket.onerror		= (event) => this.syncWS.onSocketError(event);
 		} catch(error) {
 			console.error('hth: setupWebSocketConnection() failed: ', error)
+			pongOnlineHandleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineClientApp.js
@@ -4,13 +4,13 @@ import PongOnlineSyncWS from "./PongOnlineSyncWS.js";
 import PongOnlineGameStateManager from "./PongOnlineGameStateManager.js"
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-let DEBUG_FLOW		= 0;
-let DEBUG_DETAIL1	= 0;
-let DEBUG_DETAIL2	= 0;
-let TEST_TRY1 = 0;
-let TEST_TRY2 = 0;
-let TEST_TRY3 = 0;
-let TEST_TRY4 = 0;
+const DEBUG_FLOW		= 1;
+const DEBUG_DETAIL1		= 0;
+const DEBUG_DETAIL2		= 0;
+const TEST_TRY1			= 0;
+const TEST_TRY2			= 0;
+const TEST_TRY3			= 0;
+const TEST_TRY4			= 0;
 
 /**
  * 2D-Pong Onlineのメインクラス
@@ -23,8 +23,6 @@ class PongOnlineClientApp
 				if (DEBUG_FLOW){	console.log('PongOnlineClientApp constructor begin');	}
 		this.socket = null;
 		this.init();
-		this.boundInit = this.init.bind(this);
- 		window.addEventListener('switchPageResetState', this.boundInit);
 		this.isStartButtonListenerRegistered = false;
 	}
 	
@@ -55,7 +53,7 @@ class PongOnlineClientApp
 		// 毎回新しいインスタンスを生成。SPA遷移（ renderView() ）が実行された場合、ゲームはリセットする
 		this.gameStateManager	= new PongOnlineGameStateManager(this);
 		this.syncWS				= new PongOnlineSyncWS(this, this.gameStateManager);
-		PongEngineKey.listenForEvents();
+		PongEngineKey.registerListenersKeyUpDown();
 	}
 	
 	// websocket接続開始のためのスタートボタン
@@ -70,13 +68,6 @@ class PongOnlineClientApp
 			}
 			this.startGameButton.style.display = 'block' 
 			this.registerStartButtonEventListener();
-			// const startGameButtonClickHandler = () => {
-			// 	console.log('this.socket', this.socket);
-
-			// 	this.setupWebSocketConnection();
-			// 	this.startGameButton.remove();  
-			// };
-			// this.startGameButton.addEventListener('click', startGameButtonClickHandler);
 		} catch (error) {
 			console.error('hth: initStartButton() failed: ', error);
 		}
@@ -87,6 +78,7 @@ class PongOnlineClientApp
 		if (!this.isStartButtonListenerRegistered) {
 			this.startGameButton.addEventListener('click', this.handleStartButtonClick.bind(this));
 			this.isStartButtonListenerRegistered = true;
+						if (DEBUG_FLOW){	console.log('registerStartButtonEventListener: done');	}
 		}
 	}
 	
@@ -95,12 +87,12 @@ class PongOnlineClientApp
 		if (this.isStartButtonListenerRegistered) {
 			this.startGameButton.removeEventListener('click', this.handleStartButtonClick);
 			this.isStartButtonListenerRegistered = false;
+						if (DEBUG_FLOW){	console.log('unregisterStartButtonEventListener: done');	}
 		}
 	}
 	
 	handleStartButtonClick()
 	{
-		// console.log('this.socket', this.socket);
 		this.setupWebSocketConnection();
 		this.startGameButton.style.display = 'none';
 	}
@@ -141,15 +133,15 @@ class PongOnlineClientApp
 		}
 	}
 
-	// static main(env) {
-	// 	new PongOnlineClientApp(env);
-	// }
-
 	dispose() {
+		// -----------------------------
 		// eventlistenerの削除
-		window.removeEventListener('switchPageResetState', this.boundInit);
+		// -----------------------------
+		// スタートボタン
 		this.unregisterStartButtonEventListener();
-		PongEngineKey.removeListeners();
+		// パドル操作: key up,down
+		PongEngineKey.unregistersListenersKyeUpDown();
+		// -----------------------------
 
 		// WebSocketの切断
 		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
@@ -170,6 +162,7 @@ class PongOnlineClientApp
 		this.socketUrl = null;
 		this.startGameButton = null;
 		this.isStartButtonListenerRegistered = false;
+					if (DEBUG_FLOW){	console.log('PongOnlineClientApp: dispose: done');	}
 	}
 }
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameLoopManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameLoopManager.js
@@ -2,6 +2,7 @@
 import PongOnlinePaddleMover from "./PongOnlinePaddleMover.js";
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js"
 
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
@@ -92,8 +93,7 @@ class PongOnlineGameLoopManager
 					if (elapsed >= this.desiredFrameTimeMs) 
 					{
 						if (!gameState) {
-							console.error("hth: gameState is null.");
-							return;
+							throw new Error("hth: gameState is null.");
 						} 
 						
 						if (gameState.is_running) {
@@ -114,6 +114,7 @@ class PongOnlineGameLoopManager
 							if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 				} catch(error) {
 					console.error("hth: gameLoop error:", error);
+					pongOnlineHandleCatchError(error);
 				}
 			}
 			// 最初のフレームを要求
@@ -132,6 +133,7 @@ class PongOnlineGameLoopManager
 						if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 		} catch(error) {
 			console.error("hth: stopGameLoop():  renderer.render() failed:", error);
+			pongOnlineHandleCatchError(error);
 		}
 
 		try {
@@ -144,6 +146,7 @@ class PongOnlineGameLoopManager
 						if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 		} catch(error) {
 			console.error("hth: stopGameLoop(): updateEndGameBtn() failed:", error);
+			pongOnlineHandleCatchError(error);
 		}
 
 		// アニメーションを指定してキャンセル
@@ -193,10 +196,11 @@ class PongOnlineGameLoopManager
 				endGameButton.style.display = 'block';
 				this.registerEndGameButtonListener();
 			} else {
-				console.error('End Game button not found');
+				console.error('hth: End Game button not found');
 			}
 		} catch (error){
 			console.error('hth: updateEndGameBtn() failed: ', error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -2,6 +2,7 @@
 import PongOnlineGameLoopManager from "./PongOnlineGameLoopManager.js";
 import PongOnlinePaddleMover from "./PongOnlinePaddleMover.js";
 import PongOnlineRenderer from "./PongOnlineRenderer.js";
+import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js"
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
 const DEBUG_FLOW 		= 0;
@@ -27,7 +28,8 @@ class PongOnlineGameStateManager
 
 				if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 		} catch (error) {
-			console.error("PongOnlineGameStateManager.constructor() failed:", error);
+			console.error("hth: PongOnlineGameStateManager.constructor() failed:", error);
+			pongOnlineHandleCatchError(error);
 		}
 
 		this.ctx				= null
@@ -83,6 +85,7 @@ class PongOnlineGameStateManager
 			}
 		} catch(resizeError) {
 			console.error("hth: Error during resize:", resizeError);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -96,6 +99,7 @@ class PongOnlineGameStateManager
 			this.loopManager.startGameLoop(this.gameFPS);
 		} catch(error) {
 			console.error("hth: handleGameStart() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -144,6 +148,7 @@ class PongOnlineGameStateManager
 
 			} catch(error) {
 				console.error("hth: sendClientState() failed: ", error);
+				pongOnlineHandleCatchError(error);
 			}
 		} else {
 			// 通信の遅延もあるのでエラーではない。大量に出力されて負荷が高いのでコメントアウト

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -146,7 +146,7 @@ class PongOnlineGameStateManager
 				console.error("hth: sendClientState() failed: ", error);
 			}
 		} else {
-			// 通信の遅延もあるのでエラー出力ではない。大量に出力されて負荷が高いのでコメントアウト
+			// 通信の遅延もあるのでエラーではない。大量に出力されて負荷が高いのでコメントアウト
 			// console.log("sendClientState() failed: WebSocket not ready or previous message pending.");
 
 					if (DEBUG_DETAIL2)

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -26,7 +26,7 @@ class PongOnlineGameStateManager
 			this.loopManager		= new PongOnlineGameLoopManager(clientApp, this)
 			this.clientApp 			= clientApp
 
-				if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
+						if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 		} catch (error) {
 			console.error("hth: PongOnlineGameStateManager.constructor() failed:", error);
 			pongOnlineHandleCatchError(error);
@@ -63,7 +63,7 @@ class PongOnlineGameStateManager
 		if (!this.isResizeListenerRegistered) {
 			window.addEventListener('resize', this.handleResize);
 			this.isResizeListenerRegistered = true;
-			if (DEBUG_FLOW) {	console.log('registerResizeListener: done');	}
+						if (DEBUG_FLOW) {	console.log('registerResizeListener: done');	}
 		}
 	}
 
@@ -72,14 +72,14 @@ class PongOnlineGameStateManager
 		if (this.isResizeListenerRegistered) {
 			window.removeEventListener('resize', this.handleResize);
 			this.isResizeListenerRegistered = false;
-			if (DEBUG_FLOW) {	console.log('unregisterResizeListener: done');	}
+						if (DEBUG_FLOW) {	console.log('unregisterResizeListener: done');	}
 		}
 	}
 	
 	handleResize()
 	{
 		try {
-			if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
+						if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 			if (this.renderer){
 				this.renderer.resizeForAllDevices();
 			}
@@ -93,7 +93,6 @@ class PongOnlineGameStateManager
 	{
 		try {
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
-
 			this.initCanvas();
 			this.registerResizeListener();
 			this.loopManager.startGameLoop(this.gameFPS);
@@ -113,10 +112,7 @@ class PongOnlineGameStateManager
 		}
 		this.ctx		= this.canvas.getContext("2d");
 		this.field		= this.gameState.game_settings.field;
-
-				if (DEBUG_DETAIL){
-					console.log('this.field: ', this.field);	}
-
+				if (DEBUG_DETAIL){	console.log('this.field: ', this.field);	}
 		this.renderer.initRenderer();
 		this.renderer.resizeForAllDevices();
 	}
@@ -167,14 +163,11 @@ class PongOnlineGameStateManager
 	handleGameEnd(socket, endGameState)
 	{
 		this.updateState(endGameState);
-		
 				if (DEBUG_DETAIL){
 					console.log("onSocketMessage: finalGameState:", this.finalGameState)
 					console.log("onSocketMessage: gameState:", this.gameState)
 				}
-				if (DEBUG_FLOW){
-					console.log('handleGameEnd(): done');
-				}
+				if (DEBUG_FLOW){	console.log('handleGameEnd(): done');	}
 	}
 	// ------------------------------
 	// getter , setter

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -59,7 +59,7 @@ class PongOnlineGameStateManager
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 
 			this.initCanvas();
-			
+			// TODO_ft:削除は？
 			window.addEventListener('resize', () => 
 			{
 				try {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineGameStateManager.js
@@ -4,13 +4,13 @@ import PongOnlinePaddleMover from "./PongOnlinePaddleMover.js";
 import PongOnlineRenderer from "./PongOnlineRenderer.js";
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-let DEBUG_FLOW 		= 0;
-let DEBUG_DETAIL 	= 0;
-let DEBUG_DETAIL2 	= 0;
-let TEST_TRY1 = 0;
-let TEST_TRY2 = 0;
-let TEST_TRY3 = 0;
-let TEST_TRY4 = 0;
+const DEBUG_FLOW 		= 0;
+const DEBUG_DETAIL 		= 0;
+const DEBUG_DETAIL2 	= 0;
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
+const TEST_TRY3 		= 0;
+const TEST_TRY4 		= 0;
 
 /**
  * Gameに必要なデータ(paddle,ballなどのオブジェクト、試合のスコアや状態など)を格納
@@ -48,30 +48,51 @@ class PongOnlineGameStateManager
 			state: {},
 			is_running: false
 		};
+
+		this.isResizeListenerRegistered = false;
+		this.handleResize = this.handleResize.bind(this);
 	}
 
 	// ------------------------------
 	// game start
 	// ------------------------------
+	registerResizeListener()
+	{
+		if (!this.isResizeListenerRegistered) {
+			window.addEventListener('resize', this.handleResize);
+			this.isResizeListenerRegistered = true;
+			if (DEBUG_FLOW) {	console.log('registerResizeListener: done');	}
+		}
+	}
+
+	unregisterResizeListener()
+	{
+		if (this.isResizeListenerRegistered) {
+			window.removeEventListener('resize', this.handleResize);
+			this.isResizeListenerRegistered = false;
+			if (DEBUG_FLOW) {	console.log('unregisterResizeListener: done');	}
+		}
+	}
+	
+	handleResize()
+	{
+		try {
+			if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
+			if (this.renderer){
+				this.renderer.resizeForAllDevices();
+			}
+		} catch(resizeError) {
+			console.error("hth: Error during resize:", resizeError);
+		}
+	}
+
 	handleGameStart()
 	{
 		try {
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 
 			this.initCanvas();
-			// TODO_ft:削除は？
-			window.addEventListener('resize', () => 
-			{
-				try {
-							if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
-					if (this.renderer){
-						this.renderer.resizeForAllDevices();
-					}
-				} catch(resizeError) {
-					console.error("hth: Error during resize:", resizeError);
-				}
-			});
-
+			this.registerResizeListener();
 			this.loopManager.startGameLoop(this.gameFPS);
 		} catch(error) {
 			console.error("hth: handleGameStart() failed: ", error);
@@ -162,8 +183,10 @@ class PongOnlineGameStateManager
 	}
 
 	dispose() {
-		window.removeEventListener('resize', this.resizeHandler);
-
+		// window.removeEventListener('resize', this.resizeHandler);
+		// イベントリスナー削除: window resize
+		this.unregisterResizeListener();
+		
 		if (this.renderer) {
 			this.renderer.dispose();
 			this.renderer = null;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -52,10 +52,10 @@ if (!window.disposePongOnlineClientApp) {
 	window.disposePongOnlineClientApp = disposePongOnlineClientApp;
 }
 
-endGameButton.addEventListener('click', () => {
-	const redirectTo = routeTable['top'].path;
-	switchPage(redirectTo);
-});
+// endGameButton.addEventListener('click', () => {
+// 	const redirectTo = routeTable['top'].path;
+// 	switchPage(redirectTo);
+// });
 
 export async function pongOnlineHandleCatchError(error = null) 
 {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -3,6 +3,8 @@ import PongOnlineClientApp from './PongOnlineClientApp.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
 
+const DEBUG_FLOW = 1;
+
 /**
  * 2D-Pong entry point
  */
@@ -13,6 +15,17 @@ let isEventListenerRegistered = false;
 // ---------------------------------------
 async function initPongOnlineClientApp() 
 {
+	// ----------------------------------
+	// urlが FreePlay かどうかを判定
+	// ----------------------------------
+	const currentPath = window.location.pathname;
+				if (DEBUG_FLOW) {	console.log('routeTable:', routeTable);	}
+	const game2dPath = routeTable['game2d'].path;
+	if (currentPath !== game2dPath) {
+					if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp: currentPath !== game2dPath');	}
+		return;
+	}
+	
 	if (pongOnlineClientApp) {
 		pongOnlineClientApp.dispose();
 		pongOnlineClientApp = null;
@@ -48,6 +61,7 @@ async function disposePongOnlineClientApp()
 	}
 }
 
+// このメソッドを呼び出すファイル: static/spa/js/views/pong/Game2D.js
 if (!window.disposePongOnlineClientApp) {
 	window.disposePongOnlineClientApp = disposePongOnlineClientApp;
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -91,13 +91,8 @@ if (!window.disposePongOnlineClientApp) {
 // ---------------------------------------
 // error
 // ---------------------------------------
-export async function pongOnlineHandleCatchError(error = null) 
+export function pongOnlineHandleCatchError(error = null) 
 {
-	// SPAの状態をリセットしない場合
-	// const switchPage = await loadSwitchPage();
-	// const redirectTo = routeTable['top'].path;
-	// switchPage(redirectTo);
-
 	// ゲームでのエラーは深刻なので、location.hrefでSPAの状態を完全にリセットする
 	if (error) {
 		alert("エラーが発生しました。トップページに遷移します。 error: " + error);

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -3,7 +3,7 @@ import PongOnlineClientApp from './PongOnlineClientApp.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
 
-const DEBUG_FLOW = 1;
+const DEBUG_FLOW = 0;
 
 /**
  * 2D-Pong entry point

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -15,39 +15,46 @@ let isEventListenerRegistered = false;
 // ---------------------------------------
 async function initPongOnlineClientApp() 
 {
-	// ----------------------------------
-	// urlが FreePlay かどうかを判定
-	// ----------------------------------
-	const currentPath = window.location.pathname;
-				if (DEBUG_FLOW) {	console.log('routeTable:', routeTable);	}
-	const game2dPath = routeTable['game2d'].path;
-	if (currentPath !== game2dPath) {
-					if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp: currentPath !== game2dPath');	}
+				if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp: start');	}
+	// urlが FreePlayリンク(view: game2d) かどうかを判定し、早期リターン
+	if (!_isGame2dUrl()) {
+					if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp(): not game2d url');	}
 		return;
 	}
-	
+	// 重複対策: 削除してから新規作成
 	if (pongOnlineClientApp) {
 		pongOnlineClientApp.dispose();
 		pongOnlineClientApp = null;
 	}
 	pongOnlineClientApp = new PongOnlineClientApp();
 }
+
+function _isGame2dUrl() {
+	const currentPath = window.location.pathname;
+				if (DEBUG_FLOW) {	console.log('currentPath:', currentPath);	}
+	const game2dPath = routeTable['game2d'].path;
+	return currentPath === game2dPath;
+}
+
+// PongOnlineClientAppインスタンスの作成
 initPongOnlineClientApp();
 // ---------------------------------------
 // switchPageResetState
 // ---------------------------------------
 async function handleSwitchPageResetState() {
+	// 常にinitする。
 	await initPongOnlineClientApp();
 }
 
 function registerEventListenerSwitchPageResetState() {
-	if (isEventListenerRegistered) {
-		return;
+	if (!isEventListenerRegistered) {
+		window.addEventListener('switchPageResetState', handleSwitchPageResetState);
+		isEventListenerRegistered = true;
+					if (DEBUG_FLOW) {	console.log('registerEventListenerSwitchPageResetState: done');	}
 	}
-	window.addEventListener('switchPageResetState', handleSwitchPageResetState);
-	isEventListenerRegistered = true;
 }
-
+// イベントリスナー削除はしない
+// 重複登録対策: flagで管理
 registerEventListenerSwitchPageResetState();
 // ---------------------------------------
 // dispose
@@ -56,6 +63,7 @@ async function disposePongOnlineClientApp()
 {
 	if (pongOnlineClientApp) 
 	{
+					if (DEBUG_FLOW) {	console.log('disposePongOnlineClientApp: start');	}
 		pongOnlineClientApp.dispose();
 		pongOnlineClientApp = null;
 	}
@@ -65,12 +73,9 @@ async function disposePongOnlineClientApp()
 if (!window.disposePongOnlineClientApp) {
 	window.disposePongOnlineClientApp = disposePongOnlineClientApp;
 }
-
-// endGameButton.addEventListener('click', () => {
-// 	const redirectTo = routeTable['top'].path;
-// 	switchPage(redirectTo);
-// });
-
+// ---------------------------------------
+// error
+// ---------------------------------------
 export async function pongOnlineHandleCatchError(error = null) 
 {
 	// SPAの状態をリセットしない場合

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineIndex.js
@@ -4,6 +4,8 @@ import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
 
 const DEBUG_FLOW = 0;
+const TEST_TRY1	 = 0;
+const TEST_TRY2	 = 0;
 
 /**
  * 2D-Pong entry point
@@ -15,18 +17,24 @@ let isEventListenerRegistered = false;
 // ---------------------------------------
 async function initPongOnlineClientApp() 
 {
-				if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp: start');	}
-	// urlが FreePlayリンク(view: game2d) かどうかを判定し、早期リターン
-	if (!_isGame2dUrl()) {
-					if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp(): not game2d url');	}
-		return;
+	try {
+					if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp: start');	}
+		// urlが FreePlayリンク(view: game2d) かどうかを判定し、早期リターン
+		if (!_isGame2dUrl()) {
+						if (DEBUG_FLOW) {	console.log('initPongOnlineClientApp(): not game2d url');	}
+			return;
+		}
+		// 重複対策: 削除してから新規作成
+		if (pongOnlineClientApp) {
+			pongOnlineClientApp.dispose();
+			pongOnlineClientApp = null;
+		}
+		pongOnlineClientApp = new PongOnlineClientApp();
+					if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
+	} catch(error) {
+		console.error('hth: initPongOnlineClientApp() failed: ', error);
+		pongOnlineHandleCatchError(error);
 	}
-	// 重複対策: 削除してから新規作成
-	if (pongOnlineClientApp) {
-		pongOnlineClientApp.dispose();
-		pongOnlineClientApp = null;
-	}
-	pongOnlineClientApp = new PongOnlineClientApp();
 }
 
 function _isGame2dUrl() {
@@ -61,15 +69,22 @@ registerEventListenerSwitchPageResetState();
 // ---------------------------------------
 async function disposePongOnlineClientApp() 
 {
-	if (pongOnlineClientApp) 
-	{
-					if (DEBUG_FLOW) {	console.log('disposePongOnlineClientApp: start');	}
-		pongOnlineClientApp.dispose();
-		pongOnlineClientApp = null;
+	try {
+		if (pongOnlineClientApp) 
+		{
+						if (DEBUG_FLOW) {	console.log('disposePongOnlineClientApp: start');	}
+			pongOnlineClientApp.dispose();
+			pongOnlineClientApp = null;
+		}
+					if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
+	} catch(error) {
+		console.error('hth: disposePongOnlineClientApp() failed: ', error);
+		pongOnlineHandleCatchError(error);
 	}
 }
 
 // このメソッドを呼び出すファイル: static/spa/js/views/pong/Game2D.js
+// ここから連鎖的に各クラスのdispose()を呼び出す方針
 if (!window.disposePongOnlineClientApp) {
 	window.disposePongOnlineClientApp = disposePongOnlineClientApp;
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlinePaddleMover.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlinePaddleMover.js
@@ -1,13 +1,13 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlinePaddleMover.js
 import PongEngineKey from "./PongEngineKey.js";
+// import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js"
 
 class PongOnlinePaddleMover 
 {
 	static 	handlePaddleMovement(field, gameState) 
 	{
 		if (!gameState || !gameState.objects || !gameState.objects.paddle1 || !gameState.objects.paddle2) {
-			console.error('Invalid gameState:', this.gameState);
-			return;
+			throw new Error('hth: Invalid gameState:', this.gameState);
 		}
 		
 		PongOnlinePaddleMover._updatePaddlePosition(field, gameState.objects.paddle1, 'E', 'F');

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
@@ -1,4 +1,5 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
+// import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js"
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
 const DEBUG_FLOW 		= 0;
@@ -50,6 +51,7 @@ class PongOnlineRenderer
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 		} catch(error) {
 			console.error("hth: render() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -99,7 +101,8 @@ class PongOnlineRenderer
 
 					if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 		} catch(error) {
-			console.error("resizeForAllDevices() failed", error);
+			console.error("hth: resizeForAllDevices() failed", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -121,7 +124,8 @@ class PongOnlineRenderer
 
 				if (TEST_TRY4){	throw new Error('TEST_TRY4');	}
 		} catch (error) {
-			console.error("_drawScore(): ", error);
+			console.error("hth: _drawScore() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -141,7 +145,8 @@ class PongOnlineRenderer
 
 			if (TEST_TRY5){	throw new Error('TEST_TRY5');	}
 		} catch (error) {
-			console.error("_drawPaddle(): ", error);
+			console.error("hth: _drawPaddle() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -169,7 +174,8 @@ class PongOnlineRenderer
 
 			if (TEST_TRY6){	throw new Error('TEST_TRY6');	}
 		} catch (error) {
-			console.error("_drawBall(): ", error);
+			console.error("hth: _drawBall() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -197,7 +203,8 @@ class PongOnlineRenderer
 
 			if (TEST_TRY7){	throw new Error('TEST_TRY7');	}
 		} catch (error) {
-			console.error("_clearField(): ", error);
+			console.error("hth: _clearField() failed: ", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
@@ -1,16 +1,16 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-let DEBUG_FLOW 		= 0;
-let DEBUG_DETAIL	= 0;
-let DEBUG_DETAIL2 	= 0;
-let TEST_TRY1 = 0;
-let TEST_TRY2 = 0;
-let TEST_TRY3 = 0;
-let TEST_TRY4 = 0;
-let TEST_TRY5 = 0;
-let TEST_TRY6 = 0;
-let TEST_TRY7 = 0;
+const DEBUG_FLOW 		= 0;
+const DEBUG_DETAIL		= 0;
+const DEBUG_DETAIL2		= 0;
+const TEST_TRY1			= 0;
+const TEST_TRY2			= 0;
+const TEST_TRY3			= 0;
+const TEST_TRY4			= 0;
+const TEST_TRY5			= 0;
+const TEST_TRY6			= 0;
+const TEST_TRY7			= 0;
 /**
  * <canvas>への描画（ピクセルに色を出力）を担当する
  * 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
@@ -95,6 +95,7 @@ class PongOnlineSyncWS
 				}
 			} else {
 				console.error("hth: onSocketMessage()): Invalid data:", recvEventData);
+				pongOnlineHandleCatchError(error);
 			}
 			// サーバーに送信する制約を解除するための受信済みを表すフラグ
 			this.gameStateManager.readyToSendNext = true;
@@ -145,7 +146,7 @@ class PongOnlineSyncWS
 	onSocketClose(event) 
 	{
 		try {
-			console.log("onSocketClose(): Code:", event.code);
+			// console.log("onSocketClose(): Code:", event.code);
 			// this.attemptReconnect();
 			// this.clientApp.socket.close();
 		} catch (error) {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
@@ -1,6 +1,7 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
 import PongOnlinePaddleMover from "./PongOnlinePaddleMover.js";
 import PongOnlineRenderer from "./PongOnlineRenderer.js";
+import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js";
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
 let DEBUG_FLOW = 0;
@@ -99,6 +100,7 @@ class PongOnlineSyncWS
 			this.gameStateManager.readyToSendNext = true;
 		} catch (error) {
 			console.error("hth: onSocketMessage() failed", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 	// ------------------------------
@@ -133,6 +135,7 @@ class PongOnlineSyncWS
 			// }
 		} catch (error) {
 			console.error("hth: onSocketOpen() failed", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 
@@ -147,6 +150,7 @@ class PongOnlineSyncWS
 			// this.clientApp.socket.close();
 		} catch (error) {
 			console.error("hth: onSocketClose() failed", error);
+			pongOnlineHandleCatchError(error);
 		}
 	}
 	
@@ -175,7 +179,7 @@ class PongOnlineSyncWS
 	// ------------------------------
 	onSocketError(event) {
 		console.error("hth: WebSocket error:", event);
-		alert('WebSocketの接続でエラーが起きました');
+		pongOnlineHandleCatchError("hth: WebSocket error");
 	}
 	
 	/** dev用 再接続チェック用 */

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
@@ -50,22 +50,13 @@ class PongOnlineSyncWS
 		try 
 		{
 			let recvEventData = JSON.parse(event.data);
-					
-					if (DEBUG_DETAIL){	
-						console.log("onSocketMessage()", event);	}
-					if (TEST_ERROR_CASE1){
-						recvEventData = {}	}
-		
-		
+						if (DEBUG_DETAIL){		console.log("onSocketMessage()", event);	}
+						if (TEST_ERROR_CASE1){	recvEventData = {}	}
 			if (!recvEventData){
 				return
-			} else if (recvEventData.event_type === 'game_end') {
-
-						if (DEBUG_FLOW) {
-							console.log("onSocketMessage: game_end") }
-						if (DEBUG_FLOW) {
-							console.log("onSocketMessage: recvEventData:", recvEventData) }
-
+				} else if (recvEventData.event_type === 'game_end') {
+							if (DEBUG_FLOW) {	console.log("onSocketMessage: game_end") }
+							if (DEBUG_FLOW) {	console.log("onSocketMessage: recvEventData:", recvEventData) }
 				this.gameStateManager.handleGameEnd(this.clientApp.socket, recvEventData.end_game_state,)
 			} else if (recvEventData.objects && recvEventData.state){
 				// ---------------------------------
@@ -88,9 +79,7 @@ class PongOnlineSyncWS
 				// ---------------------------------
 				if (!this.gameStateManager.isGameLoopStarted) 
 				{
-							if (DEBUG_DETAIL){	
-								console.log("初回: gameState()", this.gameStateManager.gameState)	}
-
+								if (DEBUG_DETAIL){	console.log("初回: gameState()", this.gameStateManager.gameState)	}
 					this.gameStateManager.handleGameStart()
 				}
 			} else {
@@ -110,9 +99,7 @@ class PongOnlineSyncWS
 	onSocketOpen() 
 	{
 		try { 
-			if (DEBUG_FLOW){	
-				console.log("WebSocket connection established.");	}
-			
+						if (DEBUG_FLOW){	console.log("WebSocket connection established.");	}
 			// if (!this.isReconnecting)
 			// {
 				// 初回接続時の処理　{ action: "initialize" }を送信

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineSyncWS.js
@@ -4,10 +4,10 @@ import PongOnlineRenderer from "./PongOnlineRenderer.js";
 import { pongOnlineHandleCatchError } from "./PongOnlineIndex.js";
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-let DEBUG_FLOW = 0;
-let DEBUG_DETAIL = 0;
-let TEST_ERROR_CASE1 = 0;
-let TEST_ERROR_CASE2 = 0;
+const DEBUG_FLOW		= 0;
+const DEBUG_DETAIL		= 0;
+const TEST_ERROR_CASE1	= 0;
+const TEST_ERROR_CASE2	= 0;
 
 /**
  * Websocketのイベントで動くメソッドを担当

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
@@ -4,8 +4,6 @@ import UserManager			from './manager/UserManager.js';
 import RoundManager			from './manager/RoundManager.js';
 import TournamentCreator	from './components/TournamentCreator.js';
 
-// TODO_ft: サブコンテナの名称をcontainerとわかるものに変更・統一 ex. errMsgContainer
-
 const DEBUG_FLOW	= 0;
 const DEBUG_DETAIL	= 0;
 const TEST_TRY1		= 0;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/UIHelper.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/UIHelper.js
@@ -38,7 +38,6 @@ class UIHelper
 		const backHomeButton = document.createElement('button');
 		backHomeButton.textContent = 'Back Home';
 		backHomeButton.style.display = 'block';
-		// backHomeButton.onclick = () => window.location.href = href;
 		backHomeButton.onclick = () => switchPage(href);
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -163,7 +163,7 @@ class TournamentCreator
 				throw new Error(`hth: Failed to fetch ongoing tournaments with status: ${response.status}`);
 			}
 			if (response.status === 204) {
-				console.log('No ongoing tournaments found, received 204 No Content');
+				// console.log('No ongoing tournaments found, received 204 No Content');
 				return null;
 			}
 			const result = await response.json();

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
@@ -16,7 +16,7 @@ class TournamentDeleter
 
 	async deleteTournament(tournamentId) 
 	{
-		console.log(`Deleting tournament ID: ${tournamentId}`);
+		// console.log(`Deleting tournament ID: ${tournamentId}`);
 
 		try {
 			const response = await fetch(`${this.API_URLS.tournamentDelete}${tournamentId}/`, 

--- a/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
@@ -56,8 +56,6 @@
 	<li><a href="/app/home/" class="nav__link" data-link>/app/home/</a></li>
 </ul>
 <h5>MEMO:TODO_ft</h5>
-<ul class="dev-link">
-</ul>
 <h5>本番環境</h5>
 <ul class="dev-link">
 	<li>view @csrf_exempt 削除</li>

--- a/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
@@ -55,8 +55,3 @@
 	<li><a href="/app/game/game-3d/" class="nav__link" data-link>/app/game/game-3d/</a></li>
 	<li><a href="/app/home/" class="nav__link" data-link>/app/home/</a></li>
 </ul>
-<h5>MEMO:TODO_ft</h5>
-<h5>本番環境</h5>
-<ul class="dev-link">
-	<li>view @csrf_exempt 削除</li>
-</ul>

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -2,7 +2,7 @@ import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
 
-const DEBUG_DETAIL = 1;
+const DEBUG_DETAIL = 0;
 const DEBUG_LOG = 0;
 
 // touteTable.jsの記述について

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -2,7 +2,7 @@ import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
 
-const DEBUG_DETAIL = 0;
+const DEBUG_DETAIL = 1;
 const DEBUG_LOG = 0;
 
 // touteTable.jsの記述について

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -17,46 +17,9 @@ export const switchPage = (targetPath) => {
 
   history.pushState(null, null, targetPathName );
   if (DEBUG_LOG) { console.log(` history.push: ${targetPathName}`); }
-
-  // currentViewにdisposeメソッドが存在するかどうかをチェック。オペランドの型がfunctionなら関数
-  // if (currentView && typeof currentView.dispose === "function") {
-  //         if (DEBUG_DETAIL) { console.log('switchPage(): dispose', currentView);  } 
-  //   currentView.dispose();
-  // }
-
   // 戻る、進むでも対応するために、event発行はrenderView内部に移動
   renderView(targetPathName);
-  
-  // renderView(targetPathName).then(() => {
-  //   if (DEBUG_DETAIL) { console.log('event: switchPageResetState');  }
-  //   window.dispatchEvent(new CustomEvent('switchPageResetState'));
-  //   // setOnlineStatus();
-  // });
 };
-
-// export const switchPage = (targePath) => {
-//   // const currentUrl = new URL(window.location.href);
-//   const { targetPathName, targetQueryString } = getPathAndQueryString(targePath);
-
-//   // console.log('path:', targetPathName);
-//   // console.log('queryString:', targetQueryString);
-
-//   // query string込みでURLをpush
-//   history.pushState(null, null, targetPathName + targetQueryString);
-
-//   // DEBUG console log
-//   // console.log(`switchPage`)
-//   // console.log(` currentUrl        :${currentUrl}`)
-//   // console.log(` targetPathName    :${targetPathName}`)
-//   // console.log(` targetQueryString :${targetQueryString}`)
-//   // console.log(` currentPath       :${window.location.pathname}`)
-//   // alert(`[debug] switchPage consolelog確認用`)
-
-//   renderView(targetPathName).then(() => {
-//     // resetState イベントを発行
-//     window.dispatchEvent(new CustomEvent('switchPageResetState'));
-//   });
-// };
 
 
 const getSelectedRoute = (currentPath, routeTable) => {
@@ -142,17 +105,3 @@ export const renderView = async (path) => {
   // 
   setOnlineStatus();
 };
-
-// export const renderView = async (path) => {
-//   // console.log("    renderView 1: path: " + path)
-//   const view = await getView(path)
-
-//   // HTMLの描画 <div id="app">
-//   const htmlSrc = await view.getHtml();
-//   document.querySelector("#spa").innerHTML = htmlSrc;
-//   // console.log("    renderView 2")
-
-//   // スクリプトの読み込みと実行
-//   await view.executeScript();
-//   // console.log("    renderView 3")
-// };

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -2,10 +2,10 @@
 import Home         from "../views/Home.js";
 import PongTop      from "../views/pong/PongTop.js";
 
-import FreePlay     from "../views/pong/FreePlay.js";
+// import FreePlay     from "../views/pong/FreePlay.js";
 import Tournament   from "../views/pong/Tournament.js";
 import Game2D       from "../views/pong/Game2D.js";
-import Game3D       from "../views/pong/Game3D.js";
+// import Game3D       from "../views/pong/Game3D.js";
 import GameMatch    from "../views/pong/GameMatch.js";
 
 import GameHistory  from "../views/user/GameHistory.js";
@@ -44,7 +44,7 @@ export const routeTable = {
   // game
   tournament    : { path: "/app/game/tournament/",   view: Tournament },
   game2d        : { path: "/app/game/game-2d/",      view: Game2D },
-  game3d        : { path: "/app/game/game-3d/",      view: Game3D },
+  // game3d        : { path: "/app/game/game-3d/",      view: Game3D },
   gameMatch     : { path: "/app/game/match/:matchId/",  view: GameMatch },
 
   gameHistory   : { path: "/app/user/game-history/", view: GameHistory },

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/FreePlay.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/FreePlay.js
@@ -1,24 +1,24 @@
-import AbstractView from "../AbstractView.js";
-import fetchData from "../../utility/fetch.js";
-import { getUrl } from "../../utility/url.js";
-import { loadAndExecuteScript } from "../../utility/script.js";
+// import AbstractView from "../AbstractView.js";
+// import fetchData from "../../utility/fetch.js";
+// import { getUrl } from "../../utility/url.js";
+// import { loadAndExecuteScript } from "../../utility/script.js";
 
 
-export default class extends AbstractView {
-  constructor(params) {
-    super(params);
-    this.setTitle("FreePlay");
-  }
+// export default class extends AbstractView {
+//   constructor(params) {
+//     super(params);
+//     this.setTitle("FreePlay");
+//   }
 
-  async getHtml() {
-    const uri = "/pong/game/";
-    const data = await fetchData(uri);
-    //console.log("Pong:" + data);
-    return data;
-  }
+//   async getHtml() {
+//     const uri = "/pong/game/";
+//     const data = await fetchData(uri);
+//     //console.log("Pong:" + data);
+//     return data;
+//   }
 
-  async executeScript(spaElement) {
-    loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
-  }
+//   async executeScript(spaElement) {
+//     loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
+//   }
 
-}
+// }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
@@ -5,7 +5,7 @@ import fetchData from "../../utility/fetch.js";
 import { getUrl } from "../../utility/url.js";
 import { loadAndExecuteScript } from "../../utility/script.js";
 
-const DEBUG_FLOW = 1;
+const DEBUG_FLOW = 0;
 
 export default class extends AbstractView {
   constructor(params) {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
@@ -25,7 +25,7 @@ export default class extends AbstractView {
   }
 
   async dispose() {
-          if (DEBUG_FLOW) {  console.log('FreePlay: disopose(): start'); }
+          if (DEBUG_FLOW) {  console.log('views: game2d: disopose(): start'); }
     // disposePongOnlineClientApp()の定義: static/pong/js/online/PongOnlineIndex.js
     if (typeof window.disposePongOnlineClientApp === 'function') {
       window.disposePongOnlineClientApp();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game2D.js
@@ -10,7 +10,7 @@ const DEBUG_FLOW = 1;
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Game2D");
+    this.setTitle("Free Play 2D-Game");
   }
 
   async getHtml() {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game3D.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/Game3D.js
@@ -1,36 +1,36 @@
-// Game3D.js
+// // Game3D.js
 
-import AbstractView from "../AbstractView.js";
-import fetchData from "../../utility/fetch.js";
-import { getUrl } from "../../utility/url.js";
-import { loadAndExecuteScript } from "../../utility/script.js";
+// import AbstractView from "../AbstractView.js";
+// import fetchData from "../../utility/fetch.js";
+// import { getUrl } from "../../utility/url.js";
+// import { loadAndExecuteScript } from "../../utility/script.js";
 
-const DEBUG_FLOW = 0;
+// const DEBUG_FLOW = 0;
 
-export default class extends AbstractView {
-  constructor(params) {
-    super(params);
-    this.setTitle("Game3D");
-  }
+// export default class extends AbstractView {
+//   constructor(params) {
+//     super(params);
+//     this.setTitle("Game3D");
+//   }
 
-  async getHtml() {
-    const uri = "/pong/game/";
-    const data = await fetchData(uri);
-    //console.log("Pong:" + data);
-    return data;
-  }
+//   async getHtml() {
+//     const uri = "/pong/game/";
+//     const data = await fetchData(uri);
+//     //console.log("Pong:" + data);
+//     return data;
+//   }
 
-  async executeScript(spaElement) {
-    loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
-  }
+//   async executeScript(spaElement) {
+//     loadAndExecuteScript(spaElement, "/static/pong/three/assets/index.js", true);
+//   }
 
-  // dispose() {
-  //         if (DEBUG_FLOW) {  console.log('Game3D: disopose(): start'); }
-  //   // Three.jsのインスタンスを破棄
-  //   if (window.pongApp) {
-  //           if (DEBUG_FLOW) {  console.log('Game3D: disopose(): window.pongApp is true'); }
-  //     window.pongApp.dispose();
-  //     window.pongApp = null;
-  //   }
-  // }
-}
+//   // dispose() {
+//   //         if (DEBUG_FLOW) {  console.log('Game3D: disopose(): start'); }
+//   //   // Three.jsのインスタンスを破棄
+//   //   if (window.pongApp) {
+//   //           if (DEBUG_FLOW) {  console.log('Game3D: disopose(): window.pongApp is true'); }
+//   //     window.pongApp.dispose();
+//   //     window.pongApp = null;
+//   //   }
+//   // }
+// }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/pong/GameMatch.js
@@ -44,10 +44,5 @@ export default class extends AbstractView {
     if (typeof window.disposePongApp === 'function') {
       window.disposePongApp();
     }
-    // if (window.pongApp) {
-    //       if (DEBUG_FLOW) {  console.log('GameMatch: disopose(): window.pongApp is true'); }
-    //   await window.pongApp.destroy();
-    //   window.pongApp = null;
-    // }
   }
 }

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -30,8 +30,8 @@ import PongApp from './js/PongApp'
 import './css/3d.css';
 
 // DEBUG TEST FLAG
-const DEBUG_FLOW	= 0;
-const DEBUG_DETAIL1	= 0;
+const DEBUG_FLOW	= 1;
+const DEBUG_DETAIL1	= 1;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -147,13 +147,7 @@ export async function loadRouteTable() {
 
 export async function handleCatchError(error = null) 
 {
-	// SPAの状態をリセットしない場合
-	// const switchPage = await loadSwitchPage();
-	// const redirectTo = routeTable['top'].path;
-	// switchPage(redirectTo);
-
 	// ゲームでのエラーは深刻なので、location.hrefでSPAの状態を完全にリセットする
-	
 	const routeTable = await loadRouteTable();
 	if (error) {
 		alert("エラーが発生しました。トップページに遷移します。 error: " + error);

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -30,13 +30,11 @@ import PongApp from './js/PongApp'
 import './css/3d.css';
 
 // DEBUG TEST FLAG
-const DEBUG_FLOW	= 0;
-const DEBUG_DETAIL1	= 0;
-const DEBUG_DETAIL2	= 0;
+const DEBUG_FLOW	= 1;
+const DEBUG_DETAIL1	= 1;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;
-const TEST_TRY4		= 0;
 
 window.pongApp = null;
 let isEventListenerRegistered = false; 
@@ -48,6 +46,12 @@ async function initPongApp(env)
 	try {
 					if (DEBUG_FLOW) {	console.log('initPongApp(): start');	}
 					if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
+		// URLをチェックしてはじく
+		if (!await _isGameMatchUrl()) {
+						if (DEBUG_FLOW) {	console.log('initPongApp(): not game match url');	}
+			return;
+		}
+
 		if (window.pongApp){
 			await window.pongApp.destroy();
 			window.pongApp = null;
@@ -60,7 +64,16 @@ async function initPongApp(env)
 		handleCatchError(error);
 	}	
 }
-
+async function _isGameMatchUrl() {
+	const routeTable = await loadRouteTable();
+	const currentPath = window.location.pathname;
+				if (DEBUG_FLOW) {	console.log('routeTable:', routeTable);	}
+	const gameMatchPath = routeTable['gameMatch'].path;
+	const gameMatchRegex = new RegExp(`^${gameMatchPath.replace(':matchId', '\\d+')}$`);
+				if (DEBUG_DETAIL1) {	console.log('init()', currentPath, gameMatchRegex);	}
+	return gameMatchRegex.test(currentPath);
+}
+// 3Dgameインスタンスの作成
 initPongApp();
 // ---------------------------------------
 // switchPageResetState
@@ -70,29 +83,28 @@ async function handleSwitchPageResetState()
 {
 	try {
 					if (DEBUG_FLOW) { console.log('switchPageResetState: event'); }
+		// 常にinitを呼び出す。内部でURLをチェックして処理中断する。
 		await initPongApp();
 	} catch (error) {
 		console.error('hth: handleSwitchPageResetState() failed', error);
 		handleCatchError(error);
 	}	
-
 }
 
 function registerEventListenerSwitchPageResetState() 
 {
 	try {
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
-		if (isEventListenerRegistered) {
-			return; 
+		if (!isEventListenerRegistered) {
+			window.addEventListener('switchPageResetState', handleSwitchPageResetState);
+			isEventListenerRegistered = true;
 		}
-		window.addEventListener('switchPageResetState', handleSwitchPageResetState);
-		isEventListenerRegistered = true;
 	} catch (error) {
 		console.error('hth: registerEventListenerSwitchPageResetState() failed', error);
 		handleCatchError(error);
 	}
 }
-
+// 削除はできないので、重複しないように書き換える
 registerEventListenerSwitchPageResetState();
 // ---------------------------------------
 // dispose
@@ -119,7 +131,7 @@ if (!window.disposePongApp) {
 // handle error
 // ---------------------------------------
 // vite コンテナから Django static/ のファイルをimportするための処理
-async function loadRouteTable() {
+export async function loadRouteTable() {
 	if (import.meta.env.MODE === 'development') {
 		// 開発環境用のパス
 		const devUrl = new URL('../../static/spa/js/routing/routeTable.js', import.meta.url);
@@ -150,18 +162,3 @@ export async function handleCatchError(error = null)
 	}
 	window.location.href = routeTable['top'].path;
 }
-
-// SPAの状態をリセットしない場合
-// async function loadSwitchPage() {
-// 	if (import.meta.env.MODE === 'development') {
-// 		// 開発環境用のパス
-// 		const devUrl = new URL('../../static/spa/js/routing/renderView.js', import.meta.url);
-// 		const module = await import(devUrl.href);
-// 		return module.switchPage;
-// 	} else {
-// 		// 本番環境用のパス
-// 		const prodUrl = new URL('../../../spa/js/routing/renderView.js', import.meta.url);
-// 		const module = await import(prodUrl.href);
-// 		return module.switchPage;
-// 	}
-// }

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -104,7 +104,7 @@ function registerEventListenerSwitchPageResetState()
 		handleCatchError(error);
 	}
 }
-// 削除はできないので、重複しないように書き換える
+// SPA中は削除できないので、重複しないようにフラグを見て書き換える
 registerEventListenerSwitchPageResetState();
 // ---------------------------------------
 // dispose

--- a/docker/srcs/vite/pong-three/src/index.js
+++ b/docker/srcs/vite/pong-three/src/index.js
@@ -30,8 +30,8 @@ import PongApp from './js/PongApp'
 import './css/3d.css';
 
 // DEBUG TEST FLAG
-const DEBUG_FLOW	= 1;
-const DEBUG_DETAIL1	= 1;
+const DEBUG_FLOW	= 0;
+const DEBUG_DETAIL1	= 0;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;

--- a/docker/srcs/vite/pong-three/src/js/GLTFModelsLoader.js
+++ b/docker/srcs/vite/pong-three/src/js/GLTFModelsLoader.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 // GLTFフォーマットの3Dモデルをロードするための特定のローダーをインポート。
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { handleCatchError } from '../index.js';
 
 /**
  * GLTFModelsLoader クラス:
@@ -111,6 +112,7 @@ class GLTFModelsLoader
 			this.setupAnimation(model, gltf, defaultAnimation, true);
 		}, undefined, function (error) {
 			console.error(error);
+			handleCatchError(error);
 		});
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/GLTFModelsLoader.js
+++ b/docker/srcs/vite/pong-three/src/js/GLTFModelsLoader.js
@@ -111,7 +111,7 @@ class GLTFModelsLoader
 			// モデルにアニメーションを設定
 			this.setupAnimation(model, gltf, defaultAnimation, true);
 		}, undefined, function (error) {
-			console.error(error);
+			console.error('hth: loadModel() failed', error);
 			handleCatchError(error);
 		});
 	}

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -17,7 +17,7 @@ import * as lil from 'lil-gui';
 import ControlsGUI from './ControlsGUI';
 // import { thickness } from 'three/examples/jsm/nodes/core/PropertyNode.js';
 
-const DEBUG_FLOW	= 0;
+const DEBUG_FLOW	= 1;
 const DEBUG_DETAIL	= 0;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
@@ -64,18 +64,18 @@ class PongApp
 		{
 						if (DEBUG_FLOW) {	console.log('init(): start');	}
 						if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
-			this.routeTable = await PongApp.loadRouteTable();
-			// ----------------------------------
-			// urlがtournametの試合かどうかを判定
-			// ----------------------------------
-			const currentPath = window.location.pathname;
-						if (DEBUG_DETAIL) {	console.log('this.routeTable:', this.routeTable);	}
-			const gameMatchPath = this.routeTable['gameMatch'].path;
-			const gameMatchRegex = new RegExp(`^${gameMatchPath.replace(':matchId', '\\d+')}$`);
-			if (!gameMatchRegex.test(currentPath)) {
-							if (DEBUG_FLOW) {	console.log('init()', currentPath, gameMatchRegex);	}
-				return;
-			}
+			// this.routeTable = await PongApp.loadRouteTable();
+			// // ----------------------------------
+			// // urlがtournametの試合かどうかを判定
+			// // ----------------------------------
+			// const currentPath = window.location.pathname;
+			// 			if (DEBUG_DETAIL) {	console.log('this.routeTable:', this.routeTable);	}
+			// const gameMatchPath = this.routeTable['gameMatch'].path;
+			// const gameMatchRegex = new RegExp(`^${gameMatchPath.replace(':matchId', '\\d+')}$`);
+			// if (!gameMatchRegex.test(currentPath)) {
+			// 				if (DEBUG_FLOW) {	console.log('init()', currentPath, gameMatchRegex);	}
+			// 	return;
+			// }
 			// ----------------------------------
 			// 試合が終了しているか判定
 			// ----------------------------------

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -19,8 +19,8 @@ import * as lil from 'lil-gui';
 import ControlsGUI from './ControlsGUI';
 // import { thickness } from 'three/examples/jsm/nodes/core/PropertyNode.js';
 
-const DEBUG_FLOW	= 1;
-const DEBUG_DETAIL	= 1;
+const DEBUG_FLOW	= 0;
+const DEBUG_DETAIL	= 0;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -12,13 +12,15 @@ import LoopManager from './manager/LoopManager'
 import RendererManager from './manager/RendererManager'
 import PongEngineKey from './pongEngine/PongEngineKey'
 import { handleCatchError } from '../index.js';
+import { loadRouteTable } from '../index.js';
+
 //dev用GUI
 import * as lil from 'lil-gui'; 
 import ControlsGUI from './ControlsGUI';
 // import { thickness } from 'three/examples/jsm/nodes/core/PropertyNode.js';
 
 const DEBUG_FLOW	= 1;
-const DEBUG_DETAIL	= 0;
+const DEBUG_DETAIL	= 1;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;
@@ -64,32 +66,18 @@ class PongApp
 		{
 						if (DEBUG_FLOW) {	console.log('init(): start');	}
 						if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
-			// this.routeTable = await PongApp.loadRouteTable();
-			// // ----------------------------------
-			// // urlがtournametの試合かどうかを判定
-			// // ----------------------------------
-			// const currentPath = window.location.pathname;
-			// 			if (DEBUG_DETAIL) {	console.log('this.routeTable:', this.routeTable);	}
-			// const gameMatchPath = this.routeTable['gameMatch'].path;
-			// const gameMatchRegex = new RegExp(`^${gameMatchPath.replace(':matchId', '\\d+')}$`);
-			// if (!gameMatchRegex.test(currentPath)) {
-			// 				if (DEBUG_FLOW) {	console.log('init()', currentPath, gameMatchRegex);	}
-			// 	return;
-			// }
 			// ----------------------------------
 			// 試合が終了しているか判定
 			// ----------------------------------
 			const matchDataElement = document.getElementById('match-data');
-						if (DEBUG_FLOW) {	console.log('init() matchDataElement: ', matchDataElement);	}
-			if (matchDataElement) 
-			{
-				this.matchData = JSON.parse(matchDataElement.textContent);
-							if (DEBUG_DETAIL) {	console.log('Match Data:', this.matchData);	}
-			} else {
+			if (!matchDataElement){
 							if (DEBUG_FLOW) {	console.log('matchDataElement not found');	}
 				return;
 			}
-			// this.routeTable = await PongApp.loadRouteTable();
+
+			this.matchData = JSON.parse(matchDataElement.textContent);
+						if (DEBUG_DETAIL) {	console.log('Match Data:', this.matchData);	}
+			this.routeTable = await loadRouteTable();
 			if (this.matchData && this.matchData.is_finished) 
 			{
 							if (DEBUG_FLOW) {	console.log('matchData.is_finished is true');	}
@@ -97,6 +85,7 @@ class PongApp
 				const switchPage = await PongApp.loadSwitchPage();
 				const redirectTo = this.routeTable['top'].path;
 				switchPage(redirectTo);
+							if (DEBUG_FLOW) {	console.log('switchPage: done');	}
 				return;
 			}
 			// ----------------------------------
@@ -137,6 +126,20 @@ class PongApp
 		}	
 	}
 	
+
+	static async loadSwitchPage() {
+		if (import.meta.env.MODE === 'development') {
+			// 開発環境用のパス
+			const devUrl = new URL('../../static/spa/js/routing/renderView.js', import.meta.url);
+			const module = await import(devUrl.href);
+			return module.switchPage;
+		} else {
+			// 本番環境用のパス
+			const prodUrl = new URL('../../../spa/js/routing/renderView.js', import.meta.url);
+			const module = await import(prodUrl.href);
+			return module.switchPage;
+		}
+	}
 
 	/**
 	 * ページから抜ける（アウト）時にspa/js/views/AbstractView.jsの dispose() から呼び出される
@@ -191,8 +194,9 @@ class PongApp
 			}
 
 			this.env = null;
-			this.matchData = null;
+			this.boundHandleResize = null;	
 			this.routeTable = null;
+			this.matchData = null;
 			this.renderer = null;
 			this.animationMixersManager = null;
 			this.allScenesManager = null;
@@ -221,38 +225,7 @@ class PongApp
 			handleCatchError(error);
 		}	
 	}
-
-
-	/** vite での Django コンテナの module import処理(パスの解決) */
-	static async loadRouteTable() 
-	{
-		if (import.meta.env.MODE === 'development') {
-			// 開発環境用のパス
-			const devUrl = new URL('../static/spa/js/routing/routeTable.js', import.meta.url);
-			const module = await import(devUrl.href);
-			return module.routeTable;
-		} else {
-			// 本番環境用のパス
-			const prodUrl = new URL('../../../spa/js/routing/routeTable.js', import.meta.url);
-			const module = await import(prodUrl.href);
-			return module.routeTable;
-		}
-	}
 	
-	static async loadSwitchPage() 
-	{
-		if (import.meta.env.MODE === 'development') {
-			// 開発環境用のパス
-			const devUrl = new URL('../../static/spa/js/routing/renderView.js', import.meta.url);
-			const module = await import(devUrl.href);
-			return module.switchPage;
-		} else {
-			// 本番環境用のパス
-			const prodUrl = new URL('../../../spa/js/routing/renderView.js', import.meta.url);
-			const module = await import(prodUrl.href);
-			return module.switchPage;
-		}
-	}
 
 				setupDevEnv()
 				{

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -19,8 +19,8 @@ import * as lil from 'lil-gui';
 import ControlsGUI from './ControlsGUI';
 // import { thickness } from 'three/examples/jsm/nodes/core/PropertyNode.js';
 
-const DEBUG_FLOW	= 0;
-const DEBUG_DETAIL	= 0;
+const DEBUG_FLOW	= 1;
+const DEBUG_DETAIL	= 1;
 const TEST_TRY1		= 0;
 const TEST_TRY2		= 0;
 const TEST_TRY3		= 0;

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -182,7 +182,7 @@ class PongApp
 				window.removeEventListener('resize', this.boundHandleResize);
 				this.boundHandleResize = null;
 			}
-			PongEngineKey.removeListeners();
+			PongEngineKey.unregisterListenersKeyUpDown();
 
 			// lil-gui を破棄
 			if (this.gui) {

--- a/docker/srcs/vite/pong-three/src/js/PongApp.js
+++ b/docker/srcs/vite/pong-three/src/js/PongApp.js
@@ -99,6 +99,7 @@ class PongApp
 			await this.allScenesManager.setupScenes();
 			// ゲームの状態（待機、Play、終了）を担当。シングルトン
 			this.gameStateManager = GameStateManager.getInstance(this, this.allScenesManager); 
+			PongEngineKey.registerListenersKeyUpDown()
 			// 無限ループでアニメーションの更新を担当。シングルトン
 			const renderLoop = LoopManager.getInstance(this);
 			this.renderLoop = renderLoop;

--- a/docker/srcs/vite/pong-three/src/js/SceneUnit.js
+++ b/docker/srcs/vite/pong-three/src/js/SceneUnit.js
@@ -113,8 +113,7 @@ class SceneUnit
 	{
 		if (!newConfig || !newConfig.cameraConfig) 
 		{
-			console.error("Invalid or incomplete configuration provided:", newConfig);
-			return;
+			throw new Error("Invalid or incomplete configuration provided");
 		}
 
 		// console.log("リフレッシュ時のconfigファイル:", newConfig);
@@ -142,8 +141,7 @@ class SceneUnit
 	{
 		if (!cameraConfig) 
 		{
-			console.error("No camera configuration provided");
-			return;
+			throw new Error("No camera configuration provided");
 		}
 		const config = cameraConfig;
 		const cam = new THREE.PerspectiveCamera(
@@ -167,8 +165,7 @@ class SceneUnit
 	{
 		if (!controlsConfig) 
 		{
-			console.error("No controlsConfig provided");
-			return;
+			throw new Error("No controlsConfig provided");
 		}
 		const config = controlsConfig;
 		const controls = new OrbitControls(camera, renderer.domElement);

--- a/docker/srcs/vite/pong-three/src/js/SceneUnit.js
+++ b/docker/srcs/vite/pong-three/src/js/SceneUnit.js
@@ -113,7 +113,7 @@ class SceneUnit
 	{
 		if (!newConfig || !newConfig.cameraConfig) 
 		{
-			throw new Error("Invalid or incomplete configuration provided");
+			throw new Error("hth: Invalid or incomplete configuration provided");
 		}
 
 		// console.log("リフレッシュ時のconfigファイル:", newConfig);
@@ -141,7 +141,7 @@ class SceneUnit
 	{
 		if (!cameraConfig) 
 		{
-			throw new Error("No camera configuration provided");
+			throw new Error("hth: No camera configuration provided");
 		}
 		const config = cameraConfig;
 		const cam = new THREE.PerspectiveCamera(
@@ -165,7 +165,7 @@ class SceneUnit
 	{
 		if (!controlsConfig) 
 		{
-			throw new Error("No controlsConfig provided");
+			throw new Error("hth: No controlsConfig provided");
 		}
 		const config = controlsConfig;
 		const controls = new OrbitControls(camera, renderer.domElement);

--- a/docker/srcs/vite/pong-three/src/js/effect/Aura.js
+++ b/docker/srcs/vite/pong-three/src/js/effect/Aura.js
@@ -24,7 +24,7 @@ class Aura extends THREE.Object3D
 			this.add(this.mesh);
 			this.textureLoaded = true;
 		}).catch(error => {
-			console.error('Texture load failed:', error);
+			console.error('htt: Texture load failed:', error);
 			this.textureLoaded = false;
 			// オーラが見えない描画のままゲームに進む
 		});

--- a/docker/srcs/vite/pong-three/src/js/effect/Aura.js
+++ b/docker/srcs/vite/pong-three/src/js/effect/Aura.js
@@ -26,6 +26,7 @@ class Aura extends THREE.Object3D
 		}).catch(error => {
 			console.error('Texture load failed:', error);
 			this.textureLoaded = false;
+			// オーラが見えない描画のままゲームに進む
 		});
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/effect/Flare.js
+++ b/docker/srcs/vite/pong-three/src/js/effect/Flare.js
@@ -65,7 +65,10 @@ class Flare extends THREE.Object3D
 			});
 			const mesh = new THREE.Mesh(geometry, material);
 			this.add(mesh);
-		}).catch(error => console.error('Texture load failed:', error));
+		}).catch(error => {
+			console.error('Texture load failed:', error);
+			// オーラのない描画でゲームに進む
+		});
 	}
 
 	update() 

--- a/docker/srcs/vite/pong-three/src/js/effect/Flare.js
+++ b/docker/srcs/vite/pong-three/src/js/effect/Flare.js
@@ -66,7 +66,7 @@ class Flare extends THREE.Object3D
 			const mesh = new THREE.Mesh(geometry, material);
 			this.add(mesh);
 		}).catch(error => {
-			console.error('Texture load failed:', error);
+			console.error('hth: Texture load failed:', error);
 			// オーラのない描画でゲームに進む
 		});
 	}

--- a/docker/srcs/vite/pong-three/src/js/manager/AllScenesManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/AllScenesManager.js
@@ -4,6 +4,7 @@ import EffectsSceneConfig from '../config/EffectsSceneConfig';
 import RendererManager from './RendererManager'
 import SceneUnit from '../SceneUnit';
 import * as THREE from 'three';
+import { handleCatchError } from '../../index.js';
 
 const DEBUG_FLOW 		= 0;
 const DEBUG_DETAIL		= 0;
@@ -74,7 +75,7 @@ class AllScenesManager
 		} catch (error) {
 			console.error('hth: setupScenes() failed', error);
 			// エラーを上位に伝播させ、pongAppでcatchしてSPAリセット
-			throw error;
+			handleCatchError(error);
 		}
 	}
 
@@ -129,6 +130,7 @@ class AllScenesManager
 			});
 		} catch (error) {
 			console.error('hth: handleResize() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -154,6 +156,7 @@ class AllScenesManager
 						if (TEST_TRY7) {	throw new Error('TEST_TRY7');	}
 		} catch (error) {
 			console.error('hth: _adjustCameraForGameScene() failed', error);
+			handleCatchError(error);
 		}
 	}
 	
@@ -187,6 +190,7 @@ class AllScenesManager
 					if (TEST_TRY9) {	throw new Error('TEST_TRY9');	}
 		} catch (error) {
 			console.error('hth: dispose() failed', error);
+			handleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/manager/AnimationMixersManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/AnimationMixersManager.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { handleCatchError } from '../../index.js';
 
 const DEBUG_FLOW = 0;
 const DEBUG_DETAIL = 0;
@@ -39,7 +40,7 @@ class AnimationMixersManager
 			this.mixersMap.set(object.uuid, mixer);
 		} catch (error) {
 			console.error('hth: addMixer() failed', error);
-			// 他の部分の処理には影響を与えないので伝播させない errorログの出力のみ errorログの出力のみ
+			handleCatchError(error);
 		}
 	}
 
@@ -57,7 +58,7 @@ class AnimationMixersManager
 			this.clock = null; 
 		} catch (error) {
 			console.error('hth: dispose() failed', error);
-			// 他の部分の処理には影響を与えないので伝播させない errorログの出力のみ
+			handleCatchError(error);
 		}
 	}
 	
@@ -78,7 +79,7 @@ class AnimationMixersManager
 			}
 		} catch (error) {
 			console.error('hth: removeMixer() failed', error);
-			// 他の部分の処理には影響を与えないので伝播させない errorログの出力のみ
+			handleCatchError(error);
 		}
 	}
 
@@ -106,13 +107,13 @@ class AnimationMixersManager
 				} else {
 					console.error(`Invalid mixer for UUID: ${uuid}`);
 					this.mixersMap.delete(uuid);
+					// 他のミキサーの更新処理を継続
 				}
 			});
 		} catch (error) {
 			console.error('hth: update() failed', error);
-			// 他の部分の処理には影響を与えないので伝播させない errorログの出力のみ
+			handleCatchError(error);
 		}
-		
 	}
 
 }

--- a/docker/srcs/vite/pong-three/src/js/manager/AnimationMixersManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/AnimationMixersManager.js
@@ -68,7 +68,7 @@ class AnimationMixersManager
 		{
 			if (!object || !object.uuid) 
 			{
-				console.error("Invalid object or missing UUID.");
+				console.error("hth: Invalid object or missing UUID.");
 				return;
 			}
 		
@@ -99,13 +99,13 @@ class AnimationMixersManager
 						mixer.update(delta);
 					} catch (error) {
 						// ミキサーの更新に失敗した場合
-						console.error(`Error updating mixer for UUID: ${uuid}:`, error);
+						console.error(`hth: Error updating mixer for UUID: ${uuid}:`, error);
 						// 不正なミキサーをマップから削除
 						this.mixersMap.delete(uuid);
 						// 他のミキサーの更新処理を継続
 					}
 				} else {
-					console.error(`Invalid mixer for UUID: ${uuid}`);
+					console.error(`hth: Invalid mixer for UUID: ${uuid}`);
 					this.mixersMap.delete(uuid);
 					// 他のミキサーの更新処理を継続
 				}

--- a/docker/srcs/vite/pong-three/src/js/manager/GameStateManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/GameStateManager.js
@@ -54,7 +54,6 @@ class GameStateManager
 						if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 		} catch (error) {
 			console.error('hth: changeState() failed', error);
-			// この場合、ゲームに入れないのでリセットする
 			handleCatchError(error);
 		}
 	}
@@ -70,6 +69,7 @@ class GameStateManager
 						if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 		} catch (error) {
 			console.error('hth: update() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -102,6 +102,7 @@ class GameStateManager
 						if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 		} catch (error) {
 			console.error('hth: dispose() failed', error);
+			handleCatchError(error);
 		}
 	}
 }

--- a/docker/srcs/vite/pong-three/src/js/manager/LoopManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/LoopManager.js
@@ -72,6 +72,7 @@ class RenderLoop
 							if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 			} catch (error) {
 				console.error('hth: RenderLoop.loopStart() failed', error);
+				handleCatchError(error);
 			}
 		};
 		animate();
@@ -108,6 +109,7 @@ class RenderLoop
 						if (TEST_TRY3){	throw new Error('TEST_TRY3');	}
 		} catch (error) {
 			console.error('hth: dispose() failed', error);
+			handleCatchError(error);
 		}
 	}
 }

--- a/docker/srcs/vite/pong-three/src/js/manager/RendererManager.js
+++ b/docker/srcs/vite/pong-three/src/js/manager/RendererManager.js
@@ -31,6 +31,7 @@ class RendererManager
 			return RendererManager.instance;
 		} catch (error) {
 			console.error('hth: RendererManager constructor() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -59,6 +60,7 @@ class RendererManager
 			return RendererManager.instance;
 		} catch (error) {
 			console.error('hth: getInstance() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -73,6 +75,7 @@ class RendererManager
 			return RendererManager.instance.renderer;
 		} catch (error) {
 			console.error('hth: getRenderer() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -88,6 +91,7 @@ class RendererManager
 						if (TEST_TRY5){	this.renderer = null;	}
 		} catch (error) {
 			console.error('hth: initializeRenderer() failed', error);
+			handleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
@@ -11,7 +11,7 @@ import AllScenesManager from '../manager/AllScenesManager';
 import { handleCatchError } from '../../index.js';
 
 
-const DEBUG_FLOW 		= 0;
+const DEBUG_FLOW 		= 1;
 const TEST_TRY1			= 0;
 const TEST_TRY2			= 0;
 
@@ -65,11 +65,38 @@ class PongEngine
 
 	dispose() 
 	{
-		// PongEngineMatchクラスのdispose()呼び出し　※ボタンに登録されたリスナーを念の為明示的に廃棄
+					if (DEBUG_FLOW){	console.log("Exiting GamePlay state");	 };
+		this.isRunning = false;
+
 		if (this.match) {
 			this.match.dispose();
 			this.match = null;
 		}
+		if (this.update) {
+			this.update.dispose();
+			this.update = null;
+		}
+		if (this.physics) {
+			this.physics.dispose();
+			this.physics = null;
+		}
+		if (this.data) {
+			this.data.dispose();
+			this.data = null;
+		}
+		if (this.init) {
+			this.init.dispose();
+			this.init = null;
+		}
+
+		// その他のプロパティをnullに設定
+		this.pongApp	= null;
+		this.env		= null;
+		this.matchData	= null;
+		this.scene		= null;
+		this.camera		= null;
+		this.renderer	= null;
+		this.config		= null;
 	}
 	
 	async animate() 
@@ -83,11 +110,13 @@ class PongEngine
 			// 	// ゲームが終了した場合は、描画ループを停止
 			// 	this.pongApp.stopRenderLoop();
 			}
-			await this.update.updateGame();
+			if (this.update) {
+				await this.update.updateGame();
+			}
 			if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {
 			console.error('hth: GameplayState.enter() failed', error);
-			// handleCatchError(error);
+			handleCatchError(error);
 		}
 	}
 }

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
@@ -11,7 +11,7 @@ import AllScenesManager from '../manager/AllScenesManager';
 import { handleCatchError } from '../../index.js';
 
 
-const DEBUG_FLOW 		= 1;
+const DEBUG_FLOW 		= 0;
 const TEST_TRY1			= 0;
 const TEST_TRY2			= 0;
 

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
@@ -1,4 +1,4 @@
-
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
 import * as THREE from 'three';
 import PongEngineConfig from '../config/PongEngineConfig';
 import PongEngineUpdate from './PongEngineUpdate';

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngine.js
@@ -63,6 +63,15 @@ class PongEngine
 					if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 	}
 
+	dispose() 
+	{
+		// PongEngineMatchクラスのdispose()呼び出し　※ボタンに登録されたリスナーを念の為明示的に廃棄
+		if (this.match) {
+			this.match.dispose();
+			this.match = null;
+		}
+	}
+	
 	async animate() 
 	{
 		try {

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineData.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineData.js
@@ -1,3 +1,4 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineData.js
 import PongEngine from "./PongEngine";
 import PongEngineInit from "./PongEngineInit";
 
@@ -31,6 +32,19 @@ class PongEngineData
 			this.state.score2 += score;
 		}
 	}
+
+	dispose() 
+	{
+		this.pongEngine	= null; 
+		this.config		= null;
+		this.scene		= null;
+		this.objects	= null;
+		this.settings	= null;
+		this.env		= null;
+		this.matchData	= null;
+		this.state		= null; 
+	}
+	
 }
 
 export default PongEngineData;

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineInit.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineInit.js
@@ -1,10 +1,11 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineInit.js
 import * as THREE from 'three';
 
 class PongEngineInit 
 {
 	constructor(scene, config) 
 	{
-		this.scene = scene;
+		this.scene	= scene;
 		this.config = config;
 	}
 
@@ -93,9 +94,9 @@ class PongEngineInit
 
 	addSceneObjects(data) 
 	{
-		this.objects = data.objects;
-		Object.keys(this.objects).forEach(key => {
-			this.scene.add(this.objects[key]);
+		const objects = data.objects;
+		Object.keys(objects).forEach(key => {
+			this.scene.add(objects[key]);
 		});
 		// this.scene.traverse(obj => {
 		// 	if (obj instanceof THREE.Mesh) {
@@ -176,6 +177,12 @@ class PongEngineInit
 			opacity: config.MATERIAL.opacity,
 		});
 		return new THREE.Mesh(geometry, material);
+	}
+
+	dispose() 
+	{
+		this.scene	= null;
+		this.config	= null;
 	}
 }
 

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
@@ -1,24 +1,10 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
 class PongEngineKey 
 {
 	static keys = {/** empty */};
 	static isListenerRegistered = false;
 
-	// static listenForEvents() 
-	// {
-	// 	window.addEventListener('keydown', (event) => 
-	// 	{
-	// 		const key = event.key.toUpperCase();
-	// 		PongEngineKey.keys[key] = true;
-	// 	});
-
-	// 	window.addEventListener('keyup', (event) => 
-	// 	{
-	// 		const key = event.key.toUpperCase();
-	// 		PongEngineKey.keys[key] = false;
-	// 	});
-	// }
-
-	static listenForEvents() 
+	static registerListenersKeyUpDown() 
 	{
 		if (!PongEngineKey.isListenerRegistered) {
 			window.addEventListener('keydown', PongEngineKey.handleKeyDown);
@@ -27,12 +13,13 @@ class PongEngineKey
 		}
 	}
 
-	static removeListeners() 
+	static unregisterListenersKeyUpDown() 
 	{
 		if (PongEngineKey.isListenerRegistered) {
 			window.removeEventListener('keydown', PongEngineKey.handleKeyDown);
 			window.removeEventListener('keyup', PongEngineKey.handleKeyUp);
 			PongEngineKey.isListenerRegistered = false;
+			PongEngineKey.keys = {/** empty */};
 		}
 	}
 	
@@ -55,6 +42,6 @@ class PongEngineKey
 }
 
 // モジュールインポート時にキーイベントのリスニングを開始
-PongEngineKey.listenForEvents([/** empty */]);
+PongEngineKey.registerListenersKeyUpDown();
 
 export default PongEngineKey;

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
@@ -42,6 +42,6 @@ class PongEngineKey
 }
 
 // モジュールインポート時にキーイベントのリスニングを開始
-PongEngineKey.registerListenersKeyUpDown();
+// PongEngineKey.registerListenersKeyUpDown();
 
 export default PongEngineKey;

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineKey.js
@@ -41,7 +41,7 @@ class PongEngineKey
 	}
 }
 
-// モジュールインポート時にキーイベントのリスニングを開始
+// 重複するため、init,destroyで明示的に呼び出すよう修正
 // PongEngineKey.registerListenersKeyUpDown();
 
 export default PongEngineKey;

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -234,7 +234,7 @@ class PongEngineMatch
 				.then(response => 
 					{
 						if (!response.ok) {
-							throw new Error('response failed');
+							throw new Error('hth: response failed');
 						}
 						return response.json();
 					})

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -64,7 +64,7 @@ class PongEngineMatch
 				},
 			(error) => 
 				{
-					console.error('An error happened');
+					console.error('hth: An error happened');
 					handleCatchError(error);
 				}
 		);
@@ -246,7 +246,7 @@ class PongEngineMatch
 				})
 			.catch((error) => console.error('Error:', error));
 		} catch (error) {
-			console.error('Error:', error);
+			console.error('hth: sendMatchResult() failed:', error);
 			handleCatchError(error);
 		}
 	}

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -173,9 +173,11 @@ class PongEngineMatch
 				this.registerEndGameButtonClickListener(endGameButton);
 			} else {
 				console.error('hth: End Game button not found');
+				handleCatchError(error);
 			}
 		} catch (error){
 			console.error('hth: updateEndGameBtn() failed: ', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -245,8 +247,7 @@ class PongEngineMatch
 			.catch((error) => console.error('Error:', error));
 		} catch (error) {
 			console.error('Error:', error);
-			 // 非同期なので明示的にthrow
-			throw error;
+			handleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -1,7 +1,9 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
 import * as THREE from 'three';
 import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
 import { loadRouteTable } from '../../index.js';
+import { handleCatchError } from '../../index.js';
 
 const DEBUG_FLOW = 0;
 const DEBUG_DETAIL = 0;
@@ -34,14 +36,14 @@ class PongEngineMatch
 			opacity: 0.7,
 		});
 		// 180度回転
-		this.rotationZ = Math.PI; 
-		this.pos = new THREE.Vector3(0, -90, -7);
+		this.rotationZ	= Math.PI; 
+		this.pos		= new THREE.Vector3(0, -90, -7);
 		
 		if (import.meta.env.MODE === 'development') {
-			this.fontURL = '../assets/fonts/droid_sans_bold.typeface.json';
+			this.fontURL	= '../assets/fonts/droid_sans_bold.typeface.json';
 		} else {
-			const baseURL = new URL('.', import.meta.url).href;
-			this.fontURL = new URL('../../fonts/droid_sans_bold.typeface.json', baseURL).href;
+			const baseURL	= new URL('.', import.meta.url).href;
+			this.fontURL	= new URL('../../fonts/droid_sans_bold.typeface.json', baseURL).href;
 		}
 
 		// フォントファイルのパスと3つのコールバック関数（成功、進行中、エラー）を引数として受け取り
@@ -60,9 +62,10 @@ class PongEngineMatch
 				{
 								if (DEBUG_DETAIL) {	console.log((xhr.loaded / xhr.total * 100) + '% font loaded');	}
 				},
-			(err) => 
+			(error) => 
 				{
 					console.error('An error happened');
+					handleCatchError(error);
 				}
 		);
 
@@ -201,14 +204,6 @@ class PongEngineMatch
 		}
 	}
 
-	dispose() 
-	{
-		const endGameButton = document.getElementById('hth-threejs-back-to-home-btn');
-		if (endGameButton) {
-			this.removeEndGameButtonClickListener(endGameButton);
-		}
-	}
-
 	sendMatchResult() 
 	{
 		try
@@ -253,6 +248,42 @@ class PongEngineMatch
 			 // 非同期なので明示的にthrow
 			throw error;
 		}
+	}
+
+
+	dispose() 
+	{
+		// イベントハンドラの削除
+		const endGameButton = document.getElementById('hth-threejs-back-to-home-btn');
+		if (endGameButton) {
+			this.removeEndGameButtonClickListener(endGameButton);
+		}
+
+		// シーンからオブジェクトを廃棄　リーク防止
+		if (this.scoreMesh) {
+			this.scene.remove(this.scoreMesh);
+			this.scoreMesh.geometry.dispose();
+			this.scoreMesh = null;
+		}
+		if (this.font) {
+			this.font = null;
+		}
+			if (this.textMaterial) {
+			this.textMaterial.dispose();
+			this.textMaterial = null;
+		}
+	
+		// 他のプロパティをnullに設定
+		this.pongApp	= null;
+		this.pongEngine	= null;
+		this.scene		= null;
+		this.score1		= null;
+		this.score2		= null;
+		this.maxScore	= null;
+		this.matchData	= null;
+		this.env		= null;
+		this.ball		= null;
+
 	}
 
 }

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -144,6 +144,7 @@ class PongEngineMatch
 		await this.displayEndGameButton();
 	}
 
+	// TODO_ft:共通化
 	async loadSwitchPage() {
 		if (import.meta.env.MODE === 'development') {
 			// 開発環境用のパス

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
+import { loadRouteTable } from '../../index.js';
 
 const DEBUG_FLOW = 0;
 const DEBUG_DETAIL = 0;
@@ -165,13 +166,7 @@ class PongEngineMatch
 			if (endGameButton) 
 			{
 				endGameButton.style.display = 'block';
-				const switchPage = await this.loadSwitchPage();
-				this.registerEndGameButtonClickListener(endGameButton, switchPage);
-				// endGameButton.addEventListener('click', () => 
-				// {
-				// 	const redirectTo = this.pongApp.routeTable['top'].path;
-				// 	switchPage(redirectTo);
-				// });
+				this.registerEndGameButtonClickListener(endGameButton);
 			} else {
 				console.error('hth: End Game button not found');
 			}
@@ -181,16 +176,18 @@ class PongEngineMatch
 	}
 
 
-	handleEndGameButtonClick(switchPage) 
+	async handleEndGameButtonClick() 
 	{
-		const redirectTo = this.pongApp.routeTable['top'].path;
+		const routeTable = await loadRouteTable();
+		const switchPage = await this.loadSwitchPage();
+		const redirectTo = routeTable['top'].path;
 		switchPage(redirectTo);
 	}
 
-	registerEndGameButtonClickListener(endGameButton, switchPage) 
+	registerEndGameButtonClickListener(endGameButton) 
 	{
 		if (!this.isEndGameButtonListenerRegistered) {
-			endGameButton.addEventListener('click', this.handleEndGameButtonClick.bind(this, switchPage));
+			endGameButton.addEventListener('click', this.handleEndGameButtonClick.bind(this));
 			this.isEndGameButtonListenerRegistered = true;
 		}
 	}

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -201,6 +201,14 @@ class PongEngineMatch
 		}
 	}
 
+	dispose() 
+	{
+		const endGameButton = document.getElementById('hth-threejs-back-to-home-btn');
+		if (endGameButton) {
+			this.removeEndGameButtonClickListener(endGameButton);
+		}
+	}
+
 	sendMatchResult() 
 	{
 		try

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineMatch.js
@@ -3,7 +3,9 @@ import * as THREE from 'three';
 import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
 import { loadRouteTable } from '../../index.js';
+// import { loadSwitchPage } from '../PongApp.js';
 import { handleCatchError } from '../../index.js';
+import PongApp from '../PongApp.js';
 
 const DEBUG_FLOW = 0;
 const DEBUG_DETAIL = 0;
@@ -147,21 +149,6 @@ class PongEngineMatch
 		await this.displayEndGameButton();
 	}
 
-	// TODO_ft:共通化
-	async loadSwitchPage() {
-		if (import.meta.env.MODE === 'development') {
-			// 開発環境用のパス
-			const devUrl = new URL('../../static/spa/js/routing/renderView.js', import.meta.url);
-			const module = await import(devUrl.href);
-			return module.switchPage;
-		} else {
-			// 本番環境用のパス
-			const prodUrl = new URL('../../../spa/js/routing/renderView.js', import.meta.url);
-			const module = await import(prodUrl.href);
-			return module.switchPage;
-		}
-	}
-
 	// ゲーム終了時に Back to Home ボタンリンクを表示する	
 	async displayEndGameButton() 
 	{
@@ -185,7 +172,7 @@ class PongEngineMatch
 	async handleEndGameButtonClick() 
 	{
 		const routeTable = await loadRouteTable();
-		const switchPage = await this.loadSwitchPage();
+		const switchPage = await PongApp.loadSwitchPage();
 		const redirectTo = routeTable['top'].path;
 		switchPage(redirectTo);
 	}

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEnginePhysics.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEnginePhysics.js
@@ -1,3 +1,4 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEnginePhysics.js
 /**
  * 物理演算に関する処理を担当。壁やパドルとの衝突判定、ボールの方向や速度の調整を行う。
  */
@@ -5,8 +6,8 @@ class PongEnginePhysics
 {
 	constructor(pongEngineData) 
 	{
-		this.field = pongEngineData.settings.field;
-		this.maxBallSpeed = pongEngineData.settings.maxBallSpeed;
+		this.field			= pongEngineData.settings.field;
+		this.maxBallSpeed	= pongEngineData.settings.maxBallSpeed;
 	}
 
 	// 左右の壁と衝突しているか？
@@ -52,6 +53,13 @@ class PongEnginePhysics
 			ball.speed	= Math.min(ball.speed * 1.1, this.maxBallSpeed);  // 速度を最大速度を超えないように10%増加
 		}
 	}
+
+	dispose() 
+	{
+		this.field			= null;
+		this.maxBallSpeed	= null;
+	}
+
 }
 
 export default PongEnginePhysics;

--- a/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineUpdate.js
+++ b/docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineUpdate.js
@@ -1,3 +1,4 @@
+// docker/srcs/vite/pong-three/src/js/pongEngine/PongEngineUpdate.js
 import PongEngineKey from './PongEngineKey'
 
 /**
@@ -108,15 +109,9 @@ class PongEngineUpdate
 		let nextPositionY = paddle.position.y + paddle.dirY;
 		// パドルがフィールドの上端または下端を超えないようにmax,min()で補正する
 		// 理由：衝突の直前の最後の一回はspeed分だけ動くのでフィールドからはみ出る場合がある。
-		let maxTop = -this.field.height / 2 + paddle.height / 2;
-		let maxBottom = this.field.height / 2 - paddle.height / 2;
-		paddle.position.y = Math.max(Math.min(nextPositionY, maxBottom), maxTop);
-
-		// if (PongEngineKey.isDown(keyDown) && paddle.position.y < this.field.height / 2 - paddle.height) {
-		// 	paddle.position.y += paddle.speed;
-		// } else if (PongEngineKey.isDown(keyUp) && paddle.position.y > -this.field.height / 2) {
-		// 	paddle.position.y -= paddle.speed;
-		// }
+		let maxTop			= -this.field.height / 2 + paddle.height / 2;
+		let maxBottom		= this.field.height / 2 - paddle.height / 2;
+		paddle.position.y	= Math.max(Math.min(nextPositionY, maxBottom), maxTop);
 		
 	}
 	
@@ -141,8 +136,23 @@ class PongEngineUpdate
 		if (this.pongEngine.isRunning){
 			this.updateBallPosition();
 		}
-		
 		this.handlePaddleMovement();
+	}
+
+	dispose()
+	{
+		this.pongEngine 	= null;
+		this.physics		= null;
+		this.match			= null;
+		this.pongEngineData = null;
+		this.ball			= null;
+		this.paddle1		= null;
+		this.paddle2		= null;
+		this.field			= null;
+		this.difficulty		= null;
+		this.maxBallSpeed	= null;
+		this.initBallSpeed	= null;
+		this.isResetting	= false;
 	}
 
 }

--- a/docker/srcs/vite/pong-three/src/js/state/BaseGameState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/BaseGameState.js
@@ -8,22 +8,22 @@ class BaseGameState
 	
 	enter() 
 	{
-		throw new Error("Enter method must be implemented");
+		throw new Error("hth: Enter method must be implemented");
 	}
 
 	update() 
 	{
-		throw new Error("Update method must be implemented");
+		throw new Error("hth: Update method must be implemented");
 	}
 
 	render() 
 	{
-		throw new Error("Render method must be implemented");
+		throw new Error("hth: Render method must be implemented");
 	}
 
 	exit() 
 	{
-		throw new Error("Exit method must be implemented");
+		throw new Error("hth: Exit method must be implemented");
 	}
 }
 

--- a/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
@@ -59,7 +59,7 @@ class EntryGameState extends BaseGameState
 	update() 
 	{
 		try {
-						if (DEBUG_DETAIL1) {	console.log("entryState.update(): start");	}
+						if (DEBUG_DETAIL1) {	console.log("EntryState.update(): start");	}
 			this.magmaFlare.update();
 						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {

--- a/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
@@ -71,7 +71,9 @@ class EntryGameState extends BaseGameState
 	{
 		try {
 						if (DEBUG_FLOW) {	console.log("exit(): EntryGameState");	}
+			// イベントリスナーの削除
 			this._unregisterStartButtonEventListener();
+			
 			const targetPosition = new THREE.Vector3();
 			this.magmaFlare.getWorldPosition(targetPosition);
 			this.startDistance = this.camera.position.distanceTo(targetPosition);

--- a/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import EffectsSceneConfig from '../config/EffectsSceneConfig';
 import ZoomBall from '../effect/ZoomBall';
 import AllScenesManager from '../manager/AllScenesManager';
+import { handleCatchError } from '../../index.js';
 
 let DEBUG_FLOW		= 0;
 let DEBUG_DETAIL1	= 0;
@@ -51,6 +52,7 @@ class EntryGameState extends BaseGameState
 						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 		} catch (error) {
 			console.error('hth: EntryGameState.enter() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -62,6 +64,7 @@ class EntryGameState extends BaseGameState
 						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {
 			console.error('hth: EntryGameState.update() failed', error);
+			handleCatchError(error);
 		}
 	}
 	
@@ -89,6 +92,7 @@ class EntryGameState extends BaseGameState
 						if (TEST_TRY3) {	throw new Error('TEST_TRY3');	}
 		} catch (error) {
 			console.error('hth: EntryGameState.exit() failed', error);
+			handleCatchError(error);
 		}
 	}
 
@@ -104,6 +108,7 @@ class EntryGameState extends BaseGameState
 						if (TEST_TRY4){	throw new Error('TEST_TRY4');	}
 		} catch (error) {
 			console.error('hth: initStartButton() failed: ', error);
+			handleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -97,7 +97,6 @@ class GameplayState extends BaseGameState
 			}, SCENE_CHANGE_DELAY_MS);
 		} catch (error) {
 			console.error('hth: GameplayState.enter() failed', error);
-			// 描画がないまま試合結果が決まらないように進行を止める
 			handleCatchError(error);
 		}
 	}
@@ -121,6 +120,7 @@ class GameplayState extends BaseGameState
 						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {
 			console.error("Error in GamePlayState.exit():", error);
+			handleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -45,7 +45,7 @@ class GameplayState extends BaseGameState
 			this.pongEngine	= new PongEngine(this.PongApp);
 						if (TEST_TRY1) {	this.pongEngine = null;	}
 			if (!this.pongEngine){
-				throw new Error('Failed to create PongEngine instance.');
+				throw new Error('hth: Failed to create PongEngine instance.');
 			}
 			this.camera 	= this.scenesMgr.getGameSceneCamera()
 						if (DEBUG_DETAIL)

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -9,14 +9,14 @@ import * as THREE from "three";
 import ZoomTable from '../effect/ZoomTable';
 import { handleCatchError } from '../../index.js';
 
-const DEBUG_FLOW 		= 0;
+const DEBUG_FLOW 		= 1;
 const DEBUG_DETAIL		= 0;
 const TEST_TRY1			= 0;
 const TEST_TRY2			= 0;
 
-const ZOOM_IN_FACTOR = 1.5;
-const ZOOM_OUT_FACTOR = 0.5;
-const SCENE_CHANGE_DELAY_MS = 4500;
+const ZOOM_IN_FACTOR		= 1.5;
+const ZOOM_OUT_FACTOR		= 0.5;
+const SCENE_CHANGE_DELAY_MS	= 4500;
 
 class GameplayState extends BaseGameState 
 {
@@ -40,7 +40,7 @@ class GameplayState extends BaseGameState
 	{
 		try
 		{
-						if (DEBUG_FLOW){	console.log("Entering GamePlay state");	 };
+						if (DEBUG_FLOW){	console.log("Entering GamePlay state: start");	 };
 			this.scenesMgr.gameScene.refreshScene(new GameSceneConfig());
 			this.pongEngine	= new PongEngine(this.PongApp);
 						if (TEST_TRY1) {	this.pongEngine = null;	}
@@ -64,6 +64,7 @@ class GameplayState extends BaseGameState
 			this.pongEngine.data.objects.plane.getWorldPosition(targetPosition); 
 			// 初期距離を計算
 			this.initialDistance = this.camera.position.distanceTo(targetPosition);
+						if (DEBUG_FLOW){	console.log("Entering GamePlay state: 2");	 };
 
 			const zoomParams = 
 			{
@@ -87,6 +88,7 @@ class GameplayState extends BaseGameState
 
 			// this.scenesMgr.disableAllControls();
 			// this.pongEngine.update.initMouseControl();
+						if (DEBUG_FLOW){	console.log("Entering GamePlay state: 3");	 };
 
 			setTimeout(() => 
 			{
@@ -108,8 +110,11 @@ class GameplayState extends BaseGameState
 	{
 		try {
 						if (DEBUG_FLOW){	console.log("Exiting GamePlay state");	 };
-			this.PongApp.allScenesManager.gameScene.clearScene();
-			if (this.pongEngine) {
+			if (this.PongApp.allScenesManager.gameScene){
+				this.PongApp.allScenesManager.gameScene.clearScene();
+			}
+			if (this.pongEngine) 
+			{
 				this.pongEngine.dispose();
 				this.pongEngine = null;
 			}

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -9,7 +9,7 @@ import * as THREE from "three";
 import ZoomTable from '../effect/ZoomTable';
 import { handleCatchError } from '../../index.js';
 
-const DEBUG_FLOW 		= 1;
+const DEBUG_FLOW 		= 0;
 const DEBUG_DETAIL		= 0;
 const TEST_TRY1			= 0;
 const TEST_TRY2			= 0;
@@ -40,7 +40,7 @@ class GameplayState extends BaseGameState
 	{
 		try
 		{
-						if (DEBUG_FLOW){	console.log("Entering GamePlay state: start");	 };
+						if (DEBUG_FLOW){	console.log("GamePlayState.enter(): start");	 };
 			this.scenesMgr.gameScene.refreshScene(new GameSceneConfig());
 			this.pongEngine	= new PongEngine(this.PongApp);
 						if (TEST_TRY1) {	this.pongEngine = null;	}
@@ -64,7 +64,6 @@ class GameplayState extends BaseGameState
 			this.pongEngine.data.objects.plane.getWorldPosition(targetPosition); 
 			// 初期距離を計算
 			this.initialDistance = this.camera.position.distanceTo(targetPosition);
-						if (DEBUG_FLOW){	console.log("Entering GamePlay state: 2");	 };
 
 			const zoomParams = 
 			{
@@ -88,7 +87,6 @@ class GameplayState extends BaseGameState
 
 			// this.scenesMgr.disableAllControls();
 			// this.pongEngine.update.initMouseControl();
-						if (DEBUG_FLOW){	console.log("Entering GamePlay state: 3");	 };
 
 			setTimeout(() => 
 			{
@@ -119,7 +117,7 @@ class GameplayState extends BaseGameState
 			}
 						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {
-			console.error("Error in GamePlayState.exit():", error);
+			console.error("hth: GameplayState.exit() failed", error);
 			handleCatchError(error);
 		}
 	}

--- a/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/GamePlayState.js
@@ -109,6 +109,10 @@ class GameplayState extends BaseGameState
 		try {
 						if (DEBUG_FLOW){	console.log("Exiting GamePlay state");	 };
 			this.PongApp.allScenesManager.gameScene.clearScene();
+			if (this.pongEngine) {
+				this.pongEngine.dispose();
+				this.pongEngine = null;
+			}
 						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 		} catch (error) {
 			console.error("Error in GamePlayState.exit():", error);


### PR DESCRIPTION
連続したので一つのプルリクにしました
## 今日1回目
2D ss-pong: addEventListenerで検索し、削除の実装をチェック（細かいテストはまだ）
チェック時のスクショは
2D https://github.com/42trans/ft_transcendence/issues/253
## 2回目
3D addEventListenerで検索し、削除の実装をチェック
3D https://github.com/42trans/ft_transcendence/issues/255
## 3回目
3D:
- [x] `throw new Error`, `console.error`でvite/を 検索して　全てにhth:をつけた
- dispose()をほぼ全てのクラスに実装。連鎖的に呼び出す
- 3D: catchしたら、window.location.href = routeTable['top'].path;
#257
#250
## 4回目
2D ss-pong
すでにdispose()をほぼ全てのクラスに実装済み
- [x] 2D ss-pogも `throw new Error`, `console.error`で 検索して　全てにhth:をつけた
- [x] 2D:  catchしたら、window.location.href = routeTable['top'].path;
スクショ #259

## 5回目
#261
#264 