### PR TITLE
#280の後：本日プルリク２回目的なもの:endBtnにnulllのバグある

### DIFF
--- a/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/online/PongOnlineRenderer.js
@@ -39,21 +39,50 @@ class PongOnlineRenderer
 	}
 
 
+	isObj(ctx, field, gameState)
+	{
+		if (!ctx || !field || !gameState){
+			console.warn('hth: render(): ctx, field, or gameState is null');
+			return false;
+		}
+		if (!gameState.objects || !gameState.objects.paddle1 || !gameState.objects.paddle2 || !gameState.objects.ball) {
+			console.warn('hth: render(): gameState.objects or its properties are null');
+			return false;
+		}
+		if (!gameState.state) {
+			console.warn('hth: render(): gameState.state is null');
+			return false;
+		}
+		return true;
+	}
+
+
 	render(ctx, field, gameState) 
 	{	
-		try {
-			this._clearField(ctx, field);
-			this._drawPaddle(ctx, gameState.objects.paddle1);
-			this._drawPaddle(ctx, gameState.objects.paddle2);
-			this._drawBall(ctx, gameState.objects.ball);
-			this._drawScore(ctx, field, gameState.state);
-
+		try 
+		{
+			if (this.isObj(ctx, field, gameState)) {
+				this._clearField(ctx, field);
+			}
+			if (this.isObj(ctx, field, gameState)) {
+				this._drawPaddle(ctx, gameState.objects.paddle1);
+			}
+			if (this.isObj(ctx, field, gameState)) {
+				this._drawPaddle(ctx, gameState.objects.paddle2);
+			}
+			if (this.isObj(ctx, field, gameState)) {
+				this._drawBall(ctx, gameState.objects.ball);
+			}
+			if (this.isObj(ctx, field, gameState)) {
+				this._drawScore(ctx, field, gameState.state);
+			}
 					if (TEST_TRY2){	throw new Error('TEST_TRY2');	}
 		} catch(error) {
 			console.error("hth: render() failed: ", error);
 			pongOnlineHandleCatchError(error);
 		}
 	}
+
 
 	// ウインドウのサイズに合わせて動的に描画サイズを変更
 	resizeForAllDevices() 
@@ -207,6 +236,7 @@ class PongOnlineRenderer
 			pongOnlineHandleCatchError(error);
 		}
 	}
+
 
 	dispose() {
 		this.gameStateManager = null;

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
@@ -3,6 +3,8 @@ import TournamentManager	from './manager/TournamentManager.js';
 import UserManager			from './manager/UserManager.js';
 import RoundManager			from './manager/RoundManager.js';
 import TournamentCreator	from './components/TournamentCreator.js';
+import { routeTable } from "/static/spa/js/routing/routeTable.js";
+import { switchPage } from "/static/spa/js/routing/renderView.js"
 
 const DEBUG_FLOW	= 0;
 const DEBUG_DETAIL	= 0;
@@ -23,6 +25,21 @@ export function setupTournament() {
 				if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 	} catch(error) {
 		console.error("hth: setupTournament: ", error);
+		tournamentHandleCatchError(error);
 	}
 
+}
+
+// ---------------------------------------
+// error
+// ---------------------------------------
+export function tournamentHandleCatchError(error = null) 
+{
+	// location.hrefでSPAの状態を完全にリセットする
+	if (error) {
+		alert("エラーが発生しました。トップページに遷移します。 error: " + error);
+	} else {
+		alert("エラーが発生しました。トップページに遷移します。");
+	}
+	window.location.href = routeTable['top'].path;
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentMain.js
@@ -27,7 +27,6 @@ export function setupTournament() {
 		console.error("hth: setupTournament: ", error);
 		tournamentHandleCatchError(error);
 	}
-
 }
 
 // ---------------------------------------

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -2,7 +2,7 @@
 import UIHelper		from '../UIHelper.js';
 import { config }	from '../ConfigTournament.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
-import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { switchPage } from "/static/spa/js/routing/renderView.js";
 
 
 class TournamentCreator 
