### PR TITLE
システムメッセージをイベントドリブンで送信

### DIFF
--- a/docker/srcs/uwsgi-django/chat/views/system_message.py
+++ b/docker/srcs/uwsgi-django/chat/views/system_message.py
@@ -19,13 +19,14 @@ from pong.utils.async_logger import async_log
 
 import logging
 
-
 logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s - %(levelname)s - %(message)s - [in %(funcName)s: %(lineno)d]',
 )
 logger = logging.getLogger('chat')
 
+DEBUG_FLOW = 0
+DEBUG_DETAIL = 0
 
 class SystemMessageAPI(APIView):
     permission_classes = [IsAuthenticated]  # login required
@@ -104,96 +105,96 @@ class SystemMessageAPI(APIView):
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-def send_direct_system_message(target_nickname, message):
-    @async_to_sync
-    async def async_send_direct_system_message():
-        try:
-            await async_log(f"send_system_message: start")
+# def send_direct_system_message(target_nickname, message):
+#     @async_to_sync
+#     async def async_send_direct_system_message():
+#         try:
+#             await async_log(f"send_system_message: start")
 
-            target_user = await database_sync_to_async(CustomUser.objects.get)(nickname=target_nickname)
-            system_user = await database_sync_to_async(CustomUser.objects.get)(is_system=True)
-            # print(f"target_user.nickname: {target_user.nickname}")
-            await async_log(f"send_direct_system_message(): target_user.nickname: {target_user.nickname}")
+#             target_user = await database_sync_to_async(CustomUser.objects.get)(nickname=target_nickname)
+#             system_user = await database_sync_to_async(CustomUser.objects.get)(is_system=True)
+#             # print(f"target_user.nickname: {target_user.nickname}")
+#             await async_log(f"send_direct_system_message(): target_user.nickname: {target_user.nickname}")
 
-            dm_session = await database_sync_to_async(DMSession.get_session)(
-                system_user.id,
-                target_user.id,
-                is_system_message=True
-            )
+#             dm_session = await database_sync_to_async(DMSession.get_session)(
+#                 system_user.id,
+#                 target_user.id,
+#                 is_system_message=True
+#             )
 
-            # メッセージをデータベースに保存
-            message_instance = await database_sync_to_async(Message.objects.create)(
-                sender=system_user,
-                receiver=target_user,
-                message=message
-            )
-            timestamp = message_instance.timestamp.strftime("%Y-%m-%d %H:%M:%S")
-            await async_log(f"message_instance.sender: {message_instance.sender}")
+#             # メッセージをデータベースに保存
+#             message_instance = await database_sync_to_async(Message.objects.create)(
+#                 sender=system_user,
+#                 receiver=target_user,
+#                 message=message
+#             )
+#             timestamp = message_instance.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+#             await async_log(f"message_instance.sender: {message_instance.sender}")
 
-            channel_layer = get_channel_layer()
-            # print(f"channel_layer: {channel_layer}")
-            await DMConsumer.send_system_message(
-                channel_layer,
-                dm_session.id,
-                system_user.nickname,
-                message,
-                timestamp,
-                is_system_message=True
-            )
-            await async_log(f"send_system_message: done")
+#             channel_layer = get_channel_layer()
+#             # print(f"channel_layer: {channel_layer}")
+#             await DMConsumer.send_system_message(
+#                 channel_layer,
+#                 dm_session.id,
+#                 system_user.nickname,
+#                 message,
+#                 timestamp,
+#                 is_system_message=True
+#             )
+#             await async_log(f"send_system_message: done")
 
-            # print(f"send_system_message: done")
-            return True
-        except CustomUser.DoesNotExist:
-            # print(f"Error in send_direct_system_message: {str(e)}")
-            return False
-        except Exception as e:
-            # print(f"Error in send_direct_system_message: {str(e)}")
-            return False
-    return async_send_direct_system_message()
+#             # print(f"send_system_message: done")
+#             return True
+#         except CustomUser.DoesNotExist:
+#             # print(f"Error in send_direct_system_message: {str(e)}")
+#             return False
+#         except Exception as e:
+#             # print(f"Error in send_direct_system_message: {str(e)}")
+#             return False
+#     return async_send_direct_system_message()
     
 
-# async def send_direct_system_message(target_nickname, message):
-#     try:
-#         await async_log(f"send_system_message: start")
+async def send_direct_system_message(target_nickname, message):
+    try:
+        if DEBUG_FLOW:
+            await async_log(f"send_system_message: start")
 
