### PR TITLE
pathマッチング修正

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/tests/test_valid_user_id.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_valid_user_id.py
@@ -86,7 +86,7 @@ class IsValidUserIdAPITests(TestCase):
             print(f"testing ng_id: {ng_id}")
             is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[ng_id])
             response = self.client.get(is_valid_user_id_api_path)
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_guest(self):
         is_valid_user_id_api_path = reverse(self.kIsValidUserId, args=[self.user1.id])

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -285,9 +285,9 @@ class IsValidUserIdAPI(APIView):
         try:
             user_id = int(user_id)
             if user_id <= 0:
-                return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({'exists': False}, status=status.HTTP_200_OK)
         except Exception:
-            return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({'exists': False}, status=status.HTTP_200_OK)
 
         user_exists = CustomUser.objects.filter(id=user_id).exists()
         return Response({'exists': user_exists}, status=status.HTTP_200_OK)

--- a/docker/srcs/uwsgi-django/chat/tests/test_valid_dm_user_id.py
+++ b/docker/srcs/uwsgi-django/chat/tests/test_valid_dm_user_id.py
@@ -86,7 +86,7 @@ class IsValidDmUserIdAPITests(TestCase):
             print(f"testing ng_id: {ng_id}")
             is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[ng_id])
             response = self.client.get(is_valid_user_id_api_path)
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_guest(self):
         is_valid_user_id_api_path = reverse(self.IsValidDmUserIdApiName, args=[self.user1.id])

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -141,9 +141,9 @@ class IsValidDmUserIdAPI(APIView):
         try:
             target_id = int(target_id)
             if target_id <= 0 or target_id == request.user.id:
-                return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({'exists': False}, status=status.HTTP_200_OK)
         except Exception:
-            return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({'exists': False}, status=status.HTTP_200_OK)
 
         user_exists = CustomUser.objects.filter(id=target_id).exists()
         return Response({'exists': user_exists}, status=status.HTTP_200_OK)

--- a/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
+++ b/docker/srcs/uwsgi-django/pong/templates/pong/dev-link.html
@@ -12,7 +12,7 @@
 	<hr>
 	<li><a href="https://localhost/app/user/game-history/" class="nav__link" data-link>kSpaGameHistoryUrl</a></li>
 	<li><a href="https://localhost/app/user/profile/" class="nav__link" data-link>kSpaUserProfileUrl</a></li>
-	<li><a href="https://localhost/app/user/info/user2/" class="nav__link" data-link>kSpaUserInfoUrl->user2</a></li>
+	<li><a href="https://localhost/app/user/info/4/" class="nav__link" data-link>kSpaUserInfoUrl->user2</a></li>
 <!--	<li><a href="https://localhost/app/user/info/" class="nav__link" data-link>kSpaUserInfoUrlBase</a></li>-->
 	<li><a href="https://localhost/app/user/friends/" class="nav__link" data-link>kSpaUserFriendUrl</a></li>
 	<li><a href="https://localhost/app/user/profile/edit/" class="nav__link" data-link>kSpaEditProfileUrl</a></li>
@@ -55,4 +55,30 @@
 	<li><a href="/app/game/game-3d/" class="nav__link" data-link>/app/game/game-3d/</a></li>
 	<li><a href="/app/home/" class="nav__link" data-link>/app/home/</a></li>
 	<li><a href="/app/user/game-history/" class="nav__link" data-link>/app/user/game-history/</a></li>
+</ul>
+
+<hr>
+
+<h4>path-test</h4>
+<ul class="dev-link">
+	<li><a href="https://localhost/" class="nav__link" data-link>/</a></li>
+	<li><a href="https://localhost/app/.........." class="nav__link" data-link>/app/..........</a></li>
+	<li><a href="https://localhost/app/././././" class="nav__link" data-link>/app/././././</a></li>
+	<li><a href="https://localhost/app/.././../../" class="nav__link" data-link>/app/.././../../</a></li>
+	<hr>
+	<li><a href="https://localhost/app/user/info/0/" class="nav__link" data-link>/app/user/info/0/</a></li>
+	<li><a href="https://localhost/app/user/info/-1/" class="nav__link" data-link>/app/user/info/-1/</a></li>
+	<li><a href="https://localhost/app/user/info/aaa/" class="nav__link" data-link>/app/user/info/aaa/</a></li>
+	<li><a href="https://localhost/app/user/info/1/2/" class="nav__link" data-link>/app/user/info/1/2/</a></li>
+	<hr>
+	<li><a href="https://localhost/app/dm/9999/" class="nav__link" data-link>/app/dm/9999/</a></li>
+	<li><a href="https://localhost/app/dm/aaa/" class="nav__link" data-link>/app/dm/aaa/</a></li>
+	<li><a href="https://localhost/app/dm/-1/" class="nav__link" data-link>/app/dm/-1/</a></li>
+	<li><a href="https://localhost/app/dm/0/" class="nav__link" data-link>/app/dm/0/</a></li>
+	<li><a href="https://localhost/app/dm/0/123/" class="nav__link" data-link>/app/dm/0/123/</a></li>
+	<hr>
+	<li><a href="https://localhost/app/game/match/000" class="nav__link" data-link>/app/game/match/000</a></li>
+	<li><a href="https://localhost/app/game/match/1/2/3" class="nav__link" data-link>/app/game/match/1/2/3</a></li>
+	<li><a href="https://localhost/app/game/match/nothing" class="nav__link" data-link>/app/game/match/nothing</a></li>
+	<li><a href="https://localhost/app/game/match/-1" class="nav__link" data-link>/app/game/match/-1</a></li>
 </ul>

