### PR TITLE
マージしなくても。featに反映してます。header naviで遷移する先にslideup-text追加、 上部のnickname表示を削除

### DIFF
--- a/docker/srcs/uwsgi-django/chat/templates/chat/dm_sessions.html
+++ b/docker/srcs/uwsgi-django/chat/templates/chat/dm_sessions.html
@@ -1,20 +1,20 @@
  {% comment %} chat/templates/chat/dm_sessions.html  {% endcomment %}
 {% load static %}
 
-<h2>Start DM</h2>
+<h2 class="slideup-text">Start DM</h2>
 
  {% comment %} エラーメッセージの表示  {% endcomment %}
 <p id="message-area"></p>
 
  {% comment %} DM相手を指定して開始するtext field  {% endcomment %}
-<label for="nickname-input">DM with:</label>
+<label id="nickname-input-label" for="nickname-input">DM with:</label>
 <input id="nickname-input" type="text" size="20">
 <input id="nickname-submit" type="button" value="Enter">
 
 <hr>
 
  {% comment %} DM履歴のあるuserとのDMはこちらから {% endcomment %}
-<h3>DM Session List</h3>
+<h3 class="slideup-text">DM Session List</h3>
 <ul id="dm-sessions"></ul>
 
 {% comment %} <script type=module src="{% static 'chat/js/dm-sessions.js' %}"></script> {% endcomment %}

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-accounts.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-accounts.css
@@ -1,7 +1,7 @@
 
-#user-info {
+/* #user-info {
 	list-style-type: none;
-}
+} */
 
 
 #message-area {
@@ -51,9 +51,9 @@
 }
 
 /* tournament UIHelper SPA後削除*/
-#user-info {
+/* #user-info {
 	list-style-type: none;
-}
+} */
 
 /* アバター画像 */
 .avatar {

--- a/docker/srcs/uwsgi-django/pong/static/pong/css/hth-animation.css
+++ b/docker/srcs/uwsgi-django/pong/static/pong/css/hth-animation.css
@@ -10,6 +10,15 @@
 }
 
 /* テキストが下から現れるアニメーション */