@@ -43,7 +43,7 @@ class TournamentCreator
 		// TODO_ft:onsubmit="signupUser(event)"削除する
 		return `
 		<div class="form-sign m-auto" id="tournament-create-form">
-				<form class="hth-sign-form" onsubmit="signupUser(event)">
+				<form class="hth-sign-form">
 					<h2 class="slideup-text mb-3">Create Tournament</h2>
 					
 					<input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -12,7 +12,7 @@ const TEST_TRY2 		= 0;
 const TEST_TRY3 		= 0;
 const TEST_TRY4 		= 0;
 const TEST_TRY5 		= 0;
-const TEST_TRY6 		= 1;
+const TEST_TRY6 		= 0;
 
 class TournamentCreator 
 {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -167,16 +167,36 @@ class TournamentCreator
 					.map(input => input.value.trim());
 	}
 	
+	/**
+	 * APIのvalidationの詳細: docker/srcs/uwsgi-django/pong/models.py
+	 */
 	_validateFormInputs(nicknames) 
 	{
-		// トーナメント名が未入力の場合
-		if (!this.form.elements['name'].value) {
-			return { isValid: false, errorMessage: 'Tournament name is required.' };
+		// トーナメント名が3文字以上30文字以下の英数字であることを確認
+		const tournamentName = this.form.elements['name'].value.trim();
+		if (!tournamentName || tournamentName.length < 3 || tournamentName.length > 30 || !/^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$/.test(tournamentName)) {
+			return { isValid: false, errorMessage: 'Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long.' };
 		}
-		// ８箇所すべてのニックネームが入力されているかをチェック
-		if (nicknames.length < 8 || nicknames.includes('')) {
-			return { isValid: false, errorMessage: 'All 8 nicknames are required.' };
+	
+		// // トーナメント名が未入力の場合
+		// if (!this.form.elements['name'].value) {
+		// 	return { isValid: false, errorMessage: 'Tournament name is required.' };
+		// }
+
+		// すべて(8つ)のニックネームが3文字以上30文字以下の英数字であることを確認
+		if (nicknames.length !== 8 || !nicknames.every(nickname => nickname.length >= 3 && nickname.length <= 30 && /^[A-Za-z0-9]+$/.test(nickname))) {
+			return { isValid: false, errorMessage: 'All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long.' };
 		}
+		
+		// ニックネームがすべてユニークであることを確認（Setは重複不可）
+		if (new Set(nicknames).size !== 8) {
+			return { isValid: false, errorMessage: 'All 8 nicknames must be unique.' };
+		}
+
+		// // ８箇所すべてのニックネームが入力されているかをチェック
+		// if (nicknames.length < 8 || nicknames.includes('')) {
+		// 	return { isValid: false, errorMessage: 'All 8 nicknames are required.' };
+		// }
 		return { isValid: true };
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -3,7 +3,16 @@ import UIHelper		from '../UIHelper.js';
 import { config }	from '../ConfigTournament.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js";
+import { tournamentHandleCatchError } from "../TournamentMain.js";
 
+const DEBUG_FLOW		= 0;
+const DEBUG_DETAIL		= 0;
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
+const TEST_TRY3 		= 0;
+const TEST_TRY4 		= 0;
+const TEST_TRY5 		= 0;
+const TEST_TRY6 		= 1;
 
 class TournamentCreator 
 {
@@ -17,25 +26,34 @@ class TournamentCreator
 
 	}
 
+
 	/** Public method: トーナメントの新規作成用フォームを作成 */
 	createForm(userProfile) 
 	{
-		UIHelper.displayUserInfo(userProfile, this.userInfoContainer);
-		// フォーム要素を作成し、プロパティを設定
-		this.form			= document.createElement('form');
-		this.form.method	= 'post';
-		this.form.action	= config.API_URLS.tournamentCreate;
-		this.form.organizer	= userProfile.id;
-		// フォームのHTML内容を生成して設定
-		this.form.innerHTML	= this._generateFormHTML(UIHelper.getCSRFToken(), userProfile.nickname);
-		// .htmlの<div>にフォームを追加
-		this.tournamentForm.appendChild(this.form);
-		// UTC ISO8601:"YYYY-MM-DDTHH:MM:SS.sssZ"
-		this.form.elements['date'].value = new Date().toISOString();
-		// ボタンクリックでhandleSubmit()を呼び出す
-		// removeについて: tournamentForm 要素が DOM から削除 > その子要素であるフォームも一緒に削除 > フォームに登録されていたイベントリスナーも自動で削除
-		this.form.addEventListener('submit', e => this._saveTournament(e));
+		try{
+			UIHelper.displayUserInfo(userProfile, this.userInfoContainer);
+			// フォーム要素を作成し、プロパティを設定
+			this.form			= document.createElement('form');
+			this.form.method	= 'post';
+			this.form.action	= config.API_URLS.tournamentCreate;
+			this.form.organizer	= userProfile.id;
+			// フォームのHTML内容を生成して設定
+			this.form.innerHTML	= this._generateFormHTML(UIHelper.getCSRFToken(), userProfile.nickname);
+			// .htmlの<div>にフォームを追加
+			this.tournamentForm.appendChild(this.form);
+			// UTC ISO8601:"YYYY-MM-DDTHH:MM:SS.sssZ"
+			this.form.elements['date'].value = new Date().toISOString();
+			// ボタンクリックでhandleSubmit()を呼び出す
+			// removeについて: tournamentForm 要素が DOM から削除 > その子要素であるフォームも一緒に削除 > フォームに登録されていたイベントリスナーも自動で削除
+			this.form.addEventListener('submit', e => this._saveTournament(e));
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
+		} catch (error) {
+			console.error("hth: TournamentManager.main() failed", error);
+			// this.tournamentContainer.textContent = "Error loading your information. Try again later.";
+			tournamentHandleCatchError(error);
+		}
 	}
+
 
 	/** form部分のhtml*/
 	_generateFormHTML(csrfToken, organizerNickname)
@@ -98,25 +116,30 @@ class TournamentCreator
 		</div>
 		`;
 	}