--- a/docker/srcs/uwsgi-django/pong/tournament/tests/test_valid_match_id.py
+++ b/docker/srcs/uwsgi-django/pong/tournament/tests/test_valid_match_id.py
@@ -103,7 +103,7 @@ class IsValidMatchIdAPITests(TestCase):
             print(f"testing ng_id: {ng_id}")
             is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[ng_id])
             response = self.client.get(is_valid_user_id_api_path)
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_guest(self):
         is_valid_user_id_api_path = reverse(self.IsValidMatchIdApiName, args=[self.user1.id])

--- a/docker/srcs/uwsgi-django/pong/views/tournament/is_valid_match_api_view.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament/is_valid_match_api_view.py
@@ -17,10 +17,12 @@ class IsValidMatchIdAPI(APIView):
 		try:
 			match_id = int(match_id)
 			if match_id <= 0:
-				return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+				return Response({'exists': False}, status=status.HTTP_200_OK)
+				# return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
 
 			match_exists = Match.objects.filter(id=match_id).exists()
 			return Response({'exists': match_exists}, status=status.HTTP_200_OK)
 
 		except Exception:
-			return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)
+			return Response({'exists': False}, status=status.HTTP_200_OK)
+			# return Response({'exists': False}, status=status.HTTP_400_BAD_REQUEST)

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getMatchedRoute.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getMatchedRoute.js
@@ -1,7 +1,7 @@
 import { routeTable } from "./routeTable.js";
 import { isValidParam } from "../utility/isValidParam.js"
 
-const DEBUG_LOG = 1;
+const DEBUG_LOG = 0;
 
 
 const normalizePath = (path) => {

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getMatchedRoute.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getMatchedRoute.js
@@ -1,0 +1,68 @@
+import { routeTable } from "./routeTable.js";
+import { isValidParam } from "../utility/isValidParam.js"
+
+const DEBUG_LOG = 1;
+
+
+const normalizePath = (path) => {
+    return path.replace(/\/+/g, '/');
+};
+
+
+const comparePathParts = async (routeParts, currentPathParts) => {
+    let params = {};
+    for (let i = 0; i < routeParts.length; i++) {
+        const part = routeParts[i];
+        const currentPart = currentPathParts[i];
+
+        if (part.startsWith(':')) {
+            const paramName = part.slice(1);
+            if (i !== routeParts.length - 1) {
+                return { isMatch: false, params: {} };
+            }
+
+            const isValid = await isValidParam(paramName, currentPart);
+            if (!isValid) {
+                if (DEBUG_LOG) { console.log(` ${paramName} -> x InvalidParam: ${currentPart}`); }
+                return { isMatch: false, params: {} };
+            }
+
+            params[paramName] = currentPart;
+            if (DEBUG_LOG) { console.log(` ${paramName} -> o validParam: ${currentPart}`); }
+
+        } else if (part !== currentPart) {
+            return { isMatch: false, params: {} };
+        }
+    }
+    return { isMatch: true, params };
+};
+
+
+export const getMatchedRoute = async (currentPath) => {
+    const excludeRoutes = ['userInfoBase', 'dmWithUserBase'];
+    const normalizedPath = normalizePath(currentPath);
+
+    for (const routeKey in routeTable) {
+        if (excludeRoutes.includes(routeKey)) {
+            continue;
+        }
+
+        const route = routeTable[routeKey];
+        const routeParts = route.path.split('/').filter(part => part);
+        const currentPathParts = normalizedPath.split('/').filter(part => part);
+
+        if (routeParts.length !== currentPathParts.length) {
+            continue;
+        }
+
+        const { isMatch, params } = await comparePathParts(routeParts, currentPathParts);
+        if (isMatch) {
+            const foundRoute = { ...route, params };
+            if (DEBUG_LOG) { console.log(` match -> ${foundRoute.path}`); }
+            return foundRoute;
+        }
+    }
+
+    if (DEBUG_LOG) { console.log(` NO match -> top`); }
+    return routeTable['top'];
+};

--- a/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
+++ b/docker/srcs/uwsgi-django/trans_pj/static/spa/js/routing/getNextPath.js
@@ -2,7 +2,7 @@
 
 import { routeTable } from "./routeTable.js"
 import { isUserLoggedIn, isUserEnable2FA } from "../utility/isUser.js"
-import { getSelectedRoute } from "./renderView.js"
+import { getMatchedRoute } from "./getMatchedRoute.js"
 
 
 const DEBUG = 0;
@@ -65,7 +65,7 @@ function getUserRedirectPath(url, isEnable2FA) {
 const isRenderTopPageUrl = async (url) => {
   const urlObject = new URL(url);
   const pathName = urlObject.pathname;
-  const ret =  await getSelectedRoute(pathName, routeTable) === routeTable['top'];
+  const ret =  await getMatchedRoute(pathName) === routeTable['top'];
   if (DEBUG) { console.log(' isRenderTopPageUrl -> ' + ret); }
   return ret
 }


### PR DESCRIPTION
- pathパラメータの比較を最小限とした
- 文字列操作系のためテストでバグチェックしたかったが、JSで関数単体テストを作成するハードルが高く、dev-linkにpath-testを埋め込み目視確認
- parameter検証APIの400 -> 200に変更
  - consoleの400エラーを握り潰せなかったため、invalid parameterでも200を返すように変更（is_valid=Falseを返すため問題なし）
  - 課題要件securityに則り、guestの場合は401を返す