-#         target_user = await database_sync_to_async(CustomUser.objects.get)(nickname=target_nickname)
-#         system_user = await database_sync_to_async(CustomUser.objects.get)(is_system=True)
-#         # print(f"target_user.nickname: {target_user.nickname}")
-#         await async_log(f"send_direct_system_message(): target_user.nickname: {target_user.nickname}")
+        target_user = await database_sync_to_async(CustomUser.objects.get)(nickname=target_nickname)
+        system_user = await database_sync_to_async(CustomUser.objects.get)(is_system=True)
+        if DEBUG_FLOW:
+            await async_log(f"send_direct_system_message(): target_user.nickname: {target_user.nickname}")
 
-#         dm_session = await database_sync_to_async(DMSession.get_session)(
-#             system_user.id,
-#             target_user.id,
-#             is_system_message=True
-#         )
+        dm_session = await database_sync_to_async(DMSession.get_session)(
+            system_user.id,
+            target_user.id,
+            is_system_message=True
+        )
+        # メッセージをデータベースに保存
+        message_instance = await database_sync_to_async(Message.objects.create)(
+            sender=system_user,
+            receiver=target_user,
+            message=message
+        )
+        timestamp = message_instance.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+        if DEBUG_FLOW:
+            await async_log(f"message_instance.sender: {message_instance.sender}")
 
-#         # メッセージをデータベースに保存
-#         message_instance = await database_sync_to_async(Message.objects.create)(
-#             sender=system_user,
-#             receiver=target_user,
-#             message=message
-#         )
-#         timestamp = message_instance.timestamp.strftime("%Y-%m-%d %H:%M:%S")
-#         await async_log(f"message_instance.sender: {message_instance.sender}")
+        channel_layer = get_channel_layer()
+        await DMConsumer.send_system_message(
+            channel_layer,
+            dm_session.id,
+            system_user.nickname,
+            message,
+            timestamp,
+            is_system_message=True
+        )
+        if DEBUG_FLOW:
+            await async_log(f"send_system_message: done")
 
-#         channel_layer = get_channel_layer()
-#         # print(f"channel_layer: {channel_layer}")
-#         await DMConsumer.send_system_message(
-#             channel_layer,
-#             dm_session.id,
-#             system_user.nickname,
-#             message,
-#             timestamp,
-#             is_system_message=True
-#         )
-#         await async_log(f"send_system_message: done")
-
-#         # print(f"send_system_message: done")
-#         return True
-#     except CustomUser.DoesNotExist:
-#         # print(f"Error in send_direct_system_message: {str(e)}")
-#         return False
-#     except Exception as e:
-#         # print(f"Error in send_direct_system_message: {str(e)}")
-#         return False
+        return True
+    except CustomUser.DoesNotExist:
+        logger.debug(f'[send_direct_system_message] : err {str(e)}')
+        return False
+    except Exception as e:
+        logger.debug(f'[send_direct_system_message] : err {str(e)}')
+        return False

--- a/docker/srcs/uwsgi-django/pong/views/tournament/save_views.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament/save_views.py
@@ -9,13 +9,20 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from pong.utils.async_logger import sync_log
+from pong.utils.async_logger import sync_log, async_log
 from chat.views.system_message import send_direct_system_message  
 from django.views.decorators.http import require_POST
+import random
+from asgiref.sync import async_to_sync
+# from django.core.cache import cache
+from .signals import round_finished
+from django.dispatch import receiver
 
 logger = logging.getLogger('django')
 User = get_user_model()
 
+DEBUG_FLOW = 0
+DEBUG_DETAIL = 0
 
 @require_POST
 def release_match(request, match_id):
@@ -89,23 +96,14 @@ def is_tournament_finished(tournament):
 	return True
 
 
-def send_system_message_to_organizer(tournament, next_round):
-	sync_log('send_system_message_to_organizer(): start')
-	organizer_nickname = tournament.organizer.nickname
-	if next_round == 4:
-		message = f"トーナメント「{tournament.name}」が終了しました！"
-	else:
-		message = f"トーナメント「{tournament.name}」のラウンド{next_round}が始まりました！"
-	sync_log('send_system_message_to_organizer(): 2')
-	return send_direct_system_message(organizer_nickname, message)
-
 # @csrf_exempt
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def save_game_result(request):
 	"""試合結果を保存する"""
 	try:
-		sync_log('save_game_result(): start')
+		if DEBUG_FLOW:
+			sync_log('save_game_result(): start')
 
 		data = json.loads(request.body)
 		match_id = data.get('match_id')
