### PR TITLE
FriendRequest

### DIFF
--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -23,9 +23,11 @@ export function sendFriendRequest(userId) {
             return data;
         });
     }).catch(error => {
-        console.error('hth: Error:', error);
+        // console.error('hth: Error:', error);
         const errorEvent = new CustomEvent('sendFriendRequest error:', { detail: error });
         document.dispatchEvent(errorEvent);
+        alert(error);
+        switchPage(window.location.pathname);
     });
 }
 
@@ -50,8 +52,9 @@ export function cancelFriendRequest(userId) {
             switchPage(window.location.pathname);
         })
         .catch(error => {
-            console.error('hth: Error:', error);
+            // console.error('hth: Error:', error);
             alert(error.message);
+            switchPage(window.location.pathname);
         });
 }
 
@@ -76,8 +79,9 @@ export function acceptFriendRequest(userId) {
             switchPage(window.location.pathname);
         })
         .catch(error => {
-            console.error('hth: Error:', error);
+            // console.error('hth: Error:', error);
             alert(error.message);
+            switchPage(window.location.pathname);
         });
 }
 
@@ -103,8 +107,9 @@ export function rejectFriendRequest(userId) {
                 switchPage(window.location.pathname);
             })
             .catch(error => {
-                console.error('hth: Error:', error);
+                // console.error('hth: Error:', error);
                 alert(error.message);
+                switchPage(window.location.pathname);
             });
     } else {
         alert('Request rejection has been canceled');
@@ -133,8 +138,9 @@ export function deleteFriend(userId) {
                 switchPage(window.location.pathname);
             })
             .catch(error => {
-                console.error('hth: Error:', error);
+                // console.error('hth: Error:', error);
                 alert(error.message);
+                switchPage(window.location.pathname);
             });
 
     } else {

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -14,7 +14,7 @@ export function sendFriendRequest(userId) {
         }
     }).then(response => {
         return response.json().then(data => {
-            if (!response.ok) {
+            if (!response.ok || data.error) {
                 throw new Error(data.error);
             }
             const event = new CustomEvent('sendFriendRequest success:', { detail: data });
@@ -41,7 +41,7 @@ export function cancelFriendRequest(userId) {
     })
         .then(response => {
             return response.json().then(data => {
-                if (!response.ok) {
+                if (!response.ok || data.error) {
                     throw new Error(data.error);
                 }
                 return data;
@@ -68,7 +68,7 @@ export function acceptFriendRequest(userId) {
         }
     }).then(response => {
         return response.json().then(data => {
-            if (!response.ok) {
+            if (!response.ok || data.error) {
                 throw new Error(data.error);
             }
             return data;
@@ -96,7 +96,7 @@ export function rejectFriendRequest(userId) {
         })
             .then(response => {
                 return response.json().then(data => {
-                    if (!response.ok) {
+                    if (!response.ok || data.error) {
                         throw new Error(data.error);
                     }
                     return data;
@@ -127,7 +127,7 @@ export function deleteFriend(userId) {
         })
             .then(response => {
                 return response.json().then(data => {
-                    if (!response.ok) {
+                    if (!response.ok || data.error) {
                         throw new Error(data.error);
                     }
                     return data;

--- a/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
+++ b/docker/srcs/uwsgi-django/accounts/static/accounts/js/friend.js
@@ -275,7 +275,7 @@ export function createActionButton(text, action) {
     const actionLink = document.createElement('a');
     actionLink.textContent = text;
     actionLink.href = "#";
-    actionLink.className = text.toLowerCase() + 'Button';
+    actionLink.className = text.toLowerCase() + 'Button' + ' hth-btn my-4';
     actionLink.onclick = function(event) {
         event.preventDefault();
         action();

--- a/docker/srcs/uwsgi-django/accounts/tests/test_friend.py
+++ b/docker/srcs/uwsgi-django/accounts/tests/test_friend.py
@@ -93,7 +93,7 @@ class SendFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kSendFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Already friend', response.data['error'])
 
     def test_send_friend_request_to_myself(self):
@@ -110,7 +110,7 @@ class SendFriendRequestAPITestCase(TestCase):
         user_id = self.user1.id
         url = reverse(self.kSendFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Cannot send request to yourself', response.data['error'])
 
     def test_send_friend_request_already_sent(self):
@@ -126,7 +126,7 @@ class SendFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kSendFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend request already friends', response.data['error'])
 
     def test_send_friend_request_already_received(self):
@@ -142,7 +142,7 @@ class SendFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kSendFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend request already friends', response.data['error'])
 
     def test_send_friend_request_to_nonexistent_user(self):
@@ -154,7 +154,7 @@ class SendFriendRequestAPITestCase(TestCase):
         invalid_user_id = 99999
         url = reverse(self.kSendFriendRequestAPIName, kwargs={'user_id': invalid_user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('User not found', response.data['error'])
 
 
@@ -239,7 +239,7 @@ class CancelFriendRequestAPITestCase(TestCase):
         invalid_user_id = 99999
         url = reverse(self.kCancelFriendRequestAPIName, kwargs={'user_id': invalid_user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('User not found', response.data['error'])
 
     def test_cancel_friend_request_to_myself(self):
@@ -251,7 +251,7 @@ class CancelFriendRequestAPITestCase(TestCase):
         user_id = self.user1.id
         url = reverse(self.kCancelFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Cannot send request to yourself', response.data['error'])
 
     def test_cancel_nonexistent_friend_request(self):
@@ -263,7 +263,7 @@ class CancelFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kCancelFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend request not found', response.data['error'])
 
 
@@ -343,7 +343,7 @@ class AcceptFriendRequestAPITestCase(TestCase):
         invalid_user_id = 99999
         url = reverse(self.kAcceptFriendRequestAPIName, kwargs={'user_id': invalid_user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('User not found', response.data['error'])
 
     def test_accept_friend_request_to_myself(self):
@@ -355,7 +355,7 @@ class AcceptFriendRequestAPITestCase(TestCase):
         user_id = self.user1.id
         url = reverse(self.kAcceptFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Cannot send request to yourself', response.data['error'])
 
     def test_accept_nonexistent_friend_request(self):
@@ -367,7 +367,7 @@ class AcceptFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kAcceptFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend request not found', response.data['error'])
 
 
@@ -447,7 +447,7 @@ class RejectFriendRequestAPITestCase(TestCase):
         invalid_user_id = 99999
         url = reverse(self.kRejectFriendRequestAPIName, kwargs={'user_id': invalid_user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('User not found', response.data['error'])
 
     def test_reject_friend_request_to_myself(self):
@@ -459,7 +459,7 @@ class RejectFriendRequestAPITestCase(TestCase):
         user_id = self.user1.id
         url = reverse(self.kRejectFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Cannot send request to yourself', response.data['error'])
 
     def test_reject_nonexistent_friend_request(self):
@@ -471,7 +471,7 @@ class RejectFriendRequestAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kRejectFriendRequestAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend request not found', response.data['error'])
 
 
@@ -540,7 +540,7 @@ class DeleteFriendAPITestCase(TestCase):
         user_id = self.user1.id
         url = reverse(self.kDeleteFriendAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Cannot send request to yourself', response.data['error'])
 
     def test_delete_friend_unauthenticated(self):
@@ -563,7 +563,7 @@ class DeleteFriendAPITestCase(TestCase):
         invalid_user_id = 99999
         url = reverse(self.kDeleteFriendAPIName, kwargs={'user_id': invalid_user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('User not found', response.data['error'])
 
     def test_delete_non_friend_relationship(self):
@@ -575,7 +575,7 @@ class DeleteFriendAPITestCase(TestCase):
         user_id = self.user2.id
         url = reverse(self.kDeleteFriendAPIName, kwargs={'user_id': user_id})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('Friend not found.', response.data['error'])
 
 

--- a/docker/srcs/uwsgi-django/accounts/views/friend.py
+++ b/docker/srcs/uwsgi-django/accounts/views/friend.py
@@ -64,17 +64,17 @@ class SendFriendRequestAPI(APIView):
             if err is not None:
                 # logger.error(f"SendFriendRequestAPI 2")
                 response = {'error': err}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             # logger.error(f"SendFriendRequestAPI 3 {user.nickname} -> {friend_request_target.nickname}")
             if Friend.is_friend(user, friend_request_target):
                 response = {'error': 'Already friend'}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             if (Friend.is_already_sent(user, friend_request_target)
                     or Friend.is_already_received(user, friend_request_target)):
                 response = {'error': 'Friend request already friends'}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             Friend.objects.create(sender=user, receiver=friend_request_target)
             response = {'status': 'Friend request sent successfully'}
@@ -82,10 +82,10 @@ class SendFriendRequestAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         logger.error(f"SendFriendRequestAPI error: {error_msg}")
         return Response(response, status=error_status)
@@ -102,7 +102,7 @@ class CancelFriendRequestAPI(APIView):
             user, friend_request_target, err = _get_user_and_friend(request, user_id)
             if err is not None:
                 response = {'error': err}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             # リクエストを取得
             friend_request = Friend.objects.get(sender=user,
@@ -116,13 +116,13 @@ class CancelFriendRequestAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Friend.DoesNotExist:
             error_msg = 'Friend request not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         logger.error(f"CancelFriendRequestAPI error: {error_msg}")
         return Response(response, status=error_status)
@@ -141,7 +141,7 @@ class AcceptFriendRequestAPI(APIView):
             if err is not None:
                 # logger.error(f"AcceptFriendRequestAPI 2")
                 response = {'error': err}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             # logger.error(f"AcceptFriendRequestAPI {request_sender.nickname} -> {user.nickname}")
             # request_sender -> user へのPending状態のリクエストリクエストを取得
@@ -160,13 +160,13 @@ class AcceptFriendRequestAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Friend.DoesNotExist:
             error_msg = 'Friend request not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         logger.error(f"AcceptFriendRequestAPI error: {error_msg}")
         return Response(response, status=error_status)
@@ -184,7 +184,7 @@ class RejectFriendRequestAPI(APIView):
             user, request_sender, err = _get_user_and_friend(request, user_id)
             if err is not None:
                 response = {'error': err}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             # request_sender -> user へのPending状態のリクエストリクエストを取得
             friend_request = Friend.objects.get(sender=request_sender,
@@ -197,13 +197,13 @@ class RejectFriendRequestAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Friend.DoesNotExist:
             error_msg = 'Friend request not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         logger.error(f"RejectFriendRequestAPI error: {error_msg}")
         return Response(response, status=error_status)
@@ -220,7 +220,7 @@ class DeleteFriendAPI(APIView):
             user, friend, err = _get_user_and_friend(request, user_id)
             if err is not None:
                 response = {'error': err}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             friend_requests = Friend.objects.filter(
                 Q(sender=user, receiver=friend) | Q(sender=friend, receiver=user),
@@ -229,7 +229,7 @@ class DeleteFriendAPI(APIView):
 
             if not friend_requests.exists():
                 response = {'error': 'Friend not found.'}
-                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+                return Response(response, status=status.HTTP_200_OK)
 
             friend_requests.delete()
             response = {'status': 'Success: delete friend'}
@@ -237,13 +237,13 @@ class DeleteFriendAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Friend.DoesNotExist:
             error_msg = 'Friend request not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         return Response(response, status=error_status)
 
@@ -273,13 +273,13 @@ class GetFriendListAPI(APIView):
 
         except CustomUser.DoesNotExist:
             error_msg = 'User not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Friend.DoesNotExist:
             error_msg = 'Friend request not found'
-            error_status = status.HTTP_400_BAD_REQUEST
+            error_status = status.HTTP_200_OK
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         logger.debug(f'get_friends friends: error: {error_msg}')
 
@@ -331,6 +331,6 @@ class GetFriendRequestListAPI(APIView):
 
         except Exception as e:
             error_msg = f'Unexpected error: {str(e)}'
-            error_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+            error_status = status.HTTP_200_OK
         response = {'error': error_msg}
         return Response(response, status=error_status)


### PR DESCRIPTION
- お互いが削除 or 複数ページで操作し、操作が競合するとエラー & ページ更新,遷移しない限り同じリンクが表示され続けるため、switchPage(window.location.pathname)で画面更新するよう変更
- API操作リンクをhth btnスタイルに変更
- API400->200


before
![Screenshot 2024-06-23 at 15 33 40](https://github.com/42trans/ft_transcendence/assets/51146172/a470babb-32d9-4ca5-9b63-ea659fc16087)

after
![Screenshot 2024-06-23 at 15 34 29](https://github.com/42trans/ft_transcendence/assets/51146172/de3e3308-9afa-4d4c-ba68-fb67a019bc97)
