### PR TITLE
update nickname, password後のuncaugth ReferenceError

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
+++ b/docker/srcs/uwsgi-django/accounts/templates/accounts/edit_profile.html
@@ -10,7 +10,7 @@
 		<p id="message-area"></p>
 
 		{% comment %} ニックネーム更新用のフォーム  {% endcomment %}
-		<form id="nickname-form" onsubmit="updateNickname(event)">
+		<form id="nickname-form">
 			<h2>Nickname</h2>
 			<p>
 				<label for="nickname">Nickname:</label>
@@ -20,7 +20,7 @@
 
 		{% comment %} 42authの場合はpassword変更非表示  {% endcomment %}
 		{% if not is_42auth_user %}
-		<form id="password-form" onsubmit="updatePassword(event)">
+		<form id="password-form">
 			<h3 class="mb-1">password</h3>
 			<p>current password: <input type="password" id="current_password" placeholder="current-password" required></p>
 			<p>new password: <input type="password" id="new_password" placeholder="new-password"></p>

--- a/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_user_profile.py
@@ -89,22 +89,22 @@ class EditUserProfileAPITests(TestCase):
     def test_update_nickname_fail_same_old_nickname(self):
         response = self.client.post(self.edit_user_profile_url, {'nickname': self.kUserNickname})
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('new nickname same as current', response.data['error'])
 
     def test_update_nickname_fail_already_use_nickname(self):
         response = self.client.post(self.edit_user_profile_url, {'nickname': self.kUser2Nickname})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('This nickname is already in use', response.data['error'])
 
     def test_update_nickname_fail_invalid_nickname_len(self):
         response = self.client.post(self.edit_user_profile_url, {'nickname': 'aa'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('The nickname must be at least 3 characters', response.data['error'])
 
     def test_update_nickname_fail_invalid_nickname_char(self):
         response = self.client.post(self.edit_user_profile_url, {'nickname': '***'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid nickname format', response.data['error'])
 
 
@@ -128,7 +128,7 @@ class EditUserProfileAPITests(TestCase):
             'new_password': 'newPassword123'
         })
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Current password is incorrect', response.data['error'])
 
     def test_update_password_fail_same_as_current(self):
@@ -137,7 +137,7 @@ class EditUserProfileAPITests(TestCase):
             'new_password': self.kUserPassword
         })
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('new password same as current', response.data['error'])
 
     def test_update_password_fail_invalid_password(self):
@@ -145,7 +145,7 @@ class EditUserProfileAPITests(TestCase):
             'current_password': self.kUserPassword,
             'new_password': '012345'
         })
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('error', response.json())
 
 
@@ -153,7 +153,7 @@ class EditUserProfileAPITests(TestCase):
     def test_no_data_provided(self):
         response = self.client.post(self.edit_user_profile_url, {})
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Update profile error', response.data['error'])
 
     def test_un_login_user(self):

--- a/docker/srcs/uwsgi-django/accounts/views/user.py
+++ b/docker/srcs/uwsgi-django/accounts/views/user.py
@@ -86,7 +86,7 @@ class EditUserProfileAPIView(APIView):
             is_ok, msg = self._update_nickname(request.user, new_nickname)
             if is_ok is False:
                 data = {'error': msg}
-                return Response(data, status=400)
+                return Response(data, status=200)
 
             data = {'message': msg}
             return Response(data, status=200)
@@ -95,13 +95,13 @@ class EditUserProfileAPIView(APIView):
             is_ok, msg = self._update_password(request, input_current_password, new_password)
             if is_ok is False:
                 data = {'error': msg}
-                return Response(data, status=400)
+                return Response(data, status=200)
 
             data = {'message': msg}
             return Response(data, status=200)
 
         data = {'error': 'Update profile error'}
-        return Response(data, status=400)
+        return Response(data, status=200)
 
     def _update_nickname(self, user, new_nickname):
         if self._is_progress_tournament_organizer(user):


### PR DESCRIPTION
#332 

edit profileで変更後、profileに戻ってきた時点でエラー発生


- [x] エラー対策  048787f
  ```
  # nicknmae変更後
  Uncaught ReferenceError: updateNickname is not defined
      onsubmit https://localhost/app/user/profile/edit/:1
  edit:1:1

  # password変更後
  Uncaught ReferenceError: updatePassword is not defined
      onsubmit https://localhost/app/user/profile/edit/:1
  edit:1:1
  ```
- [x] （ついでに）不正なnickname, password入力時の400握り潰し  6b36c48