### PR TITLE
[fix] invalid URL

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -238,7 +238,7 @@ function createFriendRequestList(data) {
 
 function createRequestLink(nickname, friend_id, isSent) {
     const link = document.createElement('a');
-    link.href = `${routeTable['userInfoBase'].path}${nickname}/`;
+    link.href = `${routeTable['userInfoBase'].path}${friend_id}/`;
     link.className = 'nav__link';
     link.setAttribute('data-link', '');
     link.textContent = nickname;

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/online-status.js
@@ -135,7 +135,7 @@ function updateOrCreateFriendListItem(friend) {
 
     // <link-to-user-info>
     const link = document.createElement('a');
-    link.href = `${routeTable['userInfoBase'].path}${friend.nickname}/`;
+    link.href = `${routeTable['userInfoBase'].path}${friend.id}/`;
     link.className = 'nav__link';
     link.setAttribute('data-link', '');
     link.textContent = friend.nickname;

--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/user_info.html
@@ -8,7 +8,7 @@
 	<li>History: history here</li>
 	<li>xxx: xxx</li>
 	<li>xxx: xxx</li>
-	<li><a href="{{ url_config.kSpaDmWithUrlBase }}{{ user_data.info_user_nickname }}" data-link>DM with {{ user_data.info_user_nickname }}</a></li>
+	<li><a href="{{ url_config.kSpaDmWithUrlBase }}{{ user_data.info_user_id }}/" data-link>DM with {{ user_data.info_user_nickname }}</a></li>
 </ul>
 
 <hr>

--- a/docker/srcs/uwsgi-django/accounts/tests/test_valid_user_id.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_valid_user_id.py
@@ -1,0 +1,92 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class IsValidUserIdAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    kIsValidUserId = "api_accounts:is_valid_id"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        ok_ids = [
+            self.user1.id,
+            self.user2.id
+        ]
+        for ok_id in ok_ids:
+            print(f"testing ok_id: {ok_id}")
+            is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[ok_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertTrue(response.json()['exists'])
+
+        ng_200_ids = [
+            "100",
+            "999",
+            "65535",
+            "2147483647",
+            "2147483648",
+            "18446744073709551615",
+        ]
+        for ng_id in ng_200_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        ng_400_ids = [
+            "0",
+            "-1",
+            "-2147483648",
+            "-9223372036854775808",
+            " ",
+            "-",
+            "hoge",
+            "xxxxxxxxxxxx",
+        ]
+        for ng_id in ng_400_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_guest(self):
+        is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[self.user1.id])
+        response = self.client.get(is_valid_user_id_api_path)
+        self.assertEqual(response.status_code, 401)

--- a/docker/srcs/uwsgi-django/accounts/urls.py
+++ b/docker/srcs/uwsgi-django/accounts/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
 
     path('friends/', UserFriendsView.as_view(), name='friends'),
 
-    path('info/<str:nickname>/', get_user_info, name='info'),
+    path('info/<str:user_id>/', get_user_info, name='info'),
 
     path('verify/enable_2fa/', Enable2FaTemplateView.as_view(), name='enable_2fa'),
     path('verify/verify_2fa/', Verify2FaTepmlateView.as_view(), name='verify_2fa'),

--- a/docker/srcs/uwsgi-django/accounts/urls_api.py
+++ b/docker/srcs/uwsgi-django/accounts/urls_api.py
@@ -9,6 +9,7 @@ from accounts.views.is_user import IsUserLoggedInAPIView, IsUserEnabled2FaAPIVie
 from accounts.views.user import UserProfileAPIView
 from accounts.views.user import EditUserProfileAPIView
 from accounts.views.user import UploadAvatarAPI
+from accounts.views.user import IsValidUserIdAPI
 from accounts.views.oauth import OAuthWith42
 from accounts.views.two_factor_auth import Enable2FaAPIView
 from accounts.views.two_factor_auth import Verify2FaAPIView
@@ -36,6 +37,8 @@ urlpatterns = [
     path('api/enable_2fa/'          , Enable2FaAPIView.as_view()        , name='api_enable_2fa'),
     path('api/verify_2fa/'          , Verify2FaAPIView.as_view()        , name='api_verify_2fa'),
     path('api/disable_2fa/'         , Disable2FaView.as_view()          , name='disable_2fa'),
+
+    path('api/is-valid-id/<str:user_id>/', IsValidUserIdAPI.as_view()   , name='is_valid_id'),
 
     path('api/token/refresh/'       , JWTRefreshAPIView.as_view()       , name='api_token_refresh'),
     path('oauth-ft/callback/'       , OAuthWith42.as_view()             , name='oauth_ft_callback'),

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -147,8 +147,8 @@ class EditUserProfileAPIView(APIView):
 
 
 # todo: tmp, API and FBV -> CBV
-def get_user_info(request, nickname):
-    if not nickname:
+def get_user_info(request, user_id):
+    if not user_id:
         return redirect('/accounts/login/')
 
     try:
@@ -156,7 +156,7 @@ def get_user_info(request, nickname):
         if not user.is_authenticated:
             return redirect(to='/accounts/login/')
 
-        info_user = CustomUser.objects.get(nickname=nickname)
+        info_user = CustomUser.objects.get(id=user_id)
         avatar_url = info_user.avatar.url
         is_blocking_user = request.user.blocking_users.filter(id=info_user.id).exists()
 

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -276,3 +276,18 @@ class GetUserHistoryTemplateView(LoginRequiredMixin, TemplateView):
         user = self.request.user
         context['nickname'] = user.nickname
         return context
+
+
+class IsValidUserIdAPI(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, user_id) -> Response:
+        try:
+            user_id = int(user_id)
+            if user_id <= 0:
+                return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+
+        user_exists = CustomUser.objects.filter(id=user_id).exists()
+        return Response({'exists': user_exists}, status=status.HTTP_200_OK)

--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_with.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% if not isSystemUser %}
-    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_nickname }}/" data-link>{{ target_info.nickname }}</a></h2>
+    <h2>DM with <a href="{{ url_config.kSpaUserInfoUrlBase }}{{ target_info.id }}/" data-link>{{ target_info.nickname }}</a></h2>
 {% else %}
     <h2>System Message</h2>
 {% endif %}

--- a/docker/srcs/uwsgi-django/chat/tests/test_valid_dm_user_id.py
+++ b/docker/srcs/uwsgi-django/chat/tests/test_valid_dm_user_id.py
@@ -1,0 +1,92 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+class IsValidDmUserIdAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    IsValidDmUserIdApiName = "api_chat:valid_target_id"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user2 = User.objects.create_user(email=self.kUser2Email,
+                                              nickname=self.kUser2Nickname,
+                                              password=self.kUser2Password,
+                                              enable_2fa=True)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+        self.user2_login_data = {
+            'email': self.kUser2Email,
+            'password': self.kUser2Password
+        }
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        ok_ids = [
+            self.user2.id
+        ]
+        for ok_id in ok_ids:
+            print(f"testing ok_id: {ok_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[ok_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertTrue(response.json()['exists'])
+
+        ng_200_ids = [
+            "100",
+            "999",
+            "65535",
+            "2147483647",
+            "2147483648",
+            "18446744073709551615",
+        ]
+        for ng_id in ng_200_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        ng_400_ids = [
+            self.user1.id,  # 自分自身はNG
+            "0",
+            "-1",
+            "-2147483648",
+            "-9223372036854775808",
+            " ",
+            "-",
+            "hoge",
+            "xxxxxxxxxxxx",
+        ]
+        for ng_id in ng_400_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_guest(self):
+        is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[self.user1.id])
+        response = self.client.get(is_valid_user_id_api_path)
+        self.assertEqual(response.status_code, 401)

--- a/docker/srcs/uwsgi-django/chat/urls.py
+++ b/docker/srcs/uwsgi-django/chat/urls.py
@@ -9,5 +9,5 @@ app_name = 'chat'
 urlpatterns = [
     path('dm-sessions/', DMSessionsView.as_view(), name='dm_sessions'),
     # path('dm-with/<str:target_nickname>/', DMView.as_view(), name='dm'),
-    path('dm-with/<int:target_id>/', DMView.as_view(), name='dm'),
+    path('dm-with/<str:target_id>/', DMView.as_view(), name='dm'),
 ]

--- a/docker/srcs/uwsgi-django/chat/urls_api.py
+++ b/docker/srcs/uwsgi-django/chat/urls_api.py
@@ -4,7 +4,7 @@ from django.urls import path, re_path
 from . import views, consumers
 from chat.views.get_dm_sessions import GetDMSessionsAPI
 from chat.views.system_message import SystemMessageAPI
-from chat.views.views import ValidateDmTargetAPI
+from chat.views.views import ValidateDmTargetAPI, IsValidDmUserIdAPI
 
 
 app_name = 'api_chat'
@@ -13,4 +13,5 @@ urlpatterns = [
     path('api/dm-sessions/', GetDMSessionsAPI.as_view(), name='dm_sessions'),
     path('api/system-message/', SystemMessageAPI.as_view(), name='dm_system'),
     path('api/validate-dm-target/<str:target_nickname>/', ValidateDmTargetAPI.as_view(), name='valid_dm_target'),
+    path('api/is-valid-dm-target-id/<str:target_id>/'   , IsValidDmUserIdAPI.as_view(), name='valid_target_id'),
 ]

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -75,9 +75,17 @@ class DMView(LoginRequiredMixin, TemplateView):
     Login認証していなければ accounts:login へ遷移
     """
     template_name = "chat/dm_with.html"
-    error_occurred_redirect_to = "chat:dm_sessions"
+    error_occurred_redirect_to = "/pong/"
 
     def get(self, request, target_id: str):
+        # target_idが整数でない場合の遷移
+        try:
+            target_id = int(target_id)
+            if target_id <= 0:
+                return redirect(self.error_occurred_redirect_to)
+        except ValueError:
+            return redirect(self.error_occurred_redirect_to)
+
         # user, other_userを取得
         # dm targetのnicknameがuser.nicknameである場合はerr
         user, dm_target, err = _get_dm_users(request, target_id)

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -132,3 +132,18 @@ class DMSessionsView(LoginRequiredMixin, TemplateView):
 
     def get(self, request):
         return render(request, self.template_name)
+
+
+class IsValidDmUserIdAPI(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, target_id) -> Response:
+        try:
+            target_id = int(target_id)
+            if target_id <= 0 or target_id == request.user.id:
+                return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+
+        user_exists = CustomUser.objects.filter(id=target_id).exists()
+        return Response({'exists': user_exists}, status=status.HTTP_200_OK)

--- a/docker/srcs/uwsgi-django/pong/tournament/tests/test_valid_match_id.py
+++ b/docker/srcs/uwsgi-django/pong/tournament/tests/test_valid_match_id.py
@@ -1,0 +1,109 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.messages import get_messages
+from django.urls import reverse, resolve
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from pong.models import Tournament, Match
+
+
+class IsValidMatchIdAPITests(TestCase):
+    kLoginAPIName = "api_accounts:api_login"
+    kLogoutAPIName = "api_accounts:api_logout"
+    IsValidMatchIdApiName = "is_valid_match_id"
+
+    kUser1Email = "test1@example.com"
+    kUser1Nickname = "test1"
+    kUser1Password = "pass012345"
+
+    kUser2Email = "test2@example.com"
+    kUser2Nickname = "test2"
+    kUser2Password = "pass012345"
+
+    def setUp(self):
+        self.login_api_path = reverse(self.kLoginAPIName)
+        self.client = APIClient()
+
+        User = get_user_model()
+        self.user1 = User.objects.create_user(email=self.kUser1Email,
+                                              nickname=self.kUser1Nickname,
+                                              password=self.kUser1Password,
+                                              enable_2fa=False)
+        self.user1_login_data = {
+            'email': self.kUser1Email,
+            'password': self.kUser1Password
+        }
+
+        self.tournament = Tournament.objects.create(
+            name="Test Tournament",
+            organizer=self.user1,
+            player_nicknames=["player1", "player2", "player3", "player4",
+                              "player5", "player6", "player7", "player8"]
+        )
+
+        self.match1 = Match.objects.create(
+            tournament=self.tournament,
+            round_number=1,
+            match_number=1,
+            player1="player1",
+            player2="player2"
+        )
+
+        self.match2 = Match.objects.create(
+            tournament=self.tournament,
+            round_number=1,
+            match_number=2,
+            player1="player3",
+            player2="player4"
+        )
+
+    def test_user1(self):
+        self.client.force_authenticate(user=self.user1)
+
+        ok_ids = [
+            self.match1.id,
+            self.match2.id
+        ]
+        for ok_id in ok_ids:
+            print(f"testing ok_id: {ok_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[ok_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertTrue(response.json()['exists'])
+
+        ng_200_ids = [
+            "100",
+            "999",
+            "65535",
+            "2147483647",
+            "2147483648",
+            "18446744073709551615",
+        ]
+        for ng_id in ng_200_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        ng_400_ids = [
+            "0",
+            "-1",
+            "-2147483648",
+            "-9223372036854775808",
+            " ",
+            "-",
+            "hoge",
+            "xxxxxxxxxxxx",
+        ]
+        for ng_id in ng_400_ids:
+            print(f"testing ng_id: {ng_id}")
+            is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[ng_id])
+            response = self.client.get(is_valid_user_id_api_path)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_guest(self):
+        is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[self.user1.id])
+        response = self.client.get(is_valid_user_id_api_path)
+        self.assertEqual(response.status_code, 401)

--- a/docker/srcs/uwsgi-django/pong/urls.py
+++ b/docker/srcs/uwsgi-django/pong/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
 	path("tournament/", tournament, name="tournament"),
 	# path('results/', results, name='results'),
 	path("game/", game, name="game"),
-	path("play/<int:match_id>", play_tournament, name="play_tournament"),
+	path("play/<str:match_id>", play_tournament, name="play_tournament"),
 	# root（一番下に記述する。上から順にマッチ評価されるため） ex. https://localhost/pong/
 	path("", pong_view, name="index"),
 ]

--- a/docker/srcs/uwsgi-django/pong/urls_api.py
+++ b/docker/srcs/uwsgi-django/pong/urls_api.py
@@ -12,7 +12,8 @@ from .views.tournament_views import (
 	get_matches_of_latest_tournament_user_ongoing, 
 	get_matches_by_round_latest_user_ongoing_tournament, 
 	get_tournament_id_user_all_ongoing, get_latest_user_ongoing_tournament,
-	save_game_result
+	save_game_result,
+	IsValidMatchIdAPI
 )
 
 # パスはapiが先頭につきます。ex./pong/api/tournament/create/
@@ -48,4 +49,6 @@ urlpatterns = [
 		path("tournament/user/ongoing/all/", get_tournament_id_user_all_ongoing, name="get_tournament_id_user_all_ongoing"),
 		# 「ユーザーが主催する && 未終了のトーナメント」 に関する「全7試合」のデータを全て取得する
 		path("tournament/user/ongoing/matches/all", get_matches_of_latest_tournament_user_ongoing, name="get_matches_of_latest_tournament_user_ongoing"),
+
+	path('is-valid-match-id/<str:match_id>/', IsValidMatchIdAPI.as_view(), name='is_valid_match_id'),
 ]

--- a/docker/srcs/uwsgi-django/pong/views/navi_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/navi_views.py
@@ -34,28 +34,39 @@ def pong_view(request):
 
 # 3D
 def play_tournament(request, match_id):
+	# match_idが整数でない場合の遷移
+	try:
+		match_id = int(match_id)
+		if match_id <= 0:
+			return redirect(to='/pong/')
+	except ValueError:
+		return redirect(to='/pong/')
+
 	if not request.user.is_authenticated:
 		return redirect(to='/accounts/login/')
 
-	match = get_object_or_404(Match, id=match_id)
-	match_data = {
-		"id": match.id,
-		"round_number": match.round_number,
-		"match_number": match.match_number,
-		"player1": match.player1,
-		"player2": match.player2,
-		"player1_score": match.player1_score,
-		"player2_score": match.player2_score,
-		"is_finished": match.is_finished
-	}
-	context = {
-		# viteコンテナで作成したjsをDjango dev serverでも使えるようにするため、Django の DEBUG 設定をwindow.に渡す
-		'is_dev_server': settings.DEBUG,
-		'match_json': JsonResponse(match_data, safe=False).content.decode()
-	}
-	# return render(request, 'pong/play-tournament.html', {'match': match})
-	return render(request, 'pong/play-tournament.html', context)
-	# return render(request, 'pong/play-tournament.html', {'match_json': JsonResponse(match_data, safe=False).content.decode()})
+	try:
+		match = get_object_or_404(Match, id=match_id)
+		match_data = {
+			"id": match.id,
+			"round_number": match.round_number,
+			"match_number": match.match_number,
+			"player1": match.player1,
+			"player2": match.player2,
+			"player1_score": match.player1_score,
+			"player2_score": match.player2_score,
+			"is_finished": match.is_finished
+		}
+		context = {
+			# viteコンテナで作成したjsをDjango dev serverでも使えるようにするため、Django の DEBUG 設定をwindow.に渡す
+			'is_dev_server': settings.DEBUG,
+			'match_json': JsonResponse(match_data, safe=False).content.decode()
+		}
+		# return render(request, 'pong/play-tournament.html', {'match': match})
+		return render(request, 'pong/play-tournament.html', context)
+		# return render(request, 'pong/play-tournament.html', {'match_json': JsonResponse(match_data, safe=False).content.decode()})
+	except Exception:
+		return redirect(to='/pong/')
 
 def game(request):
 	return render(request, 'pong/game.html')

--- a/docker/srcs/uwsgi-django/pong/views/tournament_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament_views.py
@@ -16,8 +16,11 @@ from django.forms.models import model_to_dict
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 import random
 
 
@@ -387,3 +390,19 @@ def get_matches_of_latest_tournament_user_ongoing(request) -> JsonResponse:
 		for match in matches
 	]
 	return JsonResponse({'matches': matches_data}, safe=False, status=200)
+
+
+class IsValidMatchIdAPI(APIView):
+	permission_classes = [IsAuthenticated]
+
+	def get(self, request, match_id) -> Response:
+		try:
+			match_id = int(match_id)
+			if match_id <= 0:
+				return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+
+			match_exists = Match.objects.filter(id=match_id).exists()
+			return Response({'exists': match_exists}, status=status.HTTP_200_OK)
+
+		except Exception:
+			return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -7,7 +7,7 @@ import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { refreshJWT } from "./utility/refreshJWT.js"
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
-const DEBUG_DETAIL = 0;
+const DEBUG_DETAIL = 1;
 
 // ブラウザの戻る/進むボタンで発火
 const setupPopStateListener = () => {
@@ -34,6 +34,8 @@ const setupDOMContentLoadedListener = () => {
     // 初期ビューを表示
     const currentPath = window.location.href;
     const renderPath = await getNextPath(currentPath)  // guest, userのredirectを加味したPathを取得
+    if (DEBUG_DETAIL) { console.log(`DOMContentLoaded: currentPath: ${currentPath} -> renderPath: ${renderPath}`); }
+    history.replaceState(null, null, renderPath);  // historyは変更せず、guest, userに応じたURLに変更
     switchPage(renderPath);
 
     // リンククリック時の遷移を設定

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -36,7 +36,7 @@ const setupDOMContentLoadedListener = () => {
     const renderPath = await getNextPath(currentPath)  // guest, userのredirectを加味したPathを取得
     if (DEBUG_DETAIL) { console.log(`DOMContentLoaded: currentPath: ${currentPath} -> renderPath: ${renderPath}`); }
     history.replaceState(null, null, renderPath);  // historyは変更せず、guest, userに応じたURLに変更
-    switchPage(renderPath);
+    renderView(renderPath);
 
     // リンククリック時の遷移を設定
     setupBodyClickListener();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/index.js
@@ -7,7 +7,7 @@ import { isUserLoggedIn, isUserEnable2FA } from "./utility/isUser.js"
 import { refreshJWT } from "./utility/refreshJWT.js"
 import { setupLoginEventListener } from "/static/accounts/js/login.js"
 
-const DEBUG_DETAIL = 1;
+const DEBUG_DETAIL = 0;
 
 // ブラウザの戻る/進むボタンで発火
 const setupPopStateListener = () => {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -5,7 +5,7 @@ import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
 import { getSelectedRoute } from "./renderView.js"
 
 
-const DEBUG = 1;
+const DEBUG = 0;
 
 // Guestのリダイレクトを制御
 //  top, home, game2d, signup, loginはそのまま表示

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -2,6 +2,7 @@
 
 import { routeTable } from "./routeTable.js"
 import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
+import { getSelectedRoute } from "./renderView.js"
 
 
 const DEBUG = 0;
@@ -55,8 +56,25 @@ function getUserRedirectPath(url, isEnable2FA) {
 }
 
 
+// TOPを表示するURLであるか判定する
+// TOP or Invalid URLの場合はTOPを表示
+//  invalidの判定にgetSelectedRoute()を使用。renderView側にまとめた方が良さそう...
+const isRenderTopPageUrl = (url) => {
+  const urlObject = new URL(url);
+  const pathName = urlObject.pathname;
+  return getSelectedRoute(pathName, routeTable) === routeTable['top'];
+}
+
+
 // login userであれば/auth/への遷移を/app/に切り返る
 export async function getNextPath(url) {
+  if (DEBUG) { console.log('getNextPath: ' + url); }
+
+  if (isRenderTopPageUrl(url)) {
+    if (DEBUG) { console.log(' invalid or top -> top'); }
+    return routeTable['top'].path;
+  }
+
   const isLoggedIn = await isUserLoggedIn();
   if (!isLoggedIn) {
     return getGuestRedirectPath(url);

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -5,7 +5,7 @@ import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
 import { getSelectedRoute } from "./renderView.js"
 
 
-const DEBUG = 0;
+const DEBUG = 1;
 
 // Guestのリダイレクトを制御
 //  top, home, game2d, signup, loginはそのまま表示
@@ -59,10 +59,12 @@ function getUserRedirectPath(url, isEnable2FA) {
 // TOPを表示するURLであるか判定する
 // TOP or Invalid URLの場合はTOPを表示
 //  invalidの判定にgetSelectedRoute()を使用。renderView側にまとめた方が良さそう...
-const isRenderTopPageUrl = (url) => {
+const isRenderTopPageUrl = async (url) => {
   const urlObject = new URL(url);
   const pathName = urlObject.pathname;
-  return getSelectedRoute(pathName, routeTable) === routeTable['top'];
+  const ret =  await getSelectedRoute(pathName, routeTable) === routeTable['top'];
+  if (DEBUG) { console.log(' isRenderTopPageUrl -> ' + ret); }
+  return ret
 }
 
 
@@ -70,7 +72,8 @@ const isRenderTopPageUrl = (url) => {
 export async function getNextPath(url) {
   if (DEBUG) { console.log('getNextPath: ' + url); }
 
-  if (isRenderTopPageUrl(url)) {
+  const isTopUrl = await isRenderTopPageUrl(url);
+  if (isTopUrl) {
     if (DEBUG) { console.log(' invalid or top -> top'); }
     return routeTable['top'].path;
   }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -36,7 +36,7 @@ const comparePathParts = async (routeParts, currentPathParts, params) => {
           // パラメータの整合性を評価
           const isValid = await isValidParam(paramName, currentPathParts[index]);
           if (!isValid) {
-              if (DEBUG_LOG) { console.log(`    -> parameter invalid`); }
+            if (DEBUG_LOG) { console.log(`    -> parameter invalid`); }
             return false;
           }
           if (DEBUG_LOG) { console.log(`    -> parameter valid`); }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -22,7 +22,7 @@ export const switchPage = (targetPath) => {
 };
 
 
-const getSelectedRoute = (currentPath, routeTable) => {
+export const getSelectedRoute = (currentPath, routeTable) => {
   let params = {};  // URLパラメータを格納するオブジェクト
 
   // パスパラメータを含む可能性があるルートを評価

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,11 +1,12 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
+
+
 import { isValidParam } from "../utility/isValidParam.js"
 
-
 const DEBUG_DETAIL = 0;
-const DEBUG_LOG = 0;
+const DEBUG_LOG = 1;
 
 // touteTable.jsの記述について
 // game3d: { path: "/app/game/game-3d/", view: Game3D }は、/app/game/game-3d/というパスに対してGame3Dという「クラス」を対応

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -1,6 +1,8 @@
 import { routeTable } from "./routeTable.js";
 import { getUrl } from "../utility/url.js";
 import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
+import { isValidParam } from "../utility/isValidParam.js"
+
 
 const DEBUG_DETAIL = 0;
 const DEBUG_LOG = 0;
@@ -22,37 +24,65 @@ export const switchPage = (targetPath) => {
 };
 
 
-export const getSelectedRoute = (currentPath, routeTable) => {
+const comparePathParts = async (routeParts, currentPathParts, params) => {
+  const isMatch = await Promise.all(
+      routeParts.map(async (part, index) => {
+        if (part.startsWith(':')) {
+          // パラメータのキーを抽出（例: :nickname -> nickname）
+          const paramName = part.slice(1);
+            if (DEBUG_LOG) { console.log(`    parameter name  : ${paramName}`); }
+
+          // パラメータの整合性を評価
+          const isValid = await isValidParam(paramName, currentPathParts[index]);
+          if (!isValid) {
+              if (DEBUG_LOG) { console.log(`    -> parameter invalid`); }
+            return false;
+          }
+
+          params[paramName] = currentPathParts[index];  // パラメータを格納
+            if (DEBUG_LOG) { console.log(`    currentPathParts: ${currentPathParts[index]}`); }
+          return true;
+        }
+        return part === currentPathParts[index];
+      })
+  );
+
+  return isMatch.every(Boolean);
+};
+
+export const getSelectedRoute = async (currentPath, routeTable) => {
   let params = {};  // URLパラメータを格納するオブジェクト
 
   // パスパラメータを含む可能性があるルートを評価
-  const matchedRoute = Object.values(routeTable).find(route => {
-    const routeParts = route.path.split('/').filter(part => part);
-    const currentPathParts = currentPath.split('/').filter(part => part);
+  const matchedRoute = await Promise.all(
+      Object.values(routeTable).map(async (route) => {
+        const routeParts = route.path.split('/').filter(part => part);
+        const currentPathParts = currentPath.split('/').filter(part => part);
 
-    if (routeParts.length !== currentPathParts.length) {
-      return false;
-    }
+        if (routeParts.length !== currentPathParts.length) {
+          return null;
+        }
 
-    // パスの各部分を比較
-    return routeParts.every((part, index) => {
-      if (part.startsWith(':')) {
-        // パラメータのキーを抽出（例: :nickname -> nickname）
-        const paramName = part.slice(1);
-        params[paramName] = currentPathParts[index];  // パラメータを格納
-        return true;
-      }
-      return part === currentPathParts[index];
-    });
-  });
+        // パスの各部分を比較
+        const isMatch = await comparePathParts(routeParts, currentPathParts, params);
+        if (isMatch) {
+          return { ...route, params };
+        }
+        return null;
+      })
+  );
 
-  if (matchedRoute) {
-    matchedRoute.params = params;
-    matchedRoute.queryParams = new URLSearchParams(window.location.search);
-    return matchedRoute;
+  const foundRoute = matchedRoute.find(route => route !== null);
+
+  if (foundRoute) {
+    foundRoute.queryParams = new URLSearchParams(window.location.search);
+    if (DEBUG_LOG) { console.log(` matchedRoute -> ` + foundRoute.path); }
+    return foundRoute;
   } else {
     // routeTableに存在しないpathの場合、Guest, Userともにtopを表示
     // todo: URLとinnerHTMLが乖離 -> URLも/app/に切り替えるべきか？
+    if (DEBUG_LOG) { console.log(` NO matchedRoute -> top`); }
+    if (DEBUG_LOG) { console.log(`---------------------------------`); }
     return routeTable['top'];
   }
 };
@@ -60,7 +90,7 @@ export const getSelectedRoute = (currentPath, routeTable) => {
 
 async function getView(path) {
   // 選択されたルートを取得
-  const selectedRoute = getSelectedRoute(path, routeTable);
+  const selectedRoute = await getSelectedRoute(path, routeTable);
   // console.log("renderView: selectedRoute.path: " + selectedRoute.path)
 
   // 選択されたルートに対応するビューをインスタンス化して、paramsを渡す
@@ -85,7 +115,7 @@ export const renderView = async (path) => {
   // --------------------------
   // ここから今回のviewに対する処理
   // viewクラスの指定とメソッド呼び出し
-  const selectedRoute = getSelectedRoute(path, routeTable);
+  const selectedRoute = await getSelectedRoute(path, routeTable);
   const view = new selectedRoute.view(selectedRoute.params);
   currentView = view;
   const htmlSrc = await view.getHtml();

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -6,7 +6,7 @@ import { setOnlineStatus } from "/static/accounts/js/setOnlineStatus.js";
 import { isValidParam } from "../utility/isValidParam.js"
 
 const DEBUG_DETAIL = 0;
-const DEBUG_LOG = 1;
+const DEBUG_LOG = 0;
 
 // touteTable.jsの記述について
 // game3d: { path: "/app/game/game-3d/", view: Game3D }は、/app/game/game-3d/というパスに対してGame3Dという「クラス」を対応

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/renderView.js
@@ -31,7 +31,7 @@ const comparePathParts = async (routeParts, currentPathParts, params) => {
         if (part.startsWith(':')) {
           // パラメータのキーを抽出（例: :nickname -> nickname）
           const paramName = part.slice(1);
-            if (DEBUG_LOG) { console.log(`    parameter name  : ${paramName}`); }
+          if (DEBUG_LOG) { console.log(`    parameter name  : ${paramName}`); }
 
           // パラメータの整合性を評価
           const isValid = await isValidParam(paramName, currentPathParts[index]);
@@ -39,6 +39,7 @@ const comparePathParts = async (routeParts, currentPathParts, params) => {
               if (DEBUG_LOG) { console.log(`    -> parameter invalid`); }
             return false;
           }
+          if (DEBUG_LOG) { console.log(`    -> parameter valid`); }
 
           params[paramName] = currentPathParts[index];  // パラメータを格納
             if (DEBUG_LOG) { console.log(`    currentPathParts: ${currentPathParts[index]}`); }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -56,7 +56,7 @@ export const routeTable = {
 
   friends       : { path: "/app/user/friends/",               view: Friends },
   dmSessions    : { path: "/app/dm/",                         view: DMSessions },
-  dmWithUser    : { path: "/app/dm/:userId/",                 view: DMwithUser },
+  dmWithUser    : { path: "/app/dm/:dmTargetId/",             view: DMwithUser },
   dmWithUserBase: { path: "/app/dm/",                         view: DMwithUser },
 
   editProfile   : { path: "/app/user/profile/edit/",          view: EditProfile },

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/routeTable.js
@@ -51,7 +51,7 @@ export const routeTable = {
 
   // user
   userProfile   : { path: "/app/user/profile/",               view: UserProfile },  // private profile
-  userInfo      : { path: "/app/user/info/:nickname/",        view: UserInfo },     // public profile
+  userInfo      : { path: "/app/user/info/:userId/",          view: UserInfo },     // public profile
   userInfoBase  : { path: "/app/user/info/",                  view: UserInfo },
 
   friends       : { path: "/app/user/friends/",               view: Friends },

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
@@ -1,0 +1,20 @@
+
+const DEBUG_LOG = 1;
+
+async function isValidUserId(userId) {
+    try {
+        const response = await fetch(`/accounts/api/is-valid-id/${userId}/`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        });
+        const data = await response.json();
+        if (DEBUG_LOG) { console.log(`      isValidUserId ->` + data.exists); }
+        return data.exists;
+    } catch (error) {
+        if (DEBUG_LOG) { console.log(`      isValidUserId -> error, false`); }
+        console.error('hth: Error:', error);
+        return false;
+    }
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
@@ -19,11 +19,34 @@ async function isValidUserId(userId) {
     }
 }
 
+async function isValidDmTargetId(dmTargetId) {
+    try {
+        const response = await fetch(`/chat/api/is-valid-dm-target-id/${dmTargetId}/`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        });
+        const data = await response.json();
+        if (DEBUG_LOG) { console.log(`      isValidDmTargetId ->` + data.exists); }
+        return data.exists;
+    } catch (error) {
+        if (DEBUG_LOG) { console.log(`      isValidDmTargetId -> error, false`); }
+        console.error('hth: Error:', error);
+        return false;
+    }
+}
+
 
 // URLパラメータの整合性を評価
+// :userId
+// :dmTargetId
 export const isValidParam = async (paramName, paramValue) => {
     if (paramName === "userId") {
         return await isValidUserId(paramValue)
+    }
+    if (paramName === "dmTargetId") {
+        return await isValidDmTargetId(paramValue)
     }
     return false;
 }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
@@ -18,3 +18,12 @@ async function isValidUserId(userId) {
         return false;
     }
 }
+
+
+// URLパラメータの整合性を評価
+export const isValidParam = async (paramName, paramValue) => {
+    if (paramName === "userId") {
+        return await isValidUserId(paramValue)
+    }
+    return false;
+}

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
@@ -1,5 +1,5 @@
 
-const DEBUG_LOG = 1;
+const DEBUG_LOG = 0;
 
 async function isValidMatchId(matchId) {
     try {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/utility/isValidParam.js
@@ -1,6 +1,24 @@
 
 const DEBUG_LOG = 1;
 
+async function isValidMatchId(matchId) {
+    try {
+        const response = await fetch(`/pong/api/is-valid-match-id/${matchId}/`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        });
+        const data = await response.json();
+        if (DEBUG_LOG) { console.log(`      isValidMatchId ->` + data.exists); }
+        return data.exists;
+    } catch (error) {
+        if (DEBUG_LOG) { console.log(`      isValidMatchId -> error, false`); }
+        console.error('hth: Error:', error);
+        return false;
+    }
+}
+
 async function isValidUserId(userId) {
     try {
         const response = await fetch(`/accounts/api/is-valid-id/${userId}/`, {
@@ -39,13 +57,20 @@ async function isValidDmTargetId(dmTargetId) {
 
 
 // URLパラメータの整合性を評価
+// :matchId (タイミングにより使用不可となる可能性あり -> Django view関数のリダイレクトを使用)
 // :userId
 // :dmTargetId
 export const isValidParam = async (paramName, paramValue) => {
+    if (paramName === "matchId") {
+        if (DEBUG_LOG) { console.log(`     isValidParam: paramName:${paramName}, paramValue:${paramValue}`); }
+        return await isValidMatchId(paramValue)
+    }
     if (paramName === "userId") {
+        if (DEBUG_LOG) { console.log(`     isValidParam: paramName:${paramName}, paramValue:${paramValue}`); }
         return await isValidUserId(paramValue)
     }
     if (paramName === "dmTargetId") {
+        if (DEBUG_LOG) { console.log(`     isValidParam: paramName:${paramName}, paramValue:${paramValue}`); }
         return await isValidDmTargetId(paramValue)
     }
     return false;

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
@@ -14,7 +14,7 @@ export default class extends AbstractView {
   }
 
   async getHtml() {
-    const userId = this.params.userId;
+    const userId = this.params.dmUserId;
     const uri = `/chat/dm-with/${userId}/`;
     const data = await fetchData(uri);
     //console.log("Pong:" + data);

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/chat/DMwithUser.js
@@ -14,8 +14,8 @@ export default class extends AbstractView {
   }
 
   async getHtml() {
-    const userId = this.params.dmUserId;
-    const uri = `/chat/dm-with/${userId}/`;
+    const targetId = this.params.dmTargetId;
+    const uri = `/chat/dm-with/${targetId}/`;
     const data = await fetchData(uri);
     //console.log("Pong:" + data);
     return data;

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/views/user/UserInfo.js
@@ -14,8 +14,8 @@ export default class extends AbstractView {
     }
 
     async getHtml() {
-        const nickname = this.params.nickname;
-        const uri = `/accounts/info/${nickname}/`;
+        const userId = this.params.userId;
+        const uri = `/accounts/info/${userId}/`;
         const data = await fetchData(uri);
         return data;
     }

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
@@ -4,7 +4,6 @@
 
   "kSpaTournamentUrl"   : "/app/game/tournament/",
   "kSpaGame2D"          : "/app/game/game-2d/",
-  "kSpaGame3D"          : "/app/game/game-3d/",
   "kSpaGameMatchBase"   : "/app/game/match/",
   "kSpaGameMatchUrl"    : "/app/game/match/:matchId/",
 

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
@@ -17,7 +17,7 @@
   "kSpaChangeAvatarUrl" : "/app/user/profile/change-avatar/",
 
   "kSpaDmUrl"           : "/app/dm/",
-  "kSpaDmWithUrl"       : "/app/dm/:userId/",
+  "kSpaDmWithUrl"       : "/app/dm/:dmTargetId/",
   "kSpaDmWithUrlBase"   : "/app/dm/",
 
   "kSpaAuthEnable2FaUrl": "/app/auth/enable-2fa/",

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/json/urlConfig.json
@@ -10,7 +10,7 @@
 
   "kSpaGameHistoryUrl"  : "/app/user/game-history/",
   "kSpaUserProfileUrl"  : "/app/user/profile/",
-  "kSpaUserInfoUrl"     : "/app/user/info/:nickname/",
+  "kSpaUserInfoUrl"     : "/app/user/info/:userId/",
   "kSpaUserInfoUrlBase" : "/app/user/info/",
   "kSpaUserFriendUrl"   : "/app/user/friends/",
   "kSpaEditProfileUrl"  : "/app/user/profile/edit/",

--- a/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/__init__.py
@@ -67,7 +67,7 @@ class TestConfig(LiveServerTestCase):
         self.top_url            = f"{kURL_PREFIX}{self.url_config['kSpaPongTopUrl']}"
 
         self.game_2d_url        = f"{kURL_PREFIX}{self.url_config['kSpaGame2D']}"
-        self.game_3d_url        = f"{kURL_PREFIX}{self.url_config['kSpaGame3D']}"
+        # self.game_3d_url        = f"{kURL_PREFIX}{self.url_config['kSpaGame3D']}"
         self.tournament_url     = f"{kURL_PREFIX}{self.url_config['kSpaTournamentUrl']}"
 
         self.game_history_url   = f"{kURL_PREFIX}{self.url_config['kSpaGameHistoryUrl']}"

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_block.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_block.py
@@ -14,13 +14,17 @@ class DMTest(TestConfig):
         self.password = "pass0123"
 
         # friend request用のtest_user1, test_user2を作成
-        self._create_new_user(email=self.test_user1_email,
-                              nickname=self.test_user1_nickname,
-                              password=self.password)
+        self.user1_id, _ = self._create_new_user(
+            email=self.test_user1_email,
+            nickname=self.test_user1_nickname,
+            password=self.password
+        )
 
-        self._create_new_user(email=self.test_user2_email,
-                              nickname=self.test_user2_nickname,
-                              password=self.password)
+        self.user2_id, _ = self._create_new_user(
+            email=self.test_user2_email,
+            nickname=self.test_user2_nickname,
+            password=self.password
+        )
 
     ############################################################################
 
@@ -41,7 +45,7 @@ class DMTest(TestConfig):
         # self._screenshot("block 2")
 
         # test_user2のinfo pageへアクセスし、block
-        self._block_user(self.test_user2_nickname)
+        self._block_user(self.test_user2_nickname, self.user2_id)
         # self._screenshot("block 3")
 
         # DMへ遷移し、dm-log要素が非表示であることを確認
@@ -52,7 +56,7 @@ class DMTest(TestConfig):
         # self._screenshot("block 4")
 
         # test_user2のinfo pageへアクセスし、unblock
-        self._unblock_user(self.test_user2_nickname)
+        self._unblock_user(self.test_user2_nickname, self.user2_id)
 
         # DMへ遷移し、dm-log要素が非表示であることを確認
         self._move_top_to_dm()
@@ -72,15 +76,15 @@ class DMTest(TestConfig):
         except Exception:
             return False
 
-    def _block_user(self, target_nickname):
-        self._access_to(f"{self.user_info_base_url}{target_nickname}/")
+    def _block_user(self, target_nickname, target_id):
+        self._access_to(f"{self.user_info_base_url}{target_id}/")
 
         block_button = self._button(By.CSS_SELECTOR, ".blockUserButton")
         self._click_button(block_button, wait_for_button_invisible=False)
         self._close_alert(f"User {target_nickname} successfully blocked")
 
-    def _unblock_user(self, target_nickname):
-        self._access_to(f"{self.user_info_base_url}{target_nickname}/")
+    def _unblock_user(self, target_nickname, target_id):
+        self._access_to(f"{self.user_info_base_url}{target_id}/")
 
         unblock_button = self._button(By.CSS_SELECTOR, ".unBlockUserButton")
         self._click_button(unblock_button, wait_for_button_invisible=False)

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_friend.py
@@ -16,13 +16,17 @@ class FriendTest(TestConfig):
         self.password = "pass0123"
 
         # friend request用のtest_user1, test_user2を作成
-        self._create_new_user(email=self.test_user1_email,
-                              nickname=self.test_user1_nickname,
-                              password=self.password)
+        self.user1_id, _ = self._create_new_user(
+            email=self.test_user1_email,
+            nickname=self.test_user1_nickname,
+            password=self.password
+        )
 
-        self._create_new_user(email=self.test_user2_email,
-                              nickname=self.test_user2_nickname,
-                              password=self.password)
+        self.user2_id, _ = self._create_new_user(
+            email=self.test_user2_email,
+            nickname=self.test_user2_nickname,
+            password=self.password
+        )
 
     ############################################################################
 
@@ -42,7 +46,7 @@ class FriendTest(TestConfig):
         # self._screenshot("friend1")
 
         # test_user2のinfo pageへアクセスし、friend requestを送信
-        self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
+        self._access_to(f"{self.user_info_base_url}{self.user2_id}/")
         # self._screenshot("friend2")
 
         request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
@@ -61,7 +65,7 @@ class FriendTest(TestConfig):
         send_to_user2_item = sent_requests_div.find_element(By.XPATH, f".//li[contains(., '{self.test_user2_nickname}')]")
         cancel_button = send_to_user2_item.find_element(By.CSS_SELECTOR, ".cancelButton")
         info_link = send_to_user2_item.find_element(By.LINK_TEXT, f"{self.test_user2_nickname}")
-        self.assertEqual(info_link.get_attribute("href"), f"{self.user_info_base_url}{self.test_user2_nickname}/")
+        self.assertEqual(info_link.get_attribute("href"), f"{self.user_info_base_url}{self.user2_id}/")
         # self._screenshot("friend4")
 
         # test_user1をlogout
@@ -94,7 +98,7 @@ class FriendTest(TestConfig):
         delete_button = friend_item.find_element(By.CSS_SELECTOR, ".deleteButton")
         # friend nameのlink: info page
         user_name_link_url = self._text_link_url(self.test_user1_nickname)
-        self.assertEqual(user_name_link_url, f"{self.user_info_base_url}{self.test_user1_nickname}/")
+        self.assertEqual(user_name_link_url, f"{self.user_info_base_url}{self.user1_id}/")
 
         # delete buttonのチェック
         # ConfirmでCancelしDelete中断
@@ -123,7 +127,7 @@ class FriendTest(TestConfig):
         self._login(email=self.test_user1_email, password=self.password)
 
         # test_user2 info page #################################################
-        self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
+        self._access_to(f"{self.user_info_base_url}{self.user2_id}/")
 
         # requestを送信
         request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")
@@ -166,7 +170,7 @@ class FriendTest(TestConfig):
         # self._screenshot("friend1")
 
         # test_user2のinfo pageへアクセスし、friend requestを送信
-        self._access_to(f"{self.user_info_base_url}{self.test_user2_nickname}/")
+        self._access_to(f"{self.user_info_base_url}{self.user2_id}/")
         # self._screenshot("friend2")
 
         request_button = self._button(By.CSS_SELECTOR, ".sendFriendRequestButton")

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -52,7 +52,7 @@ class UrlAccessTest(TestConfig):
                               nickname=self.user2_nickname,
                               password=self.password)
 
-        self.set_up_key = self._create_new_user(
+        _, self.set_up_key = self._create_new_user(
                               email=self.user3_email,
                               nickname=self.user3_nickname,
                               password=self.password,

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_url_access.py
@@ -6,7 +6,7 @@ HomePage         = "kSpaHomeUrl"
 
 TournamentPage   = "kSpaTournamentUrl"
 Game2D           = "kSpaGame2D"
-Game3D           = "kSpaGame3D"
+# Game3D           = "kSpaGame3D"
 GameMatchBase    = "kSpaGameMatchBase"
 GameMatchPage    = "kSpaGameMatchUrl"
 
@@ -44,19 +44,24 @@ class UrlAccessTest(TestConfig):
 
         self.password = "pass0123"
 
-        self._create_new_user(email=self.user1_email,
-                              nickname=self.user1_nickname,
-                              password=self.password)
+        self.user1_id, _ = self._create_new_user(
+            email=self.user1_email,
+            nickname=self.user1_nickname,
+            password=self.password
+        )
 
-        self._create_new_user(email=self.user2_email,
-                              nickname=self.user2_nickname,
-                              password=self.password)
+        self.user2_id, _ = self._create_new_user(
+            email=self.user2_email,
+            nickname=self.user2_nickname,
+            password=self.password
+        )
 
-        _, self.set_up_key = self._create_new_user(
-                              email=self.user3_email,
-                              nickname=self.user3_nickname,
-                              password=self.password,
-                              is_enable_2fa=True)
+        self.user3_id, self.set_up_key = self._create_new_user(
+            email=self.user3_email,
+            nickname=self.user3_nickname,
+            password=self.password,
+            is_enable_2fa=True
+        )
 
     ############################################################################
 
@@ -183,16 +188,18 @@ class UrlAccessTest(TestConfig):
             GameMatchPage,
             UserInfoPage,
             DmWithPage,
+            UserInfoUrlBase,  # login->app遷移, except追加
+            DmWithUrlBase,  # login->app遷移, except追加
         }
         return page_name in except_test_pages
 
     def _is_page_login_required(self, page_name):
         login_required_pages = {
             TournamentPage,
-            Game3D,
+            # Game3D,
             GameHistoryPage,
             UserProfilePage,
-            UserInfoUrlBase,  # :nicknameを置き換えるためにUrlBaseでテスト
+            UserInfoUrlBase,  # :nicknameを置き換えるためにUrlBaseでテスト  login->app遷移
             UserFriendPage,
             EditProfilePage,
             ChangeAvatarPage,
@@ -229,7 +236,7 @@ class UrlAccessTest(TestConfig):
         """
         url_with_param_pages = {
             UserInfoUrlBase,
-            # DmWithUrlBase,  # /url/<user_id>/ に変更, id取得必要のためテストNG
+            DmWithUrlBase,  # /url/<user_id>/ に変更, id取得必要のためテストNG
         }
         return page_name in url_with_param_pages
 
@@ -459,7 +466,7 @@ class UrlAccessTest(TestConfig):
 
     def _get_url(self, page_name, page_path):
         if self._is_url_with_param(page_name):
-            url = f"{kURL_PREFIX}{page_path}{self.user2_nickname}/"
+            url = f"{kURL_PREFIX}{page_path}{self.user2_id}/"
         else:
             url = f"{kURL_PREFIX}{page_path}"
         return url


### PR DESCRIPTION
## 概要
- URLの検証を追加しました。不正なURL, parameterであれば`/app/`に画面、URL共に遷移するようになっていると思います
- ルーター周りの負債が蓄積してきた感が否めません...他の最低限の要件を確実にクリアしてから、リファクタリングしたいと思っています
- PRの新規実装・変更が2-300行、テストが300行程度だと思います。テスト追加＆修正で変更が大きめに出ています。
- 主な検証パラメータはAPIテストに記載しています 1563c3a bc968a5 41fd87c

<br>

### URLパラメータの整合性評価を追加
- `/url/:intParam/`に文字列で表示バグ（`/app/game/match/hoge/`, `/app/dm/hoge/`）
  - Djangoのルーティングでintが期待されているため、文字列の入力で404に飛ばされているらしい
- `int` -> `str`とし、`int(intParam)`の変換で整数でなければtopに飛ばすなどの処理を追加。とりあえず何かしら表示されるようになった。 b502189
- djangoのviewで遷移するとルーター経由しないため、表示内容やURLに不整合が生じる。getSelectedRoute()でパラメータの整合性を評価し、不正なURLの場合 `/app/invalid/` -> `/app/` に変更  4c150e6
  - UserInfo: userIdの判定  a4de784
  - DM: dmUserIdの判定  0376e60
  - Tournament: matchIdの判定  2444a6e

<br>

### 不正なURLの取り扱いを修正
- `/app/invalid-url/` -> `/app/`
  - routeTableにマッチしない不正なURLは`getNextPath()`でtopを返すよう変更。不正なURLの場合は`getSelectedRoute()`がTOPを返すことを利用しているが、この関数を複数回呼ぶのは違和感。余裕があればリファクタリングしたいが...  9f0d645

<br>

### URLパラメータをnickname -> idベースに変更（リンク変更漏れの修正含む）
- `/user-info/<nickname>/` -> `/user-info/<user_id>/`  fbcd948
- UserInfo: DM withのURLをidに変更  a7b0631

<br>

### memo
- 余力があれば、login userの場合に、DMのinvalidは`/dm/`, matchIdのinvalidは`/tournament/`に遷移させたいです。ゲストの場合はapp or login遷移の分岐があり、少々面倒なので未着手です。
- django view <-> JSの往復が冗長感が否めません...（ 初めからJSメインで実装しておくべきだったのか？）
- APIでURLパラメータ(userIdなど)の判定を行っているため、consoleに400や401が出てきます