+/* 適用したい文字列の要素に対し「直接一つずつ(ex.ulではなくli)」クラスを追加してください */
+#friends-container h3,
+#requests-container h3,
+#requests-container li,
+#friends-ul li,
+#nickname-input,
+#nickname-input-label,
+#nickname-submit,
+#dm-sessions li,
 .slideup-text {
 	animation: slideUp 0.5s ease-out forwards;
 }

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/ConfigTournament.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/ConfigTournament.js
@@ -20,7 +20,7 @@ class ConfigTournament
 	init() 
 	{
 		this.tournamentFormId		= 'tournament-form';
-		this.userInfoId				= 'user-info';
+		// this.userInfoId				= 'user-info';
 		this.errorMessageId			= 'error-message';
 		this.submitMessageId		= 'submit-message';
 		this.backHomeButtonId		= 'back-home';

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/UIHelper.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/UIHelper.js
@@ -10,27 +10,27 @@ import { switchPage } from "/static/spa/js/routing/renderView.js"
 */
 class UIHelper 
 {
-	static displayUserInfo(userProfile, container) 
-	{
-		if (!container) 
-		{
-			console.error(`UIHelper error: UserInfo container not found (${container})`);
-			return;
-		}
+	// static displayUserInfo(userProfile, container) 
+	// {
+	// 	if (!container) 
+	// 	{
+	// 		console.error(`UIHelper error: UserInfo container not found (${container})`);
+	// 		return;
+	// 	}
 
-		if (userProfile && userProfile.nickname) 
-		{
-			const nicknameItem = document.createElement('li');
-			nicknameItem.textContent = `${userProfile.nickname}`;
-			// nicknameItem.textContent = `Nickname: ${userProfile.nickname}`;
-			nicknameItem.id = 'user-info';
-			nicknameItem.className = 'mb-2';
-			// nicknameItem.style.listStyle = 'none';
-			container.appendChild(nicknameItem);
-		} else {
-			UIHelper.putError('User profile data is incomplete or missing.', container);
-		}
-	}
+	// 	if (userProfile && userProfile.nickname) 
+	// 	{
+	// 		const nicknameItem = document.createElement('li');
+	// 		nicknameItem.textContent = `${userProfile.nickname}`;
+	// 		// nicknameItem.textContent = `Nickname: ${userProfile.nickname}`;
+	// 		nicknameItem.id = 'user-info';
+	// 		nicknameItem.className = 'mb-2';
+	// 		// nicknameItem.style.listStyle = 'none';
+	// 		container.appendChild(nicknameItem);
+	// 	} else {
+	// 		UIHelper.putError('User profile data is incomplete or missing.', container);
+	// 	}
+	// }
 
 	static handleSuccess(message, href, submitMessage) 
 	{

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentCreator.js
@@ -31,7 +31,7 @@ class TournamentCreator
 	createForm(userProfile) 
 	{
 		try{
-			UIHelper.displayUserInfo(userProfile, this.userInfoContainer);
+			// UIHelper.displayUserInfo(userProfile, this.userInfoContainer);
 			// フォーム要素を作成し、プロパティを設定
 			this.form			= document.createElement('form');
 			this.form.method	= 'post';

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
@@ -71,6 +71,7 @@ class TournamentEntry
 		UIHelper.displayUserInfo(userProfile, this.tournamentContainer);
 		const header = document.createElement('h2');
 		header.id = 'overview-header';
+		header.className = 'slideup-text';
 		header.textContent = 'Tournament is in progress.';
 		return header;
 	}
@@ -80,7 +81,7 @@ class TournamentEntry
 	{
 		const naviButton = document.createElement('button');
 		naviButton.id = 'round-navigation';
-		naviButton.className = 'hth-btn my-3';
+		naviButton.className = 'slideup-text hth-btn my-3';
 		naviButton.textContent = 'Round';
 		naviButton.onclick = () => this.roundManager.changeStateToRound(1);
 					if (TEST_TRY3) {	throw new Error('TEST_TRY3');	}
@@ -91,7 +92,7 @@ class TournamentEntry
 	addDeleteButton(tournamentId) {
 		const deleteButton = document.createElement('button');
 		deleteButton.id = 'delete-button';
-		deleteButton.className = 'hth-btn my-3';
+		deleteButton.className = 'slideup-text hth-btn my-3';
 		deleteButton.textContent = 'Delete Tournament';
 		deleteButton.onclick = async () => {
 			if (confirm('Delete this tournament?')) {

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentEntry.js
@@ -68,7 +68,7 @@ class TournamentEntry
 	{
 					if (TEST_TRY2) {	throw new Error('TEST_TRY2');	}
 
-		UIHelper.displayUserInfo(userProfile, this.tournamentContainer);
+		// UIHelper.displayUserInfo(userProfile, this.tournamentContainer);
 		const header = document.createElement('h2');
 		header.id = 'overview-header';
 		header.className = 'slideup-text';

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/components/TournamentOverview.js
@@ -82,6 +82,18 @@ class TournamentOverview
 			</p>
 			<ul>${nicknamesList}</ul>
 		`;
+
+		// 上記htmlのul以外にslideup-textを追加
+		const allElementsExceptUl = detailsContainer.querySelectorAll(':not(ul)'); 
+		allElementsExceptUl.forEach(element => {
+			element.classList.add('slideup-text');
+		});
+		// li 要素（nicknamesList）にも追加
+		const listElements = detailsContainer.querySelectorAll('li'); 
+		listElements.forEach(element => {
+			element.classList.add('slideup-text');
+		});
+
 		return detailsContainer;
 	}
 

--- a/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
+++ b/docker/srcs/uwsgi-django/pong/static/pong/js/tournament/round/StateBaseRound.js
@@ -75,7 +75,7 @@ class StateBaseRound
 
 			let matchDetails = `
 				<div class="round-result-score hth-transparent-black-bg-color mb-2">
-				<h4 class="round-match-title px-3 pt-3 mb-2">Match #${match.match_number}: ${player1} vs ${player2}</h4>
+				<h4 class="slideup-text round-match-title px-3 pt-3 mb-2">Match #${match.match_number}: ${player1} vs ${player2}</h4>
 			`;
 
 			// 試合終了している場合はスコア表示
@@ -90,16 +90,16 @@ class StateBaseRound
 					minute: '2-digit' // 分
 				});
 				
-				matchDetails += `<p class="round-result-score text-white px-4  mb-0">Score: ${match.player1_score} - ${match.player2_score}</p>`;
-				matchDetails += `<p class="round-result-winner text-white px-4 mb-0">Winner: ${match.winner}</p>`;
-				matchDetails += `<p class="round-result-endedat text-white px-4 pb-2">Ended at: ${formattedEndedAt}</p>`;
+				matchDetails += `<p class="slideup-text round-result-score text-white px-4  mb-0">Score: ${match.player1_score} - ${match.player2_score}</p>`;
+				matchDetails += `<p class="slideup-text round-result-winner text-white px-4 mb-0">Winner: ${match.winner}</p>`;
+				matchDetails += `<p class="slideup-text round-result-endedat text-white px-4 pb-2">Ended at: ${formattedEndedAt}</p>`;
 				
 			} else {
 				if (match.can_start) {
 					// Pong gameへのリンク APIにmatch.idを渡す。
-					matchDetails += `<a class="hth-btn px-3 mx-4 mt-2 mb-3" href="/app/game/match/${match.id}/" data-link>Start Match</a>`;
+					matchDetails += `<a class="slideup-text hth-btn px-3 mx-4 mt-2 mb-3" href="/app/game/match/${match.id}/" data-link>Start Match</a>`;
 				} else {
-					matchDetails += `<p class="px-4 pb-2" >On Hold</p>`;
+					matchDetails += `<p class="slideup-text px-4 pb-2" >On Hold</p>`;
 				}
 			}
 			matchDetails += '</div>'
@@ -107,8 +107,8 @@ class StateBaseRound
 			matchElement.innerHTML = matchDetails;
 			this.tournamentContainer.appendChild(matchElement);
 		});
-		const prevNavi = this.addPrevNavigationLinks(roundNumber, 'prev-round', 'hth-btn my-5 me-5', 'prev');
-		const nextNavi = this.addNextNavigationLinks(roundNumber, 'next-round', 'hth-btn my-5', 'next');
+		const prevNavi = this.addPrevNavigationLinks(roundNumber, 'prev-round', 'slideup-text hth-btn my-5 me-5', 'prev');
+		const nextNavi = this.addNextNavigationLinks(roundNumber, 'next-round', 'slideup-text hth-btn my-5', 'next');
 		this.tournamentContainer.appendChild(prevNavi);
 		this.tournamentContainer.appendChild(nextNavi);
 	}

--- a/docker/srcs/uwsgi-django/pong/templates/pong/tournament.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/tournament.html
@@ -3,10 +3,10 @@
 	{% csrf_token %}
 		<div class="container" id="tournament-container">
 
-			<div class="hth-accounts-container">
-				<ul id="user-info">
-				</ul>
-			</div>
+			{% comment %} <div class="hth-accounts-container"> {% endcomment %}
+				{% comment %} <ul id="user-info">
+				</ul> {% endcomment %}
+			{% comment %} </div> {% endcomment %}
 
 			<div id="tournament-round"></div>
 


### PR DESCRIPTION
#301
- [x] headerで遷移する先だけ　下から浮かび上がるテキストアニメーション適用。同じパターンでaccountの設定がかなりいけると思うので、余力ある時にでも。
- あと、再現できないですが、復旧できないエラーに遭遇しました。エラーハンドリングもない。リセットしてtopに飛ばすくらいのケアは必要だと思います。42Authでログインできない現象に遭遇 #303
- [x] 不要だったtournamentのnickname表示を削除