### PR TITLE
tournamentInviteのerror抑制

### DIFF
--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -148,7 +148,12 @@ export function tournamentInvite() {
                 });
             })
             .catch(error => {
-                console.error('tournamentInvite(): error', error);
+                if (error.message.includes('<!doctype')) {
+                    messageArea.textContent = "The specified user does not exist";
+                } else {
+                    messageArea.textContent = error.message;
+                }
+                // console.error('tournamentInvite(): error', error);
             });
     };
 }

--- a/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
+++ b/docker/srcs/uwsgi-django/chat/static/chat/js/dm-sessions.js
@@ -55,7 +55,7 @@ export function startDMwithUser() {
         })
             .then(response => {
                 return response.json().then(data => {
-                    if (!response.ok) {
+                    if (!response.ok || data.error) {
                         throw new Error(data.error);
                     } else {
                         // 検証が成功した場合にdiWithUserに遷移
@@ -131,7 +131,7 @@ export function tournamentInvite() {
         })
             .then(response => {
                 return response.json().then(data => {
-                    if (!response.ok) {
+                    if (!response.ok || data.error) {
                         throw new Error(data.error);
                     } else {
                         const targetId = data.target_id;

--- a/docker/srcs/uwsgi-django/chat/views/views.py
+++ b/docker/srcs/uwsgi-django/chat/views/views.py
@@ -64,7 +64,7 @@ class ValidateDmTargetAPI(APIView):
         logger.error(f"ValidateDmTargetAPI target: {target_nickname}")
         if err is not None:
             logger.error(f"ValidateDmTargetAPI error: {err}")
-            return Response({'error': err}, status=400)
+            return Response({'error': err}, status=200)
         return Response({'status': 'ok', 'target_id': dm_target.id}, status=200)
 
 


### PR DESCRIPTION
- console error -> message-areaへの表示に変更
  ```
  tournamentInvite(): error Error: The specified user does not exist
      at dm-sessions.js:135:31
  (anonymous) @ dm-sessions.js:151
  Promise.catch (async)
  tournamentInviteButton.onclick @ dm-sessions.js:150Understand this error
  ```
- validate-dm-targetの400->200