### PR TITLE
[fix] E2E & tournament

### DIFF
--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -129,6 +129,7 @@ class TournamentCreator
 			UIHelper.clearContainer(this.errorMessage);
 			UIHelper.clearContainer(this.submitMessage);
 
+			this._trimTournamentName();
 			const nicknames			= this._getNicknames();
 			const validationResult	= this._validateFormInputs(nicknames);
 
@@ -166,18 +167,30 @@ class TournamentCreator
 		return Array.from(this.form.querySelectorAll('input[name="nickname"]'))
 					.map(input => input.value.trim());
 	}
-	
+
+	_trimTournamentName()
+	{
+		this.form.elements['name'].value = this.form.elements['name'].value.trim();
+	}
+
 	/**
 	 * APIのvalidationの詳細: docker/srcs/uwsgi-django/pong/models.py
 	 */
-	_validateFormInputs(nicknames) 
+	_validateFormInputs(nicknames)
 	{
+		console.log("tournament 1")
+		const tournamentName = this.form.elements['name'].value;
 		// トーナメント名が3文字以上30文字以下の英数字であることを確認
-		const tournamentName = this.form.elements['name'].value.trim();
+		console.log(` tournamentName: [${tournamentName}]`)
+		console.log(` length        : [${tournamentName.length}]`)
+		console.log(` pattern       : [${/^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$/.test(tournamentName)}]`)
+
 		if (!tournamentName || tournamentName.length < 3 || tournamentName.length > 30 || !/^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$/.test(tournamentName)) {
+			console.log("tournament 3")
 			return { isValid: false, errorMessage: 'Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long.' };
 		}
-	
+		console.log("tournament 4")
+
 		// // トーナメント名が未入力の場合
 		// if (!this.form.elements['name'].value) {
 		// 	return { isValid: false, errorMessage: 'Tournament name is required.' };

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -137,7 +137,7 @@ class TournamentCreator
 			if (!validationResult.isValid) 
 			{
 				// UIHelper.putError(validationResult.errorMessage, this.errorMessage);
-				alert('You cannot create: ', validationResult.errorMessage)
+				alert('You cannot create: ' + validationResult.errorMessage)
 				return;
 			}
 
@@ -178,18 +178,11 @@ class TournamentCreator
 	 */
 	_validateFormInputs(nicknames)
 	{
-		console.log("tournament 1")
 		const tournamentName = this.form.elements['name'].value;
 		// トーナメント名が3文字以上30文字以下の英数字であることを確認
-		console.log(` tournamentName: [${tournamentName}]`)
-		console.log(` length        : [${tournamentName.length}]`)
-		console.log(` pattern       : [${/^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$/.test(tournamentName)}]`)
-
 		if (!tournamentName || tournamentName.length < 3 || tournamentName.length > 30 || !/^[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+)*$/.test(tournamentName)) {
-			console.log("tournament 3")
 			return { isValid: false, errorMessage: 'Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long.' };
 		}
-		console.log("tournament 4")
 
 		// // トーナメント名が未入力の場合
 		// if (!this.form.elements['name'].value) {

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
@@ -36,6 +36,9 @@ class TournamentTest(TestConfig):
             "a a",
             "1 a",
             "abc",
+            "       abc",       # -> abc
+            "abc     ",         # -> abc
+            "       abc     ",  # -> abc
             f"{'a' * 29}",
             f"{'a' * 30}",
         ]
@@ -66,8 +69,8 @@ class TournamentTest(TestConfig):
             {"name": ".",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "abc*012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "abc_012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "  abc",           "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "abc  ",           "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "  ab",            "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "ab  ",            "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
             {"name": "<script>alert('a')</script>",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
 
             # too short
@@ -91,7 +94,8 @@ class TournamentTest(TestConfig):
             # self._screenshot("invalid1")
             self._submit_tournament(wait_invisible=False)
             # self._screenshot("invalid2")
-            self._assert_message(expected_message, value="error-message")
+            # self._assert_message(expected_message, value="error-message")
+            self._close_alert("You cannot create: ")
             self._is_tournament_top()
 
     def test_invalid_player_name(self):
@@ -133,7 +137,8 @@ class TournamentTest(TestConfig):
             # self._screenshot("invalid_nickname_1")
             self._submit_tournament(wait_invisible=False)
             # self._screenshot("invalid_nickname_2")
-            self._assert_message(expected_message, value="error-message")
+            # self._assert_message(expected_message, value="error-message")
+            self._close_alert("You cannot create: ")
             self._is_tournament_top()
 
     def _submit_tournament(self, wait_invisible=True):

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_tournament.py
@@ -61,33 +61,33 @@ class TournamentTest(TestConfig):
 
         invalid_tournament_name_and_expected_messages = [
             # empty
-            {"name": "",                "message": "Tournament name is required."},
+            {"name": "",                "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
 
             # invalid character
-            {"name": "トーナメント",      "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": " ",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": ".",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "abc*012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "abc_012",         "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "  ab",            "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "ab  ",            "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "<script>alert('a')</script>",        "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "トーナメント",      "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": " ",               "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": ".",               "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "abc*012",         "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "abc_012",         "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "  ab",            "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "ab  ",            "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "<script>alert('a')</script>",        "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
 
             # too short
-            {"name": "a",               "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "aa",              "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
-            {"name": "  aa  ",          "message": "Error: Invalid tournament_name: non-empty alnum 3-30 length name required."},
+            {"name": "a",               "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "aa",              "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "  aa  ",          "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
 
             # too long
-            {"name": f"{'a' * 31}",     "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
-            {"name": f"{'a' * 8192}",   "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 8192 文字になっています)。"},
-            {"name": "<script>alert('hello')</script>",   "message": "Error: Invalid name: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+            {"name": f"{'a' * 31}",     "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": f"{'a' * 8192}",   "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
+            {"name": "<script>alert('hello')</script>",   "message": "Tournament name must be a non-empty alphanumeric string between 3 and 30 characters long."},
         ]
 
         print(f"[Testing] invalid tournament name")
         for invalid_data in invalid_tournament_name_and_expected_messages:
             invalid_tournament_name = invalid_data["name"]
-            expected_message = invalid_data["message"]
+            expected_message = f"You cannot create: {invalid_data["message"]}"
             print(f" tournament name: [{invalid_tournament_name}]")
 
             self._send_to_elem(By.CSS_SELECTOR, 'input[name="name"]', invalid_tournament_name)
@@ -95,7 +95,7 @@ class TournamentTest(TestConfig):
             self._submit_tournament(wait_invisible=False)
             # self._screenshot("invalid2")
             # self._assert_message(expected_message, value="error-message")
-            self._close_alert("You cannot create: ")
+            self._close_alert(expected_message)
             self._is_tournament_top()
 
     def test_invalid_player_name(self):
@@ -103,34 +103,34 @@ class TournamentTest(TestConfig):
 
         invalid_player_name_and_expected_messages = [
             # empty
-            {"name": "",                "message": "All 8 nicknames are required."},
-            {"name": " ",               "message": "All 8 nicknames are required."},
+            {"name": "",                "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": " ",               "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
 
             # same as user
-            {"name": self.nickname,    "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": self.nickname,    "message": "All 8 nicknames must be unique."},
 
             # invalid character
-            {"name": "ニックネーム",      "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": ".",               "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": "abc*012",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": "abc_012",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": "<script>alert('a')</script>",         "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "ニックネーム",      "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": ".",               "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "abc*012",         "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "abc_012",         "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "<script>alert('a')</script>",         "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
 
             # too short
-            {"name": "a",               "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": "aa",              "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
-            {"name": "  aa  ",          "message": "Error: Invalid player_nicknames: 8 unique, non-empty alnum, 3-30 length nicknames required."},
+            {"name": "a",               "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "aa",              "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "  aa  ",          "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
 
             # too long
-            {"name": f"{'a' * 31}",     "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
-            {"name": f"{'a' * 8192}",   "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 8192 文字になっています)。"},
-            {"name": "<script>alert('hello')</script>",     "message": "Error: Invalid player_nicknames: Item 2 in the array did not validate: この値は 30 文字以下でなければなりません( 31 文字になっています)。"},
+            {"name": f"{'a' * 31}",     "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": f"{'a' * 8192}",   "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
+            {"name": "<script>alert('hello')</script>",     "message": "All 8 nicknames must be unique, non-empty alphanumeric strings between 3 and 30 characters long."},
         ]
 
         print(f"[Testing] invalid player name")
         for invalid_data in invalid_player_name_and_expected_messages:
             invalid_player_name = invalid_data["name"]
-            expected_message = invalid_data["message"]
+            expected_message = f"You cannot create: {invalid_data["message"]}"
             print(f" player name: [{invalid_player_name}]")
 
             self._send_to_elem(By.CSS_SELECTOR,  '.slideup-text.form-floating:nth-of-type(3) input[name="nickname"]', invalid_player_name)
@@ -138,7 +138,7 @@ class TournamentTest(TestConfig):
             self._submit_tournament(wait_invisible=False)
             # self._screenshot("invalid_nickname_2")
             # self._assert_message(expected_message, value="error-message")
-            self._close_alert("You cannot create: ")
+            self._close_alert(expected_message)
             self._is_tournament_top()
 
     def _submit_tournament(self, wait_invisible=True):


### PR DESCRIPTION
E2E TestでTournament作成エラー時のアラート処置を追加 & 関連箇所の修正


- `_trimTournamentName()`を追加  5097650
  -  `_getNicknames()`同様、trimする関数
  - `      aaa` などの入力に対し、validate関数ではtrimした`aaa`を元に判定するが、API POSTの際にはtrimされていない`      aaa`で渡されるため、Tournament modelのValidationErrorが発生していた
- alertのエラーメッセージ表示 & E2Eでメッセージを検証  3e7d983