### PR TITLE
[fix] 42authログイン後戻る->logiin表示 & header更新

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/login.html
@@ -66,11 +66,12 @@
 			id="auth42-a-btn"
 			role="button"
 			href="{% url 'accounts:oauth_ft' %}"
+		    data-link
 			>Log in to your 42 account</a>
 
 		 {% comment %} link: Sign up  {% endcomment %}
 		<div class="slideup-text form-sign-text pt-4" >
-			<a href="{{ signup_url }}">Create an Account</a>
+			<a href="{{ signup_url }}" data-link>Create an Account</a>
 		</div>
 
     </div>

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -6,6 +6,7 @@ import { getNextPath } from "./routing/getNextPath.js"
 import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { refreshJWT } from "./utility/refreshJWT.js"
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
+import { setNoCache, clearNoCache } from "/static/spa/js/utility/cache.js"
 
 const DEBUG_DETAIL = 0;
 
@@ -34,7 +35,9 @@ const setupDOMContentLoadedListener = () => {
     // 初期ビューを表示
     const currentPath = window.location.href;
     const renderPath = await getNextPath(currentPath)  // guest, userのredirectを加味したPathを取得
-    switchPage(renderPath);
+    if (DEBUG_DETAIL) { console.log(`DOMContentLoaded: currentPath: ${currentPath} -> renderPath: ${renderPath}`); }
+    history.replaceState(null, null, renderPath);  // historyは変更せず、guest, userに応じたURLに変更
+    renderView(renderPath);
 
     // リンククリック時の遷移を設定
     setupBodyClickListener();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -4,7 +4,7 @@ import { routeTable } from "./routeTable.js"
 import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
 
 
-const DEBUG = 0;
+const DEBUG = 1;
 
 // Guestのリダイレクトを制御
 //  top, home, game2d, signup, loginはそのまま表示
@@ -19,6 +19,8 @@ function getGuestRedirectPath(url) {
       || pathName === routeTable['game2d'].path
       || pathName === routeTable['signup'].path
       || pathName === routeTable['login'].path) {
+      || pathName === routeTable['login'].path
+      || pathName === routeTable['oAuthLogin'].path) {
     // nextPath = url;
     nextPath = pathName;  // queryStringなどを排除しpathNameに整形
     if (DEBUG) { console.log('guest access to  : ' + nextPath); }
@@ -42,7 +44,8 @@ function getUserRedirectPath(url, isEnable2FA) {
   if (pathName === routeTable['signup'].path
       || pathName === routeTable['login'].path
       || pathName === routeTable['veryfy2fa'].path
-      || (pathName === routeTable['enable2fa'].path && isEnable2FA)) {
+      || (pathName === routeTable['enable2fa'].path && isEnable2FA
+      || pathName === routeTable['oAuthLogin'].path)) {
     // topを表示
     nextPath = routeTable['top'].path;
     if (DEBUG) { console.log('user redirect to: ' + nextPath); }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -4,7 +4,7 @@ import { routeTable } from "./routeTable.js"
 import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
 
 
-const DEBUG = 1;
+const DEBUG = 0;
 
 // Guestのリダイレクトを制御
 //  top, home, game2d, signup, loginはそのまま表示

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -18,8 +18,8 @@ function getGuestRedirectPath(url) {
       || pathName === routeTable['home'].path
       || pathName === routeTable['game2d'].path
       || pathName === routeTable['signup'].path
-      || pathName === routeTable['login'].path) {
       || pathName === routeTable['login'].path
+      || pathName === routeTable['veryfy2fa'].path
       || pathName === routeTable['oAuthLogin'].path) {
     // nextPath = url;
     nextPath = pathName;  // queryStringなどを排除しpathNameに整形

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -6,7 +6,7 @@ import { setNoCache, clearNoCache } from "/static/spa/js/utility/cache.js"
 
 
 const DEBUG_DETAIL = 0;
-const DEBUG_LOG = 1;
+const DEBUG_LOG = 0;
 
 // login, signin, 42loginはcacheを保存しない
 function controlCache(targetPathName) {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,9 +1,24 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
+import { updateHeader } from "/static/spa/js/views/updateHeader.js"
+import { setNoCache, clearNoCache } from "/static/spa/js/utility/cache.js"
+
 
 const DEBUG_DETAIL = 0;
-const DEBUG_LOG = 0;
+const DEBUG_LOG = 1;
+
+// login, signin, 42loginはcacheを保存しない
+function controlCache(targetPathName) {
+  if (targetPathName === routeTable['oAuthLogin'].path
+      || targetPathName === routeTable['login'].path
+      || targetPathName === routeTable['signup'].path) {
+    setNoCache();
+  } else {
+    clearNoCache();
+  }
+}
+
 
 // touteTable.jsの記述について
 // game3d: { path: "/app/game/game-3d/", view: Game3D }は、/app/game/game-3d/というパスに対してGame3Dという「クラス」を対応
@@ -16,14 +31,9 @@ export const switchPage = (targetPath) => {
   const targetPathName = targetUrl.pathname;
 
   history.pushState(null, null, targetPathName );
+  controlCache()
+
   if (DEBUG_LOG) { console.log(` history.push: ${targetPathName}`); }
-
-  // currentViewにdisposeメソッドが存在するかどうかをチェック。オペランドの型がfunctionなら関数
-  // if (currentView && typeof currentView.dispose === "function") {
-  //         if (DEBUG_DETAIL) { console.log('switchPage(): dispose', currentView);  } 
-  //   currentView.dispose();
-  // }
-
   // 戻る、進むでも対応するために、event発行はrenderView内部に移動
   renderView(targetPathName);
   
@@ -118,6 +128,14 @@ export const renderView = async (path) => {
         if (DEBUG_DETAIL) { console.log('renderView(): currentView.dispose(): currentView', currentView);  }
     currentView.dispose();
   }
+
+  if (path === routeTable['oAuthLogin'].path) {
+    if (DEBUG_DETAIL) { console.log('oauth');  }
+    window.location = routeTable['oAuthLogin'].path;  // oauth loginの場合はwindow切り替え
+    // alert("oauth");
+    return;
+  }
+
   // ここまで前回のviewに対する処理
   // --------------------------
   // ここから今回のviewに対する処理

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -68,6 +68,7 @@ export const routeTable = {
 
   signup        : { path: "/app/auth/signup/",       view: Signup },
   login         : { path: "/app/auth/login/",        view: Login },
+  oAuthLogin    : { path: "/accounts/oauth-ft/",     view: Login },  // viewは関係なし
 
   // 開発用テストリンク
   // lang    : { path: "/lang/",         view: Lang },

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/cache.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/cache.js
@@ -1,0 +1,24 @@
+// static/spa/js/utility/cache.js
+
+const DEBUG_LOG = 1;
+
+export function setNoCache() {
+    if (DEBUG_LOG) { console.log("set no cache"); }
+
+    // IE
+    if (!window.onbeforeunload) {
+        window.onbeforeunload = function() {};
+    }
+
+    // IE以外
+    if (!window.onload) {
+        window.onunload = function() {};
+    }
+}
+
+export function clearNoCache() {
+    if (DEBUG_LOG) { console.log("no cache clear"); }
+
+    window.onbeforeunload = null;
+    window.onunload = null;
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/cache.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/cache.js
@@ -1,6 +1,6 @@
 // static/spa/js/utility/cache.js
 
-const DEBUG_LOG = 1;
+const DEBUG_LOG = 0;
 
 export function setNoCache() {
     if (DEBUG_LOG) { console.log("set no cache"); }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isUser.js
@@ -1,5 +1,7 @@
 // spa/js/utility/isUser.js
 
+const DEBUG_LOG = 0;
+
 export async function isUserLoggedIn() {
     try {
         const response = await fetch('/accounts/api/is-user-logged-in/', {
@@ -10,9 +12,11 @@ export async function isUserLoggedIn() {
         });
         const data = await response.json();
         // alert(`isUserLoggedIn: ${data.is_logged_in}`)
+        if (DEBUG_LOG) { console.log('isUserLoggedIn: ' + data.is_logged_in); }
         return data.is_logged_in;
     } catch (error) {
         console.error('Error:', error);
+        if (DEBUG_LOG) { console.log('isUserLoggedIn: error: ' + error); }
         // alert(`isUserLoggedIn: error: ${error}`)
         return false;
     }

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -102,6 +102,9 @@ class UrlAccessTest(TestConfig):
                     self._is_expected_page(PongTopPage)  # topページに遷移していることを確認
 
                 self._logout()  # 次のテストのためにlogout
+            elif page_name == AuthVerify2FaPage:
+                # 42auth->verify2FAルートのために除外
+                continue
             else:
                 self._assert_current_url(url)
                 self._is_not_login_page()  # login pageでないことを確認
@@ -199,7 +202,7 @@ class UrlAccessTest(TestConfig):
             DmPage,
             DmWithUrlBase,  # :nicknameを置き換えるためにUrlBaseでテスト
             AuthEnable2FaPage,
-            AuthVerify2FaPage,
+            # AuthVerify2FaPage,  # 42auth->verify2FAルートのために除外
         }
         return page_name in login_required_pages
 


### PR DESCRIPTION
#267 

## 現象
- Guest -> Log-in -> 42login -> TOP -> 戻るボタンでloginに戻る（login済みなのでTOPに遷移するはず）
- Guest -> Sign-up -> 42signup -> TOP -> 戻るボタンでsignupに戻る（login済みなのでTOPに遷移するはず）

<br>

## 対策
- login, signup, oauthのキャッシュ管理を追加
- switchPage()でcacheを管理
  - oauthで42サーバー接続前と思われる`/login`/, `/signup`/, (/`oauth-ft/`)のキャッシュ保持しないよう`setNoCache()`を呼び出し
  - それ以外はキャッシュ保持に戻すため`clearNocache()`を呼び出し
  - Login.jsなどの該当ページconstructor, disposeで呼び出すと、たまにlogin表示漏れるため、switchPage()で確実に実行
- DonContentLoadedのページ表示を`switchPage()` -> `renderView()`に変更
  - 42authで42サーバーに移動するため、42auth後にDOMContentLoadedが呼ばれる 
  - 42auth前後の戻る、進むでDOMContentLoadedが発火する
  - login済みuserが`/login/`に戻る際、topに切り替わるが、switchPage()にすると履歴を上書きするため、URLのみ変更する`history.replaceState()` -> `renderView()`の呼び出しとした
- `updateHeader()`の追加呼び出しは不要そうだが、不安定ならrenderView()のどこかで呼び出すよう変更する

<br>

## memo
- TOP->loginのブラウザバックがキャッシュ使ってそう（42authでリダイレクト遷移しているため？）
  - 42auth -> TOP遷移後のブラウザバックはpopStateが発火していない
  - isUserLoggedInでログイン状態調べてもGuestのまま
  - 非login状態を保持しているため、イベントで強制遷移ができない
  - django viewで42authへのredirect()のresponseにno-store(meta)を付与しても効果なし -> 戻るボタンには効果ないらしい[1]

<br>

## Ref
- [1] [ブラウザの「戻る」ボタンでキャッシュが表示されてしまう際の対策](https://qiita.com/shibe23/items/79f950061457ff1a7687)