@@ -127,23 +125,25 @@ def save_game_result(request):
 		if winner:
 			assign_winner_to_next_match(match, winner)
 		
-		sync_log('save_game_result(): 1')
 		# ラウンドの最終試合の場合 次のラウンドの開始をDMする
 		current_round = match.round_number
 		if is_round_finished(match.tournament, current_round):
-			sync_log(f'save_game_result(): is_round_finished: {is_round_finished}')
+			if DEBUG_FLOW:
+				sync_log(f'save_game_result(): is_round_finished: {is_round_finished}')
 			match.tournament.last_finished_round = current_round
 			match.tournament.save()
-			# 次のラウンドの開始メッセージを送信
-			send_system_message_to_organizer(match.tournament, current_round + 1)
+			# シグナルを発行　=>  @receiver(round_finished)によって、次のラウンドの開始メッセージを送信する関数 handle_round_finished() を呼び出す
+			round_finished.send(sender=match.tournament, current_round=current_round)
+			if DEBUG_FLOW:
+				sync_log(f'round_finished.send')
 
-		# debug test用
-		# send_system_message_to_organizer(match.tournament, 99)
-		
 		# トーナメントの全試合が終了していた場合、 is_Finisjed を立てる
 		if is_tournament_finished(match.tournament):
 			match.tournament.is_finished = True
 			match.tournament.save()
+
+		if DEBUG_FLOW:
+				sync_log(f'save_game_result(): done')
 
 		return JsonResponse({"status": "success", "message": "Game result saved successfully."})
 	except Exception as e:
@@ -153,8 +153,31 @@ def save_game_result(request):
 		return JsonResponse({"status": "error", "message": str(e)}, status=400)
 
 
+@receiver(round_finished)
+def handle_round_finished(sender, **kwargs):
+	"""
+	※Djangoのシグナルディスパッチャー: 
+	- 同期的な動作を前提としているため、非同期関数を直接シグナルハンドラとして使用することができない。
+	- そのために、asyncをつけず同期関数として定義し、async_to_sync()を用いて非同期関数を処理する
+	"""
+	if DEBUG_FLOW:
+		sync_log('handle_round_finished(): start')
+	tournament = sender
+	current_round = kwargs['current_round']
+	send_system_message_to_organizer(tournament, current_round + 1)
 
-# def send_direct_system_message(target_nickname, message):
-# 	# chat/のsend_direct_system_message関数を呼び出す
-# 	from chat.views.system_message import send_direct_system_message  
-# 	return send_direct_system_message(target_nickname, message)
+
+def send_system_message_to_organizer(tournament, next_round):
+	"""
+	send_direct_system_message()が非同期処理を行うが、同期関数として扱う。※Djangoのシグナルディスパッチャーを利用するため。
+	"""
+	if DEBUG_FLOW:
+		sync_log('send_system_message_to_organizer(): start')
+	organizer_nickname = tournament.organizer.nickname
+	if next_round == 4:
+		message = f"トーナメント「{tournament.name}」が終了しました！"
+	else:
+		message = f"トーナメント「{tournament.name}」のラウンド{next_round}が始まりました！"
+	if DEBUG_FLOW:
+		async_log('send_system_message_to_organizer(): done')
+	return async_to_sync(send_direct_system_message)(organizer_nickname, message)

--- a/docker/srcs/uwsgi-django/pong/views/tournament/signals.py
+++ b/docker/srcs/uwsgi-django/pong/views/tournament/signals.py
@@ -1,0 +1,6 @@
+from django.dispatch import Signal
+
+# @receiver(round_finished)によって、イベント発生時に関数を呼び出す
+# イベントドリブンプログラミングの一種
+# 参考:【シグナル | Django ドキュメント | Django】 <https://docs.djangoproject.com/en/3.2/topics/signals/>
+round_finished = Signal()


### PR DESCRIPTION
#326 
- testが間に合うかわからないけど、一応作業は進めとく。
- 初回提出まではmainブランチのチェック優先
- 試合終了 > roundの全試合が終わったかチェック　の後に、DB保存と　トーナメント案内の2つの処理が発生する
  - 関数が二つの機能を持つ。しかも同期と、非同期と。
  - 大きく変更するのは怖いので、追加の機能だけ編集したい
    - round終了判定は、既存関数内で行う（行を追加）
    - そこでDjango signalsを発行（イベント的なもの）
    - それを受け取ってsendMsgFromSys的関数を走らせる