### PR TITLE
42signup nickname重複時のエラーハンドリング & 400握り潰し

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/login.js
@@ -22,13 +22,13 @@ export function loginUser() {
 		.then(data => {
 			if (data.error) {
 				// Error
-				document.getElementById('message-area').textContent = data.error;
 				if (data.redirect) {
                     // alert('[tmp] login failure')
 					switchPage(data.redirect);
 				} else {
 					// alert('[tmp] error: ' + data.error)
-					throw new Error(data.error);
+					// throw new Error(data.error);
+					document.getElementById('message-area').textContent = data.error;
 				}
 			} else if (data.message) {
 				// Verified

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/signup.js
@@ -25,12 +25,12 @@ function signupUser() {
 	.then(data => {
 		if (data.error) {
 			// Error
-			document.getElementById('message-area').textContent = data.error;
 			if (data.redirect) {
 				if (DEBUG_LOG) { console.log('signup error: next: ' + data.redirect); };
 				switchPage(data.redirect);
 			} else {
-				throw new Error(data.error);
+				// throw new Error(data.error);
+				document.getElementById('message-area').textContent = data.error;
 			}
 		} else if (data.message) {
 			// Verified

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/verify_2fa.js
@@ -19,13 +19,13 @@ function verify2FA() {
 		.then(data => {
 			if (data.error) {
 				// Error
-				document.getElementById('error-message').textContent = data.error;
 				if (data.redirect) {
 					// alert('[tmp] varify2fa error: redirectTo:' + data.redirect)
 					switchPage(data.redirect);
 				} else {
 					// alert('[tmp] varify2fa error' + data.error)
-					throw new Error(data.error);
+					// throw new Error(data.error);
+					document.getElementById('error-message').textContent = data.error;
 				}
 			} else if (data.message) {
 				// Verified

--- a/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_2fa.py
@@ -93,7 +93,7 @@ class Enable2FaAPITests(TestCase):
 
     def test_post_invalid_token1(self):
         response = self.client.post(self.enable_2fa_api_url, {'token': '012345'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Invalid token provided", response.json()['error'])
 
         self.user.refresh_from_db()
@@ -101,7 +101,7 @@ class Enable2FaAPITests(TestCase):
 
     def test_post_invalid_token2(self):
         response = self.client.post(self.enable_2fa_api_url, {'token': ''})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Invalid token provided", response.json()['error'])
 
         self.user.refresh_from_db()
@@ -109,7 +109,7 @@ class Enable2FaAPITests(TestCase):
 
     def test_post_invalid_token3(self):
         response = self.client.post(self.enable_2fa_api_url, {'token': 'abc'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Invalid token provided", response.json()['error'])
 
         self.user.refresh_from_db()
@@ -117,7 +117,7 @@ class Enable2FaAPITests(TestCase):
 
     def test_post_empty_token(self):
         response = self.client.post(self.enable_2fa_api_url, {'token': ''})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid token provided', response.json()['error'])
 
         self.user.refresh_from_db()
@@ -125,7 +125,7 @@ class Enable2FaAPITests(TestCase):
 
     def test_post_empty_request(self):
         response = self.client.post(self.enable_2fa_api_url, {})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid token provided', response.json()['error'])
 
         self.user.refresh_from_db()
@@ -220,26 +220,26 @@ class Verify2FaAPITests(TestCase):
         self._login()
 
         response = self.client.post(self.verify_2fa_api_url, {'token': '012345'})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid token', response.json()['error'])
 
     def test_faulure_empty_token(self):
         self._login()
 
         response = self.client.post(self.verify_2fa_api_url, {'token': ''})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid token', response.json()['error'])
 
     def test_faulure_empty_request(self):
         self._login()
 
         response = self.client.post(self.verify_2fa_api_url, {})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid token', response.json()['error'])
 
     def test_un_login_user(self):
         response = self.client.post(self.verify_2fa_api_url, {'token': '012345'})
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('No valid session found', response.json()['error'])
         self.assertIn(settings.URL_CONFIG['kSpaAuthLoginUrl'], response.json()['redirect'])
 

--- a/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_jwt.py
@@ -67,7 +67,7 @@ class JWTTest(APITestCase):
 
     def test_invalid_credentials(self):
         response = self.client.post(self.login_api_path, {'email': 'wrong@example.com', 'password': 'wrong'})
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('error', response.json())
         self.assertEqual(response.json()['error'], 'Invalid credentials')
 

--- a/docker/srcs/uwsgi-django/accounts/tests/test_login.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_login.py
@@ -55,7 +55,7 @@ class LoginAPIViewTestCase(TestCase):
         response = self.client.post(self.login_path, data=login_data)
         response_json = response.json()
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Invalid credentials', response_json['error'])
 
     def test_2fa_authentication_needed(self):

--- a/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_signup.py
@@ -42,49 +42,56 @@ class SignUpAPITests(TestCase):
         user_data = self.user_data.copy()
         user_data['password2'] = 'wrong0123'
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("passwords don't match", response.json()['error'])
 
     def test_invalid_email_already_use(self):
         user_data = self.user_data.copy()
         user_data['nickname'] = 'test1'
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("This email is already in use", response.json()['error'])
 
     def test_invalid_email(self):
         user_data = self.user_data.copy()
         user_data['email'] = 'invalid-email'
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('error', response.json())
 
     def test_invalid_email_empty(self):
         user_data = self.user_data.copy()
         user_data['email'] = ''
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('error', response.json())
 
     def test_invalid_email_too_short(self):
         user_data = self.user_data.copy()
         user_data['email'] = 'a@b'
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters", response.json()['error'])
 
     def test_invalid_email_too_long(self):
         user_data = self.user_data.copy()
         user_data['email'] = f"a@{'b' * 64}.com"
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(f"The email must be {CustomUser.kEMAIL_MAX_LENGTH} characters or less", response.json()['error'])
+
+    def test_invalid_email_42email(self):
+        user_data = self.user_data.copy()
+        user_data['email'] = f"test@tokyo.42.school"
+        response = self.client.post(self.signup_api_url, user_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(f"Please signup for 42 account", response.json()['error'])
 
     def test_invalid_nickname_already_use(self):
         user_data = self.user_data.copy()
         user_data['email'] = 'test1@signup.com'
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("This nickname is already in use", response.json()['error'])
 
     def test_invalid_password_too_short(self):
@@ -94,7 +101,7 @@ class SignUpAPITests(TestCase):
         user_data['password1'] = "pass0"
         user_data['password2'] = "pass0"
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("このパスワードは短すぎます。最低 8 文字以上必要です。", response.json()['error'])
 
     def test_invalid_password_too_long(self):
@@ -104,7 +111,7 @@ class SignUpAPITests(TestCase):
         user_data['password1'] = "pass0" + "0123456789" * 6
         user_data['password2'] = "pass0" + "0123456789" * 6
         response = self.client.post(self.signup_api_url, user_data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(f"The password must be {CustomUser.kPASSWORD_MAX_LENGTH} characters or less", response.json()['error'])
 
     def test_successful_signup(self):
@@ -125,5 +132,5 @@ class SignUpAPITests(TestCase):
         user_data['email'] = 'error@signup.com'
         with self.assertRaises(Exception):
             self.client.post(self.signup_api_url, data)
-            self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertIn('error', response.json())

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -61,6 +61,10 @@ class SignupAPIView(APIView):
             data = {'error': "passwords don't match"}
             return JsonResponse(data, status=400)
 
+        if self._is_42email(email):
+            data = {'error': "please signup for 42 account"}
+            return JsonResponse(data, status=400)
+
         ok, err = CustomUser.objects._is_valid_user_field(email, nickname, password1)
         if not ok:
             data = {'error': err}
@@ -79,6 +83,9 @@ class SignupAPIView(APIView):
         except Exception as e:
             data = {'error': str(e)}
             return JsonResponse(data, status=500)
+
+    def _is_42email(self, email):
+        return email.endswith('@tokyo.42.school')
 
 
 class LoginTemplateView(TemplateView):

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -59,16 +59,16 @@ class SignupAPIView(APIView):
 
         if password1 != password2:
             data = {'error': "passwords don't match"}
-            return JsonResponse(data, status=400)
+            return JsonResponse(data, status=200)
 
         if self._is_42email(email):
-            data = {'error': "please signup for 42 account"}
-            return JsonResponse(data, status=400)
+            data = {'error': "Please signup for 42 account"}
+            return JsonResponse(data, status=200)
 
         ok, err = CustomUser.objects._is_valid_user_field(email, nickname, password1)
         if not ok:
             data = {'error': err}
-            return JsonResponse(data, status=400)
+            return JsonResponse(data, status=200)
 
         try:
             user = CustomUser.objects.create_user(email=email,
@@ -82,7 +82,7 @@ class SignupAPIView(APIView):
             return get_jwt_response(user, data)
         except Exception as e:
             data = {'error': str(e)}
-            return JsonResponse(data, status=500)
+            return JsonResponse(data, status=200)
 
     def _is_42email(self, email):
         return email.endswith('@tokyo.42.school')

--- a/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/basic_auth.py
@@ -125,7 +125,7 @@ class LoginAPIView(APIView):
         user = authenticate(request, email=email, password=password)
         if user is None:
             data = {'error': 'Invalid credentials'}
-            return JsonResponse(data, status=401)
+            return JsonResponse(data, status=200)
 
         if user.enable_2fa:
             request.session['tmp_auth_user_id'] = user.id

--- a/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
+++ b/docker/srcs/uwsgi-django/accounts/views/two_factor_auth.py
@@ -95,7 +95,7 @@ class Enable2FaAPIView(APIView):
             return JsonResponse(data, status=200)
         else:
             data = {"error": "Invalid token provided"}
-            return JsonResponse(data, status=400)
+            return JsonResponse(data, status=200)
 
     def _get_secret_key(self, request):
         """
@@ -172,7 +172,7 @@ class Disable2FaView(APIView):
                 'message': 'No valid 2FA session',
                 'redirect': settings.URL_CONFIG['kSpaUserProfileUrl'],
             }
-            return Response(data, status=400)
+            return Response(data, status=200)
 
         self._delete_totp_devices(user)
         self._disable_user_2fa(user)
@@ -217,7 +217,7 @@ class Verify2FaAPIView(APIView):
                 'error': 'No valid session found',
                 'redirect': settings.URL_CONFIG['kSpaAuthLoginUrl'],
             }
-            return Response(data, status=401)
+            return Response(data, status=200)
 
         token = request.data.get('token')
 
@@ -231,7 +231,7 @@ class Verify2FaAPIView(APIView):
                 return get_jwt_response(user, data)
 
         data = {'error': 'Invalid token'}
-        return Response(data, status=400)
+        return Response(data, status=200)
 
     @classmethod
     def _get_user_and_devices(self, request):

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_api_scurity.py
@@ -22,6 +22,7 @@ class AccountsAPITestCase(TestCase):
         exclude_urls = {
             "api/signup/",
             "api/login/",
+            "api/verify_2fa/",
             "api/is-user-logged-in/",
             "api/is-user-enabled2fa/",
             "oauth-ft/callback/",

--- a/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
+++ b/docker/srcs/uwsgi-django/trans_pj/tests/test_basic_auth.py
@@ -128,6 +128,8 @@ class BasicAuthTest(TestConfig):
             {"email": "メール@email.com",      "message": "有効なメールアドレスを入力してください。"},
             {"email": "メールアドレス",         "message": "有効なメールアドレスを入力してください。"},
 
+            {"email": "test@tokyo.42.school", "message": "Please signup for 42 account"},
+
             # too short
             {"email": "a@b",                  "message": f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters"},
             {"email": "a@bc",                 "message": f"The email must be at least {CustomUser.kEMAIL_MIN_LENGTH} characters"},
@@ -148,7 +150,7 @@ class BasicAuthTest(TestConfig):
         for invalid_data in invalid_emails_and_expected_messages:
             invalid_email = invalid_data["email"]
             expected_message = invalid_data["message"]
-            # print(f" email: [{invalid_email}]")
+            print(f" email: [{invalid_email}]")
 
             nickname = self._generate_random_string()
             password1 = "pass0123"


### PR DESCRIPTION
## todo
- 42signup nickname重複対策
  - ランダムな0-9 x 5文字をsuffixとしたnicknameでユーザー登録（10000回トライ）   08a165d
    ```python
    random_suffix = self._random_digit(5)
    nick = f"{nickname}{random_suffix}"
    ```
  - ユーザー数の上限10000なので十分なはず（作成失敗してもsignup遷移するだけ）
  - 42auth->42emailでuserの存在評価するため、basic signupで42emailを禁止する（42emailでuser作成したければ42auth使ってね） d40b745
  - 42emailのテスト追加
* ついでに
  * signup, login, 2FAで不正値入力の際に400->200へ変更
  * signup, login, 2FAで不正値入力の際のconsole.error削除

<br>

## スクショ

42signup（42nicknameに重複がなかった場合）
![Screenshot 2024-06-23 at 10 56 10](https://github.com/42trans/ft_transcendence/assets/51146172/9860b7ac-b107-42f9-aea8-1b207a978d49)

42signup（別のuserがすでにtakiraを使っていた場合）
![Screenshot 2024-06-23 at 10 22 19](https://github.com/42trans/ft_transcendence/assets/51146172/73851dcb-58fe-4572-9fdf-4c0a500f07a5)

signupで42email使用不可に
42authではemailベースでuser検索するため、別userが42email使用済みだと42signup不可 & そのuserとして42loginできてしまうため
![Screenshot 2024-06-23 at 10 57 32](https://github.com/42trans/ft_transcendence/assets/51146172/54ce737c-ec9a-4108-933e-9ea810b800f3)