+
+
 	/** トーナメントを保存する */
 	async _saveTournament(event) 
 	{
-		// イベントのデフォルトの動作をキャンセル: フォームの送信によるページの再読み込みをキャンセルする
-		event.preventDefault();
-		// フォームに関連するメッセージをクリア
-		UIHelper.clearContainer(this.errorMessage);
-		UIHelper.clearContainer(this.submitMessage);
-
-		const nicknames			= this._getNicknames();
-		const validationResult	= this._validateFormInputs(nicknames);
-
-		if (!validationResult.isValid) 
-		{
-			UIHelper.putError(validationResult.errorMessage, this.errorMessage);
-			return;
-		}
-
 		try {
+
+			// イベントのデフォルトの動作をキャンセル: フォームの送信によるページの再読み込みをキャンセルする
+			event.preventDefault();
+			// フォームに関連するメッセージをクリア
+			UIHelper.clearContainer(this.errorMessage);
+			UIHelper.clearContainer(this.submitMessage);
+
+			const nicknames			= this._getNicknames();
+			const validationResult	= this._validateFormInputs(nicknames);
+
+						if (TEST_TRY2) {	validationResult.isValid = false;	}
+			if (!validationResult.isValid) 
+			{
+				// UIHelper.putError(validationResult.errorMessage, this.errorMessage);
+				alert('You cannot create: ', validationResult.errorMessage)
+				return;
+			}
+
 			// 進行中のトーナメントの判定を行い、なければ作成する。二重登録防止
 			const isOngoing = await this._isOngoingTournaments();
 			if (isOngoing) 
@@ -127,11 +150,15 @@ class TournamentCreator
 				await this._processFormSubmission(nicknames);
 				
 			}
+						if (TEST_TRY3) {	throw new Error('TEST_TRY3');	}
 		} catch (error) {
-			UIHelper.putError('Error processing your request. Please try again.', this.errorMessage);
+			console.error('hth: _saveTournament() failed');
+			tournamentHandleCatchError(error);
+			// throw error;
 		}
 	}
 	
+
 	// フォームからすべてのニックネーム入力フィールドを取得し、それらを配列に変換
 	// .map(input => input.value.trim());: 各ニックネーム入力フィールドの値から前後の空白を取り除いた配列を作成
 	_getNicknames() 
