### PR TITLE
`make`コマンドでvite_buildもstaticも一発起動

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ build_up_three: init
 
 # 通常の起動: viteはbuildのみ行い、即downしrmする
 .PHONY: build_up_default
-build_up_default: init build_up_three vite_npm_run_build down_vite django_collectstatic
+build_up_default: build_up_three vite_npm_run_build down_vite django_collectstatic
 # docker-compose $(COMPOSE_FILES_ARGS) build
 # docker-compose $(COMPOSE_FILES_ARGS) up -d
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ COMPOSE_FILES_ARGS = $(addprefix -f , $(COMPOSE_FILES))
 # -----------------------------------------------
 #  docker-compose
 # -----------------------------------------------
-all: init build up
+# all: init build up
+all: build_up_default
 
 # DEBUG: 環境変数チェック
 # echo $$SERVER_NAME 
@@ -32,7 +33,8 @@ all: init build up
 # -----------------------------------------------
 .PHONY: build
 build: init
-	COMPOSE_PROFILES=elk,blockchain,monitor docker-compose $(COMPOSE_FILES_ARGS) build
+	COMPOSE_PROFILES=three docker-compose $(COMPOSE_FILES_ARGS) build
+# COMPOSE_PROFILES=elk,blockchain,monitor docker-compose $(COMPOSE_FILES_ARGS) build
 
 
 .PHONY: b
@@ -41,7 +43,8 @@ b:
 
 .PHONY: up
 up: init
-	COMPOSE_PROFILES=elk,blockchain,monitor docker-compose $(COMPOSE_FILES_ARGS) up -d
+	COMPOSE_PROFILES=three docker-compose $(COMPOSE_FILES_ARGS) up -d
+# COMPOSE_PROFILES=elk,blockchain,monitor docker-compose $(COMPOSE_FILES_ARGS) up -d
 
 .PHONY: u
 u:

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,10 @@ logs:
 .PHONY: fclean
 fclean: down docker_rm remove_mount_volume
 
+.PHONY: re
+re: fclean all
+
+
 # -----------------------------------------------
 #  init
 # -----------------------------------------------


### PR DESCRIPTION
- viteはbuildして、即down
- nginx, Django, Postgresのみ常時起動
  - それに合わせてdownも修正
  - make で build_up_defaultをそのまま呼び出すことにした
- [x] docker_rm, static/削除,　mount_volume削除後起動確認
- [x] viteのbuildしたものはレビュワー用に一発でstaticに入ってることを確認