@@ -156,51 +183,53 @@ class TournamentCreator
 	// 進行中のトーナメントを確認する関数
 	async _isOngoingTournaments() {
 		try {
+						if (TEST_TRY4) {	throw new Error('TEST_TRY4');	}
+
 			const response = await fetch(this.API_URLS.ongoingLatestTour);
 
+
 			// 見つからない場合でも、viewは204を返す。ここはそれ以外のエラーの場合の判定
-			// 見つからない場合のviewの戻り値: return JsonResponse({'status': 'success', 'message': 'No ongoing tournaments found'}, status=200)
 			if (!response.ok) {
 				throw new Error(`hth: Failed to fetch ongoing tournaments with status: ${response.status}`);
 			}
 			if (response.status === 204) {
-				// console.log('No ongoing tournaments found, received 204 No Content');
 				return null;
 			}
 			const result = await response.json();
 			// result.tournamentが存在する場合はtrueを、それ以外の場合はfalseを返す
 			return !!result.tournament;
 		} catch (error) {
-			console.error('hth: Error checking ongoing tournaments:', error);
-			return false;
+			console.error('hth: _isOngoingTournaments() failed: ', error);
+			tournamentHandleCatchError(error);
 		}
 	}
 	
 	/** 入力フォームの値をAPIにPOST */
 	async _processFormSubmission(nicknames)
 	{
-		// player_nicknamesという名前でニックネームの配列をFormDataに追加
-		// ニックネームの配列はJSON形式に変換
-		const formData = new FormData(this.form);
-		formData.append('player_nicknames', JSON.stringify(nicknames));
 		try {
+						if (TEST_TRY5) {	throw new Error('TEST_TRY5');	}
+			// player_nicknamesという名前でニックネームの配列をFormDataに追加
+			// ニックネームの配列はJSON形式に変換
+			const formData = new FormData(this.form);
+			formData.append('player_nicknames', JSON.stringify(nicknames));
 			const response = await fetch(this.form.action, {
 				method: 'POST',
 				body: formData,
 			});
 	
 			const data = await response.json(); 
+						if (TEST_TRY6) {	response = 404;	}
 			if (!response.ok) {
 				// APIの返すメッセージを使用する
+				// エラーを再 throw する
 				throw new Error(data.message);
 			}
-	
 			UIHelper.handleSuccess('Tournament successfully', routeTable["top"].path, this.submitMessage)
 			switchPage(routeTable["tournament"].path)
-
 		} catch (error) {
-			console.error('Fetch error:', error);
-			UIHelper.putError(error, this.errorMessage);
+			console.error('hth: _processFormSubmission() failed:', error);
+			tournamentHandleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentDeleter.js
@@ -3,7 +3,10 @@ import UIHelper		from '../UIHelper.js';
 import { config }	from '../ConfigTournament.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
 import { switchPage } from "/static/spa/js/routing/renderView.js"
+// import { tournamentHandleCatchError } from "../TournamentMain.js";
 
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
 
 class TournamentDeleter 
 {
@@ -16,9 +19,8 @@ class TournamentDeleter
 
 	async deleteTournament(tournamentId) 
 	{
-		// console.log(`Deleting tournament ID: ${tournamentId}`);
-
 		try {
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 			const response = await fetch(`${this.API_URLS.tournamentDelete}${tournamentId}/`, 
 			{
 				method: 'POST',
@@ -37,15 +39,19 @@ class TournamentDeleter
 			}
 
 			const data = await response.json();
+						if (TEST_TRY2) {	data.status = 404;	}
 			if (data.status === 'success') {
 				UIHelper.handleSuccess('Tournament deleted successfully', routeTable["top"].path, this.submitMessage)
 				switchPage(routeTable["tournament"].path)
 
 			} else {
 				UIHelper.putError("No data returned. Please try again later.", this.errorMessage);
+				alert("No data returned. Please try again later.", this.errorMessage);
+
 			}
 		} catch (error) {
 			UIHelper.putError("Failed to delete the tournament. Please try again.", this.errorMessage);
+			alert("Failed to delete the tournament. Please try again.", this.errorMessage);
 		}
 	}
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
@@ -3,6 +3,11 @@ import UIHelper				from '../UIHelper.js';
 import { config }			from '../ConfigTournament.js';
 import TournamentDeleter	from './TournamentDeleter.js';
 import TournamentOverview	from './TournamentOverview.js';
+import { tournamentHandleCatchError } from "../TournamentMain.js";
+
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
+const TEST_TRY3 		= 0;
 
 /** 
  * トーナメントの入り口のページを構築 
@@ -28,29 +33,41 @@ class TournamentEntry
 	/** 注意: appendChildの順番は上から順番で追加される。 */
 	async display(ongoingTournament, userProfile) 
 	{
-		this.tournamentContainer.innerHTML = ''; 
-		// 見出し要素を作成
-		const header = await this.addDisplayHeader(userProfile);
-		// overviewクラスで概要（名称、日付、参加者nickname）を作成
-		const overview = await this.tournamentOverview.generateOverview(ongoingTournament.id);
-		// ナビを作成
-		const naviButton = this.addNavigationLinks();
-		// トーナメントid要素を作成
-		const tourId = this.addAddTournamentId(ongoingTournament.id);
-		// 削除ボタンを作成
-		const deleteButton = this.addDeleteButton(ongoingTournament.id);
+		try {
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
 
-		// 作成した<div>要素をhtmlに追加
-		this.tournamentContainer.appendChild(header);
-		this.tournamentContainer.appendChild(naviButton);
-		this.tournamentContainer.appendChild(overview);
-		// this.tournamentContainer.appendChild(tourId);
-		this.tournamentContainer.appendChild(deleteButton);
+			this.tournamentContainer.innerHTML = ''; 
+			// 見出し要素を作成
+			const header = await this.addDisplayHeader(userProfile);
+			// overviewクラスで概要（名称、日付、参加者nickname）を作成
+			const overview = await this.tournamentOverview.generateOverview(ongoingTournament.id);
+			// ナビを作成
+			const naviButton = this.addNavigationLinks();
+
+			// 現時点では不要なので非表示
+			// トーナメントid要素を作成
+			// const tourId = this.addAddTournamentId(ongoingTournament.id);
+
+			// 削除ボタンを作成
+			const deleteButton = this.addDeleteButton(ongoingTournament.id);
+
+			// 作成した<div>要素をhtmlに追加
+			this.tournamentContainer.appendChild(header);
+			this.tournamentContainer.appendChild(naviButton);
+			this.tournamentContainer.appendChild(overview);
+			this.tournamentContainer.appendChild(deleteButton);
+			
+			// this.tournamentContainer.appendChild(tourId);
+		} catch(error) { 
+			tournamentHandleCatchError(error);
+		}
 	}
 
 	/** トーナメントが進行中であることを示す見出しを作成 */
 	async addDisplayHeader(userProfile) 
 	{
+					if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
+
 		UIHelper.displayUserInfo(userProfile, this.tournamentContainer);
 		const header = document.createElement('h2');
 		header.id = 'overview-header';
@@ -66,6 +83,7 @@ class TournamentEntry
 		naviButton.className = 'hth-btn my-3';
 		naviButton.textContent = 'Round';
 		naviButton.onclick = () => this.roundManager.changeStateToRound(1);
+					if (TEST_TRY3) {	throw new Error('TEST_TRY3');	}
 		return naviButton;
 	}
 
@@ -84,13 +102,13 @@ class TournamentEntry
 	}
 
 	// トーナメントIDを作成
-	addAddTournamentId(tournamentId) 
-	{
-		const tourId = document.createElement('p');
-		tourId.id = 'tourId';
-		tourId.textContent = `tournament ID: ${tournamentId}`;
-		return tourId;
-	}
+	// addAddTournamentId(tournamentId) 
+	// {
+	// 	const tourId = document.createElement('p');
+	// 	tourId.id = 'tourId';
+	// 	tourId.textContent = `tournament ID: ${tournamentId}`;
+	// 	return tourId;
+	// }
 
 }
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
@@ -1,5 +1,10 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
 import { config }	from '../ConfigTournament.js';
+// import { tournamentHandleCatchError } from "../TournamentMain.js";
+
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
+const TEST_TRY3 		= 0;
 
 /**
  * - ゲストも利用可能なAPIを用いている
@@ -16,6 +21,8 @@ class TournamentOverview
 	 */
 	async generateOverview(tournamentId) 
 	{
+					if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
+
 		const tournament = await this.fetchTournamentDetails(tournamentId);
 		if (tournament) 
 		{
@@ -34,27 +41,20 @@ class TournamentOverview
 	async fetchTournamentDetails(tournamentId) 
 	{
 		try {
+						if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 			const url = `${config.API_URLS.tournamentData}${tournamentId}/`;
-			// console.log(`fetchTournamentDetails fetch: ${url}`);
-
 			const response = await fetch(url,
 			{
 				headers: {
 					'Content-Type': 'application/json'
 				}
 			});
-
-			// console.log(`Response status: ${response.status}`);
-			// console.log(`Response status text: ${response.statusText}`);
-
 			if (!response.ok)
 			{
 				throw new Error('Failed to fetch tournament details');
 			}
 
 			const jsonData = await response.json();
-			// console.log(`jsonData: ${JSON.stringify(jsonData)}`);
-
 			return jsonData
 		} catch (error) {
 			console.error('hth: Failed to load tournament details:', error);
@@ -65,6 +65,8 @@ class TournamentOverview
 	/** 表示するエレメントを生成 */
 	createOverviewElement(tournament) 
 	{
+					if (TEST_TRY3) {	throw new Error('TEST_TRY3');	}
+
 		const detailsContainer = document.createElement('div');
 		// # トーナメント参加者のニックネームをHTML でのリスト表示が可能な形にする
 		// - tournament.player_nicknames 配列に含まれる各ニックネームに対して、map 関数が <li> タグを追加

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/RoundManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/RoundManager.js
@@ -4,6 +4,10 @@ import StateSecondRound from '../round/StateSecondRound.js'
 import StateFinalRound	from '../round/StateFinalRound.js'
 import StateEntry		from '../round/StateEntry.js';
 import { config }		from '../ConfigTournament.js';
+import { tournamentHandleCatchError } from "../TournamentMain.js";
+
+const DEBUG_FLOW		= 0;
+const TEST_TRY1 		= 0;
 
 /** ラウンドの切り替え */
 class RoundManager 
@@ -29,6 +33,7 @@ class RoundManager
 	changeStateToRound(roundNumber) 
 	{
 		try {
+						if (DEBUG_FLOW){	console.log('changeStateToRound(): start');	}
 			const newState = this.states[roundNumber];
 			if (!newState || this.currentRound === roundNumber) {
 				return;
@@ -41,8 +46,11 @@ class RoundManager
 				this.currentState = newState;
 				this.currentState.enter();
 			}
+						if (TEST_TRY1){	throw new Error('TEST_TRY1');	}
 		} catch(error) {
 			console.error("hth: changeStateToRound() failed: ", error);
+			// トーナメントページが一切表示できないのでtopにリダイレクトする
+			tournamentHandleCatchError(error);
 		}
 	}
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/TournamentManager.js
@@ -1,14 +1,15 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/tournament/TournamentManager.js
 import { config }	from '../ConfigTournament.js';
 import { routeTable } from "/static/spa/js/routing/routeTable.js";
-import { switchPage } from "/static/spa/js/routing/renderView.js"
+import { switchPage } from "/static/spa/js/routing/renderView.js";
+import { tournamentHandleCatchError } from "../TournamentMain.js";
 
 // console.log: 出力=true、本番時はfalseに設定。0,1でも動く
-let DEBUG_FLOW		= 0;
-let DEBUG_DETAIL	= 0;
-let TEST_TRY1 = 0;
-let TEST_TRY2 = 0;
-let TEST_TRY3 = 0;
+const DEBUG_FLOW		= 0;
+const DEBUG_DETAIL		= 0;
+const TEST_TRY1 		= 0;
+const TEST_TRY2 		= 0;
+const TEST_TRY3 		= 0;
 
 /**
  * 処理フロー: 
@@ -42,7 +43,8 @@ class TournamentManager
 			}
 		} catch (error) {
 			console.error("hth: TournamentManager.main() failed", error);
-			this.tournamentContainer.textContent = "Error loading your information. Try again later.";
+			// this.tournamentContainer.textContent = "Error loading your information. Try again later.";
+			tournamentHandleCatchError(error);
 		}
 	}
 
@@ -73,7 +75,8 @@ class TournamentManager
 			}
 		} catch (error) {
 			console.error('hth: _handleLoggedInUser() failed: ', error);
-			this.tournamentContainer.textContent = 'Error loading tournaments.';
+			// this.tournamentContainer.textContent = 'Error loading tournaments.';
+			tournamentHandleCatchError(error);
 		}
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/UserManager.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/manager/UserManager.js
@@ -1,9 +1,9 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/tournament/UserManager.js
 import { config }	from '../ConfigTournament.js';
 
-let DEBUG_FLOW		= 0;
-let DEBUG_DETAIL	= 0;
-let TEST_TRY1 		= 0;
+const DEBUG_FLOW		= 0;
+const DEBUG_DETAIL		= 0;
+const TEST_TRY1 		= 0;
 
 class UserManager 
 {
@@ -40,7 +40,7 @@ class UserManager
 			} catch (error) {
 				if (error.code === 401) {
 					console.error('hth: Authentication failed');
-					// 401 Unauthorized エラーの場合UIに表示
+					// 401 Unauthorized エラーの場合、ログインを促すメッセージをコンテナに表示
 					alert('Your session has expired. Please log in again.');
 				} else {
 					console.error('hth: Failed to fetch user profile:', error);

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
@@ -1,5 +1,9 @@
 // docker/srcs/uwsgi-django/pong/static/pong/js/tournament/StateBaseRound.js
 import { config }	from '../ConfigTournament.js';
+import { tournamentHandleCatchError } from "../TournamentMain.js";
+
+const TEST_TRY1		= 0;
+const TEST_TRY2		= 0;
 
 /**
  * # StateBaseRound
@@ -34,21 +38,26 @@ class StateBaseRound
 	async loadAndDisplayMatches(roundNumber) 
 	{
 		try {
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
+
 			const response = await fetch(`${this.API_URLS.ongoingMatchesByRound}${roundNumber}/`);
 			if (!response.ok) {
 				throw new Error('Server responded with an error: ' + response.status);
 			}
 			const data = await response.json();
 			this.matches = data.matches; 
-			this.displayMatches(roundNumber);
+			this._displayMatches(roundNumber);
 		} catch (error) {
-			console.error('Failed to load matches:', error);
-			this.tournamentContainer.innerHTML = 'Failed to load matches.';
+			console.error('hth: loadAndDisplayMatches() failed:', error);
+			tournamentHandleCatchError(error);
+			// this.tournamentContainer.innerHTML = 'Failed to load matches.';
 		}
 	}
 
-	displayMatches(roundNumber) 
+	_displayMatches(roundNumber) 
 	{
+					if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
+
 		this.tournamentContainer.innerHTML = ''; 
 		// matchesが空の配列であるか、null/undefinedである場合は早期リターン
 		if (!this.matches || this.matches.length === 0) {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateEntry.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateEntry.js
@@ -1,5 +1,8 @@
 import StateBaseRound	from './StateBaseRound.js'
 import TournamentEntry	from '../components/TournamentEntry.js';
+import { tournamentHandleCatchError } from "../TournamentMain.js";
+
+const TEST_TRY1		= 0;
 
 /** トーナメントの最初の初期のページ。Round 0として扱う */
 class StateEntry extends StateBaseRound 
@@ -13,13 +16,18 @@ class StateEntry extends StateBaseRound
 	
 	enter() 
 	{
-		this.tournamentContainer.innerHTML = ''; 
-		// console.log("Entering Tournament entry");
-		// トーナメントの入り口を描画するクラスの呼び出し
-		this.tournamentEntry.display(
-			this.roundManager.userTournament,
-			this.roundManager.userProfile
-		);
+		try {
+						if (TEST_TRY1) {	throw new Error('TEST_TRY1');	}
+			this.tournamentContainer.innerHTML = ''; 
+			// トーナメントの入り口を描画するクラスの呼び出し
+			this.tournamentEntry.display(
+				this.roundManager.userTournament,
+				this.roundManager.userProfile
+			);
+		} catch(error) { 
+			console.error('hth: StateEntry.enter(): ', error);
+			tournamentHandleCatchError(error);
+		}
 	}
 
 	exit() {

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/bootstrap_index.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/bootstrap_index.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% comment %} {% load static %}
 
 <!doctype html>
 <html lang="en" class="h-100" data-bs-theme="auto">
@@ -186,4 +186,4 @@
 <script src="{% static 'assets/js/color-modes.js' %}"></script>
 
     </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/bootstrap_sign-in.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/bootstrap_sign-in.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% comment %} {% load static %}
 
 <!doctype html>
 <html lang="en" data-bs-theme="auto">
@@ -185,4 +185,4 @@
 <script src="{% static 'assets/js/color-modes.js' %}"></script>
 
     </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/error.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/error.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% comment %} <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -14,4 +14,4 @@
 </ul>
 {% endif %}
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/game_tmp.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/game_tmp.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% comment %} {% load static %}
 <!doctype html>
 <html lang="ja">
 <head>
@@ -15,4 +15,4 @@
 
 </body>
 
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/index copy.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/index copy.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% comment %} {% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -45,4 +45,4 @@
     <script src="{% static 'accounts/js/logout.js' %}"></script>
 
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/index.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% comment %} <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -46,4 +46,4 @@
 
 
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/results.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/results.html
@@ -1,4 +1,4 @@
-
+{% comment %} 
 <h1>pongゲーム結果</h1>
 {% if results_list %}
 	{% for game_result in results_list %}
@@ -14,4 +14,4 @@
 		{% endfor %}
 	{% else %}
 		<p>No results are available.</p>
-{% endif %}
+{% endif %} {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/sign-in.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/sign-in.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% comment %} <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -7,4 +7,4 @@
 <body>
     <h1>pong sign-in</h1>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/plane/sign-up.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/plane/sign-up.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% comment %} <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -7,4 +7,4 @@
 <body>
     <h1>pong sign-up</h1>
 </body>
-</html>
+</html> {% endcomment %}

--- a/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
+++ b/docker/srcs/vite/pong-three/src/js/state/EntryGameState.js
@@ -7,12 +7,12 @@ import ZoomBall from '../effect/ZoomBall';
 import AllScenesManager from '../manager/AllScenesManager';
 import { handleCatchError } from '../../index.js';
 
-let DEBUG_FLOW		= 0;
-let DEBUG_DETAIL1	= 0;
-let TEST_TRY1		= 0;
-let TEST_TRY2		= 0;
-let TEST_TRY3		= 0;
-let TEST_TRY4		= 0;
+const DEBUG_FLOW		= 0;
+const DEBUG_DETAIL1		= 0;
+const TEST_TRY1			= 0;
+const TEST_TRY2			= 0;
+const TEST_TRY3			= 0;
+const TEST_TRY4			= 0;
 
 class EntryGameState extends BaseGameState 
 {


### PR DESCRIPTION
e2e待ちで、前回の延長で行っています。
https://github.com/42trans/ft_transcendence/pull/280
前回プルリクがマージされていないので、変更に含まれています。

ここから２回分が実質の変更点です
https://github.com/42trans/ft_transcendence/pull/285/commits/5cff30a1c169b5d175d33af821ab6c59b84c023a
というか、それはコメントアウトしただけなので、
見てほしいコードはここだけ。２箇所にisvalid()メソッドを追加して毎行if(isValid)した
https://github.com/42trans/ft_transcendence/pull/285/commits/fe356fb0ff5d7ee611bcd3878a4dc4efca9561b1

# #280 修正後、そこからブランチ切った
#284 
問題：最後のloopでnullが入る
理由：3D同様、spaのイベントでdispose()が走るため非同期でnullが先に入る
修正前状況：雑にリセットで対処されてたので要件的にはOK
修正後：毎行nullチェックを行い、console.warn()してreturnする処理。リセットはしない